### PR TITLE
Move integration test helpers local

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -48,7 +48,6 @@
     "@nmtjs/protocol": "workspace:*"
   },
   "devDependencies": {
-    "@nmtjs/tests-integration": "workspace:*",
     "@nmtjs/type": "workspace:*",
     "@nmtjs/contract": "workspace:*",
     "@nmtjs/common": "workspace:*",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -34,9 +34,6 @@
     "@nmtjs/protocol": "workspace:*",
     "@nmtjs/type": "workspace:*"
   },
-  "devDependencies": {
-    "@nmtjs/tests-integration": "workspace:*"
-  },
   "files": [
     "dist",
     "src",

--- a/packages/gateway/tests/_helpers/test-utils.ts
+++ b/packages/gateway/tests/_helpers/test-utils.ts
@@ -1,0 +1,50 @@
+import type { LoggingOptions } from '@nmtjs/core'
+import { Container, createLogger } from '@nmtjs/core'
+import { BaseServerFormat } from '@nmtjs/protocol/server'
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+class TestServerFormat extends BaseServerFormat {
+  accept = ['application/json']
+  contentType = 'application/json'
+
+  encode(data: unknown): ArrayBufferView {
+    return encoder.encode(JSON.stringify(data))
+  }
+
+  encodeRPC(data: unknown): ArrayBufferView {
+    return this.encode(data)
+  }
+
+  encodeBlob(streamId: number, metadata: unknown) {
+    return { streamId, metadata }
+  }
+
+  decode(buffer: ArrayBufferView) {
+    return JSON.parse(decoder.decode(buffer))
+  }
+
+  decodeRPC(buffer: ArrayBufferView) {
+    return this.decode(buffer)
+  }
+}
+
+export function createTestLogger(
+  options: LoggingOptions = { pinoOptions: { enabled: false } },
+  label = 'test',
+) {
+  return createLogger(options, label)
+}
+
+export function createTestContainer(
+  options: ConstructorParameters<typeof Container>[0] = {
+    logger: createTestLogger(),
+  },
+) {
+  return new Container(options)
+}
+
+export function createTestServerFormat() {
+  return new TestServerFormat()
+}

--- a/packages/gateway/tests/heartbeat.spec.ts
+++ b/packages/gateway/tests/heartbeat.spec.ts
@@ -12,7 +12,7 @@ import {
   createTestContainer,
   createTestLogger,
   createTestServerFormat,
-} from '@nmtjs/tests-integration'
+} from './_helpers/test-utils.ts'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { GatewayApi } from '../src/api.ts'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,6 @@ importers:
       '@nmtjs/protocol':
         specifier: workspace:*
         version: link:../protocol
-      '@nmtjs/tests-integration':
-        specifier: workspace:*
-        version: link:../../tests/integration
       '@nmtjs/type':
         specifier: workspace:*
         version: link:../type
@@ -123,10 +120,6 @@ importers:
       hookable:
         specifier: 6.1.1
         version: 6.1.1
-    devDependencies:
-      '@nmtjs/tests-integration':
-        specifier: workspace:*
-        version: link:../../tests/integration
 
   packages/http-client:
     dependencies:

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -1,10 +1,7 @@
 {
-  "name": "@nmtjs/tests-integration",
+  "name": "tests-integration",
   "private": true,
   "type": "module",
-  "exports": {
-    ".": "./src/index.ts"
-  },
   "scripts": {
     "test": "vitest run --passWithNoTests"
   },

--- a/tests/integration/tests/_helpers/container.ts
+++ b/tests/integration/tests/_helpers/container.ts
@@ -2,10 +2,6 @@ import { Container } from '@nmtjs/core'
 
 import { createTestLogger } from './logger.ts'
 
-/**
- * Create a test container with a silent logger.
- * Useful for unit tests that need DI container functionality.
- */
 export function createTestContainer(
   options: ConstructorParameters<typeof Container>[0] = {
     logger: createTestLogger(),

--- a/tests/integration/tests/_helpers/format.ts
+++ b/tests/integration/tests/_helpers/format.ts
@@ -5,16 +5,10 @@ import { JsonFormat as ServerJsonFormat } from '@nmtjs/json-format/server'
 
 export type { BaseClientFormat, BaseServerFormat }
 
-/**
- * Creates a server-side format instance for testing.
- */
 export function createTestServerFormat(): BaseServerFormat {
   return new ServerJsonFormat()
 }
 
-/**
- * Creates a client-side format instance for testing.
- */
 export function createTestClientFormat(): BaseClientFormat {
   return new ClientJsonFormat()
 }

--- a/tests/integration/tests/_helpers/index.ts
+++ b/tests/integration/tests/_helpers/index.ts
@@ -1,6 +1,3 @@
-// Common test utilities for Neemata packages
-// Install as dev dependency: "@nmtjs/tests-integration": "workspace:*"
-
 export { createTestContainer } from './container.ts'
 export {
   type BaseClientFormat,

--- a/tests/integration/tests/_helpers/logger.ts
+++ b/tests/integration/tests/_helpers/logger.ts
@@ -1,10 +1,6 @@
 import type { LoggingOptions } from '@nmtjs/core'
 import { createLogger } from '@nmtjs/core'
 
-/**
- * Create a silent test logger with logging disabled.
- * Useful for unit tests where log output is not needed.
- */
 export function createTestLogger(
   options: LoggingOptions = { pinoOptions: { enabled: false } },
   label = 'test',

--- a/tests/integration/tests/_setup.ts
+++ b/tests/integration/tests/_setup.ts
@@ -34,7 +34,7 @@ import {
   createTestClientFormat,
   createTestLogger,
   createTestServerFormat,
-} from '@nmtjs/tests-integration'
+} from './_helpers/index.ts'
 import {
   ApplicationApi,
   isProcedure,
@@ -497,7 +497,7 @@ export {
   createTestClientFormat,
   createTestLogger,
   createTestServerFormat,
-} from '@nmtjs/tests-integration'
+} from './_helpers/index.ts'
 export { t } from '@nmtjs/type'
 export {
   ApiError,

--- a/tests/integration/tsconfig.json
+++ b/tests/integration/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "noEmit": true, "rootDir": "." },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["tests/**/*"]
 }


### PR DESCRIPTION
Moves integration test helper utilities out of the workspace package export path and into the test suites that use them.

Summary:
- Replaces `@nmtjs/tests-integration` imports in gateway and integration tests with local helper modules.
- Removes the `@nmtjs/tests-integration` workspace package export/dependency wiring.
- Keeps the gateway heartbeat test self-contained with a local server format/logger/container helper.

Validation:
- Gateway heartbeat spec: 2 passed.
- Integration tests: 124 passed.