### PR TITLE
Fix RPC abort signal composition

### DIFF
--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -587,7 +587,10 @@ export class Gateway {
       try {
         rpcContext.container.provide([
           ...injections,
-          provision(injectables.rpcAbortSignal, signal),
+          // Provide only the base per-call signal here. rpcAbortSignal is a
+          // derived injectable that combines rpcClientAbortSignal,
+          // connectionAbortSignal, and optional rpcStreamAbortSignal.
+          provision(injectables.rpcClientAbortSignal, rpcContext.signal),
           provision(
             injectables.createBlob,
             this.createBlobFunction(rpcContext),
@@ -647,7 +650,10 @@ export class Gateway {
       encoder,
     } = context
     try {
-      container.provide(injectables.rpcAbortSignal, signal)
+      // Provide only the base per-call signal here. rpcAbortSignal is resolved
+      // through DI so it can include connection and optional stream timeout
+      // cancellation as well.
+      container.provide(injectables.rpcClientAbortSignal, signal)
       const response = await this.options.api.call({
         connection: connection as any,
         container,

--- a/packages/gateway/src/injectables.ts
+++ b/packages/gateway/src/injectables.ts
@@ -43,12 +43,16 @@ export const connectionAbortSignal = createLazyInjectable<
 >(Scope.Connection, 'Connection abort signal')
 
 /**
- * The per-RPC signal controlled by the transport/client side.
+ * Base per-RPC signal provisioned by the gateway for the current call.
  *
  * Scope: Call
  *
- * This is aborted for call-level cancellation (client abort, client timeout,
- * or request abort in unidirectional transports).
+ * This represents call-level cancellation from the client/request side
+ * (client abort, client timeout, or request abort in unidirectional
+ * transports) and acts as the source input for rpcAbortSignal.
+ *
+ * Prefer rpcAbortSignal in handlers unless you specifically need the
+ * pre-composed per-call signal.
  */
 export const rpcClientAbortSignal = createLazyInjectable<
   AbortSignal,
@@ -61,7 +65,8 @@ export const rpcClientAbortSignal = createLazyInjectable<
  * Scope: Call
  *
  * This is provided only when stream timeout logic is enabled by the runtime
- * for the procedure (i.e. when `procedure.streamTimeout` is configured).
+ * for the procedure (i.e. when the procedure uses a numeric stream timeout,
+ * such as `stream: 5_000`).
  * Prefer rpcAbortSignal for general handler cancellation.
  */
 export const rpcStreamAbortSignal = createLazyInjectable<
@@ -70,12 +75,15 @@ export const rpcStreamAbortSignal = createLazyInjectable<
 >(Scope.Call, 'RPC stream abort signal')
 
 /**
- * Unified RPC cancellation signal.
+ * Unified RPC cancellation signal derived from other call/connection signals.
  *
  * Scope: Call
  *
  * Combines rpcClientAbortSignal, connectionAbortSignal, and (if present)
  * rpcStreamAbortSignal. This is the recommended signal for procedure logic.
+ *
+ * Gateway/transport code should provide rpcClientAbortSignal, not
+ * rpcAbortSignal directly, so this composition remains intact.
  */
 export const rpcAbortSignal = createFactoryInjectable(
   {

--- a/skills/use-neemata/SKILL.md
+++ b/skills/use-neemata/SKILL.md
@@ -89,7 +89,7 @@ Containers form a hierarchy: `Global → Connection → Call`. A scope can only 
 
 Two streaming mechanisms:
 
-- **RPC Streams** — Procedure returns `AsyncIterable`, set `stream: true`. Client consumes via `client.stream.*`
+- **RPC Streams** — Procedure returns `AsyncIterable`; use `stream: true` for standard streaming or `stream: <ms>` for streaming with an explicit per-procedure timeout. Client consumes via `client.stream.*`
 - **Blob Streams** — Binary data via `ProtocolBlob.from()` / `client.createBlob()` on the client, `n.inject.createBlob` on the server, and explicit consumption via `client.consumeBlob()` / `n.inject.consumeBlob`. Use `c.blob()` in contracts
 
 ### Metadata

--- a/skills/use-neemata/references/client-usage.md
+++ b/skills/use-neemata/references/client-usage.md
@@ -43,7 +43,7 @@ const client = new StaticClient<typeof appContract>(
 - `StaticClient` is proxy-based and resolves procedure paths lazily from property access.
 - `autoConnect: true` lets the client connect on the first call/stream instead of requiring an explicit `await client.connect()`.
 - After an explicit `await client.disconnect()`, implicit reconnection is suppressed until you connect again manually.
-- Use `client.call.*` for non-stream procedures and `client.stream.*` for procedures declared with `stream: true`.
+- Use `client.call.*` for non-stream procedures and `client.stream.*` for procedures declared with `stream: true` or a numeric `stream` timeout such as `stream: 5_000`.
 
 ## RuntimeClient Setup
 

--- a/skills/use-neemata/references/injectables.md
+++ b/skills/use-neemata/references/injectables.md
@@ -93,17 +93,19 @@ If a lazy token may be absent, inject it as optional in dependencies using
 | `n.inject.connectionId` | Connection | `string` | Stable current connection identifier | Correlation IDs, metrics labels, per-connection caches/maps |
 | `n.inject.connectionData` | Connection | `unknown` | Transport-provided request/connection context | Auth/session/user/request metadata propagated from transport |
 | `n.inject.connectionAbortSignal` | Connection | `AbortSignal` | Signal aborted when connection is closed/disconnected | Cancel long-running work tied to connection lifetime |
-| `n.inject.rpcClientAbortSignal` | Call | `AbortSignal` | Per-call cancellation from client/request side | Use only if you specifically need client/request-originated cancellation |
-| `n.inject.rpcStreamAbortSignal` | Call | `AbortSignal` | Optional stream-timeout signal | Only available when procedure sets `streamTimeout` |
-| `n.inject.rpcAbortSignal` | Call | `AbortSignal` | Unified call signal (client/request + connection + optional stream timeout) | Recommended default signal for handler cancellation checks |
+| `n.inject.rpcClientAbortSignal` | Call | `AbortSignal` | Base per-call cancellation signal from client/request side | Use only if you specifically need the pre-composed call signal before framework-level composition |
+| `n.inject.rpcStreamAbortSignal` | Call | `AbortSignal` | Optional stream-timeout signal | Only available when the procedure uses a timed stream configuration such as `stream: 5_000` |
+| `n.inject.rpcAbortSignal` | Call | `AbortSignal` | Unified call signal resolved from client/request + connection + optional stream timeout | Recommended default signal for handler cancellation checks |
 | `n.inject.createBlob` | Call | Function | Factory that wraps data source into protocol blob response | Server-to-client binary streaming/blob responses |
 | `n.inject.consumeBlob` | Call | Function | Converts an incoming blob marker from request payload into a readable stream | Client-to-server blob uploads that handlers want to consume explicitly; ignored upload blobs are aborted when the handler completes |
 
 ### Cancellation signal quick guide
 
 - Use `n.inject.rpcAbortSignal` by default in procedure handlers.
+- `n.inject.rpcClientAbortSignal` is the base per-call signal provided by the gateway; most handlers should prefer `n.inject.rpcAbortSignal`.
 - Use `n.inject.connectionAbortSignal` when work should survive call boundaries but stop on disconnect.
-- Use `n.inject.rpcStreamAbortSignal` only in stream procedures with explicit `streamTimeout`.
+- Use `n.inject.rpcStreamAbortSignal` only in stream procedures with an explicit timed stream configuration (for example `stream: 5_000`).
+- Plain `stream: true` is fully valid for stream procedures; it simply means there is no custom per-procedure stream timeout, so `n.inject.rpcStreamAbortSignal` is not provided.
 - Avoid requiring `n.inject.rpcStreamAbortSignal` in generic procedures because it is optional by design.
 
 ## Using Injectables in Procedures

--- a/skills/use-neemata/references/rpc.md
+++ b/skills/use-neemata/references/rpc.md
@@ -113,6 +113,8 @@ export const streamProcedure = n.procedure({
 ```
 
 - Set `stream: true` to enable streaming
+- `stream: true` is the standard streaming form and does not add a custom per-procedure stream timeout
+- Use `stream: <ms>` (for example `stream: 5_000`) when you want the stream procedure to expose `n.inject.rpcStreamAbortSignal`
 - Handler must be an `async *generator` that `yield`s values matching `output` type
 - Client consumes via `client.stream.procedureName(input)` which returns `AsyncIterable`
 
@@ -141,8 +143,14 @@ export const liveDataProcedure = n.procedure({
 
 - Prefer `n.inject.rpcAbortSignal` in handlers for general cancellation support
   (client abort, client timeout/request abort, and disconnect)
+- `n.inject.rpcClientAbortSignal` is the base per-call signal provided by the
+  gateway; `n.inject.rpcAbortSignal` resolves the unified signal by combining
+  that call signal with disconnect and optional stream-timeout cancellation.
+- Regular `stream: true` procedures are fully valid and usually all you need
+  when you do not want a custom per-procedure stream timeout.
 - `n.inject.rpcStreamAbortSignal` is optional and only available when
-  `streamTimeout` is configured for that procedure
+  a timed stream configuration is used for that procedure (for example
+  `stream: 5_000`)
 
 ```ts
 import { n, t } from 'nmtjs'
@@ -154,8 +162,7 @@ export const streamWithTimeoutProcedure = n.procedure({
   },
   input: t.object({}),
   output: t.object({ value: t.number() }),
-  stream: true,
-  streamTimeout: 5_000,
+  stream: 5_000,
   async *handler({ signal, streamSignal }) {
     while (!signal.aborted && !streamSignal.aborted) {
       yield { value: Math.random() }

--- a/tests/integration/tests/_setup.ts
+++ b/tests/integration/tests/_setup.ts
@@ -482,6 +482,7 @@ export {
   createBlob,
   Gateway,
   rpcAbortSignal,
+  rpcClientAbortSignal,
   rpcStreamAbortSignal,
 } from '@nmtjs/gateway'
 export {

--- a/tests/integration/tests/simple-procedures.spec.ts
+++ b/tests/integration/tests/simple-procedures.spec.ts
@@ -11,6 +11,7 @@ import {
   ErrorCode,
   ProtocolError,
   rpcAbortSignal,
+  rpcClientAbortSignal,
   t,
 } from './_setup.ts'
 
@@ -174,6 +175,17 @@ const abortableWithStateProcedure = createProcedure({
   },
 })
 
+const clientAbortSignalStateProcedure = createProcedure({
+  input: t.object({ delayMs: t.number() }),
+  output: t.object({ initialAborted: t.boolean(), finalAborted: t.boolean() }),
+  dependencies: { signal: rpcClientAbortSignal },
+  handler: async ({ signal }, input) => {
+    const initialAborted = signal.aborted
+    await new Promise((resolve) => setTimeout(resolve, input.delayMs))
+    return { initialAborted, finalAborted: signal.aborted }
+  },
+})
+
 let guardedDatePayload: { createdAt: Date } | null = null
 const dateGuard = createGuard((_ctx, call) => {
   guardedDatePayload = call.payload as { createdAt: Date }
@@ -214,6 +226,7 @@ const router = createRootRouter(
         fast: fastProcedure,
         abortable: abortableProcedure,
         abortableWithState: abortableWithStateProcedure,
+        clientAbortSignalState: clientAbortSignalStateProcedure,
         guardedDate: guardedDateProcedure,
       },
     }),
@@ -489,6 +502,18 @@ describe('Simple RPC Calls', () => {
   })
 
   describe('Abort Signal', () => {
+    it('should provide rpcClientAbortSignal to handler dependencies', async () => {
+      const result = await setup.client.call.clientAbortSignalState({
+        delayMs: 10,
+      })
+
+      expect(result).toEqual({ initialAborted: false, finalAborted: false })
+
+      await waitForCleanup()
+      expect(setup.gateway.rpcs.rpcs.size).toBe(0)
+      expect(setup.client.pendingCallsCount).toBe(0)
+    })
+
     it('should abort RPC call when signal is aborted', async () => {
       const controller = new AbortController()
 

--- a/tests/integration/tests/streaming.spec.ts
+++ b/tests/integration/tests/streaming.spec.ts
@@ -7,6 +7,7 @@ import {
   createRouter,
   createTestSetup,
   rpcAbortSignal,
+  rpcStreamAbortSignal,
   t,
 } from './_setup.ts'
 
@@ -83,6 +84,23 @@ const streamWithTrackingProcedure = createProcedure({
   },
 })
 
+const streamWithTimeoutSignalProcedure = createProcedure({
+  dependencies: { signal: rpcAbortSignal, streamSignal: rpcStreamAbortSignal },
+  input: t.object({ waitMs: t.number() }),
+  output: t.object({
+    signalAborted: t.boolean(),
+    streamSignalAborted: t.boolean(),
+  }),
+  stream: 25,
+  async *handler({ signal, streamSignal }, { waitMs }) {
+    await new Promise((resolve) => setTimeout(resolve, waitMs))
+    yield {
+      signalAborted: signal.aborted,
+      streamSignalAborted: streamSignal.aborted,
+    }
+  },
+})
+
 const router = createRootRouter([
   createRouter({
     routes: {
@@ -90,6 +108,7 @@ const router = createRootRouter([
       streamDelay: streamDelayProcedure,
       streamError: streamErrorProcedure,
       streamWithTracking: streamWithTrackingProcedure,
+      streamWithTimeoutSignal: streamWithTimeoutSignalProcedure,
     },
   }),
 ] as const)
@@ -354,6 +373,26 @@ describe('RPC Streaming', () => {
   })
 
   describe('Error Handling', () => {
+    it('should include stream timeout in rpcAbortSignal when configured', async () => {
+      const stream = await setup.client.stream.streamWithTimeoutSignal({
+        waitMs: 60,
+      })
+
+      const chunks: unknown[] = []
+      for await (const chunk of stream) {
+        chunks.push(chunk)
+      }
+
+      expect(chunks).toEqual([
+        { signalAborted: true, streamSignalAborted: true },
+      ])
+
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(setup.gateway.rpcs.rpcs.size).toBe(0)
+      expect(setup.client.pendingCallsCount).toBe(0)
+      expect(setup.client.activeRpcStreamsCount).toBe(0)
+    })
+
     it('should propagate server error during iteration', async () => {
       const stream = await setup.client.stream.streamError({ errorAt: 3 })
       const chunks: unknown[] = []


### PR DESCRIPTION
## Summary
Fix the gateway's RPC abort signal wiring so `rpcAbortSignal` remains the derived unified signal instead of being overridden directly.

## What changed
- provide `rpcClientAbortSignal` from the gateway and let `rpcAbortSignal` resolve through DI composition
- add focused integration tests for `rpcClientAbortSignal` injection and stream-timeout participation in `rpcAbortSignal`
- clarify source comments around the RPC signal model in the gateway package
- update the Neemata skill docs to explain the difference between `rpcClientAbortSignal` and `rpcAbortSignal`
- document that `stream: true` is the standard streaming mode and `stream: <ms>` enables timed streaming

## Validation
- `pnpm vitest run tests/integration/tests/simple-procedures.spec.ts tests/integration/tests/streaming.spec.ts`