### PR TITLE
Add runtime config for output serialization

### DIFF
--- a/packages/nmtjs/src/index.ts
+++ b/packages/nmtjs/src/index.ts
@@ -11,6 +11,7 @@ import {
 import { createTransport, GatewayInjectables } from '@nmtjs/gateway'
 
 import {
+  config as runtimeConfig,
   createContractProcedure,
   createContractRouter,
   createFilter,
@@ -63,6 +64,7 @@ export namespace neemata {
   export const contractProcedure = createContractProcedure
   export const middleware = createMiddleware
   export const meta = createMeta
+  export const config = runtimeConfig
   export const guard = createGuard
   export const filter = createFilter
   export const job = createJob

--- a/packages/nmtjs/src/runtime/application/api/api.ts
+++ b/packages/nmtjs/src/runtime/application/api/api.ts
@@ -19,7 +19,12 @@ import type {
 } from '@nmtjs/gateway'
 import { withTimeout } from '@nmtjs/common'
 import { IsStreamProcedureContract } from '@nmtjs/contract'
-import { getMetaBindingMeta, isStaticMetaBinding, Scope } from '@nmtjs/core'
+import {
+  getMetaBindingMeta,
+  getStaticMetaValue,
+  isStaticMetaBinding,
+  Scope,
+} from '@nmtjs/core'
 import {
   createGatewayStaticMetaView,
   isAsyncIterable,
@@ -30,6 +35,7 @@ import { ProtocolError } from '@nmtjs/protocol/server'
 import { NeemataTypeError, registerDefaultLocale, type } from '@nmtjs/type'
 import { prettifyError } from 'zod/mini'
 
+import type { RuntimeConfig } from './config.ts'
 import type { kDefaultProcedure as kDefaultProcedureKey } from './constants.ts'
 import type { AnyFilter } from './filters.ts'
 import type { AnyGuard } from './guards.ts'
@@ -38,6 +44,7 @@ import type { AnyMiddleware } from './middlewares.ts'
 import type { AnyProcedure } from './procedure.ts'
 import type { AnyRouter } from './router.ts'
 import type { ApiCallContext } from './types.ts'
+import { config, defaultRuntimeConfig } from './config.ts'
 import { kDefaultProcedure } from './constants.ts'
 
 registerDefaultLocale()
@@ -70,6 +77,7 @@ type ResolvedMetaBindings = Readonly<{
   static: readonly StaticMetaBinding[]
   beforeDecode: readonly AnyFactoryMetaBinding[]
   afterDecode: readonly AnyFactoryMetaBinding[]
+  config: Required<RuntimeConfig>
 }>
 
 export class ApiError extends ProtocolError {
@@ -206,9 +214,13 @@ export class ApplicationApi implements GatewayApi {
         const context = await container.createContext(dependencies)
         const result = await handler(context, input)
         if (isIterableProcedure) {
-          return this.handleIterableOutput(procedure, result)
+          return this.handleIterableOutput(
+            procedure,
+            result,
+            metaBindings.config,
+          )
         } else {
-          return this.handleOutput(procedure, result)
+          return this.handleOutput(procedure, result, metaBindings.config)
         }
       }
     }
@@ -240,10 +252,13 @@ export class ApplicationApi implements GatewayApi {
       }
     }
 
+    const runtimeConfig = getStaticMetaValue(staticBindings, config)
+
     return Object.freeze({
       static: Object.freeze(staticBindings),
       beforeDecode: Object.freeze(beforeDecode),
       afterDecode: Object.freeze(afterDecode),
+      config: Object.freeze({ ...defaultRuntimeConfig, ...runtimeConfig }),
     })
   }
 
@@ -348,7 +363,11 @@ export class ApplicationApi implements GatewayApi {
     }
   }
 
-  private handleIterableOutput(procedure: AnyProcedure, response: any) {
+  private handleIterableOutput(
+    procedure: AnyProcedure,
+    response: any,
+    runtimeConfig: Required<RuntimeConfig>,
+  ) {
     if (!isAsyncIterable(response))
       throw new Error('Response is an async iterable')
     const chunkType = procedure.contract.output
@@ -357,10 +376,11 @@ export class ApplicationApi implements GatewayApi {
 
     return async function* (onDone?: () => void) {
       try {
-        if (chunkType instanceof type.AnyType === false) {
+        if (runtimeConfig.serializeOutput === false) {
+          yield* response
+        } else if (chunkType instanceof type.AnyType === false) {
           for await (const chunk of response) {
-            const encoded = chunkType.encode(chunk)
-            yield encoded
+            yield chunkType.encode(chunk)
           }
         } else {
           yield* response
@@ -371,8 +391,13 @@ export class ApplicationApi implements GatewayApi {
     }
   }
 
-  private handleOutput(procedure: AnyProcedure, response: any) {
+  private handleOutput(
+    procedure: AnyProcedure,
+    response: any,
+    runtimeConfig: Required<RuntimeConfig>,
+  ) {
     if (procedure.contract.output instanceof type.NeverType === false) {
+      if (runtimeConfig.serializeOutput === false) return response
       const type = procedure.contract.output
       return type.encode(response)
     }

--- a/packages/nmtjs/src/runtime/application/api/config.ts
+++ b/packages/nmtjs/src/runtime/application/api/config.ts
@@ -1,0 +1,18 @@
+import type { MetadataKind } from '@nmtjs/core'
+import { createMeta } from '@nmtjs/core'
+
+import type { ApiMetaContext } from './meta.ts'
+
+export interface RuntimeConfig {
+  serializeOutput?: boolean
+}
+
+export const config = createMeta<
+  RuntimeConfig,
+  MetadataKind.STATIC,
+  ApiMetaContext
+>()
+
+export const defaultRuntimeConfig = Object.freeze({
+  serializeOutput: true,
+} satisfies Required<RuntimeConfig>)

--- a/packages/nmtjs/src/runtime/application/api/index.ts
+++ b/packages/nmtjs/src/runtime/application/api/index.ts
@@ -57,6 +57,7 @@ export function createMeta<
 }
 
 export * from './api.ts'
+export * from './config.ts'
 export * from './constants.ts'
 export * from './filters.ts'
 export * from './guards.ts'

--- a/packages/nmtjs/tests/meta.spec.ts
+++ b/packages/nmtjs/tests/meta.spec.ts
@@ -508,4 +508,142 @@ describe('meta runtime', () => {
       await harness.cleanup()
     }
   })
+
+  it('serializes procedure outputs by default and can skip serialization with runtime config', async () => {
+    const outputDate = new Date('2026-04-25T12:34:56.000Z')
+
+    const serializedProcedure = n.procedure({
+      output: t.date(),
+      handler: () => outputDate,
+    })
+
+    const rawProcedure = n.procedure({
+      output: t.date(),
+      meta: [n.config.static({ serializeOutput: false })],
+      handler: () => outputDate,
+    })
+
+    const rootRouter = n.rootRouter([
+      n.router({
+        routes: { serialized: serializedProcedure, raw: rawProcedure },
+      }),
+    ] as const)
+
+    const harness = createApiHarness(rootRouter)
+
+    try {
+      await expect(harness.call('serialized', undefined)).resolves.toBe(
+        outputDate.toISOString(),
+      )
+      await expect(harness.call('raw', undefined)).resolves.toBe(outputDate)
+    } finally {
+      await harness.cleanup()
+    }
+  })
+
+  it('uses the narrowest runtime config binding for output serialization', async () => {
+    const outputDate = new Date('2026-04-25T12:34:56.000Z')
+
+    const appConfiguredProcedure = n.procedure({
+      output: t.date(),
+      handler: () => outputDate,
+    })
+
+    const routerConfiguredProcedure = n.procedure({
+      output: t.date(),
+      handler: () => outputDate,
+    })
+
+    const procedureConfiguredProcedure = n.procedure({
+      output: t.date(),
+      meta: [n.config.static({ serializeOutput: false })],
+      handler: () => outputDate,
+    })
+
+    const configuredRouter = n.router({
+      name: 'configured',
+      routes: {
+        routerConfigured: routerConfiguredProcedure,
+        procedureConfigured: procedureConfiguredProcedure,
+      },
+      meta: [n.config.static({ serializeOutput: true })],
+    })
+
+    const rootRouter = n.rootRouter([
+      n.router({
+        routes: {
+          appConfigured: appConfiguredProcedure,
+          configured: configuredRouter,
+        },
+      }),
+    ] as const)
+
+    const harness = createApiHarness(rootRouter, [
+      n.config.static({ serializeOutput: false }),
+    ])
+
+    try {
+      await expect(harness.call('appConfigured', undefined)).resolves.toBe(
+        outputDate,
+      )
+      await expect(
+        harness.call('configured/routerConfigured', undefined),
+      ).resolves.toBe(outputDate.toISOString())
+      await expect(
+        harness.call('configured/procedureConfigured', undefined),
+      ).resolves.toBe(outputDate)
+    } finally {
+      await harness.cleanup()
+    }
+  })
+
+  it('applies runtime output serialization config to stream procedure chunks', async () => {
+    const outputDate = new Date('2026-04-25T12:34:56.000Z')
+
+    const serializedStreamProcedure = n.procedure({
+      output: t.date(),
+      stream: true,
+      async *handler() {
+        yield outputDate
+      },
+    })
+
+    const rawStreamProcedure = n.procedure({
+      output: t.date(),
+      stream: true,
+      meta: [n.config.static({ serializeOutput: false })],
+      async *handler() {
+        yield outputDate
+      },
+    })
+
+    const rootRouter = n.rootRouter([
+      n.router({
+        routes: {
+          serializedStream: serializedStreamProcedure,
+          rawStream: rawStreamProcedure,
+        },
+      }),
+    ] as const)
+
+    const harness = createApiHarness(rootRouter)
+
+    try {
+      const serializedStream = (await harness.call(
+        'serializedStream',
+        undefined,
+      )) as () => AsyncIterable<unknown>
+      const rawStream = (await harness.call(
+        'rawStream',
+        undefined,
+      )) as () => AsyncIterable<unknown>
+
+      await expect(Array.fromAsync(serializedStream())).resolves.toEqual([
+        outputDate.toISOString(),
+      ])
+      await expect(Array.fromAsync(rawStream())).resolves.toEqual([outputDate])
+    } finally {
+      await harness.cleanup()
+    }
+  })
 })

--- a/skills/use-neemata/references/api-reference.md
+++ b/skills/use-neemata/references/api-reference.md
@@ -17,7 +17,7 @@ Create a standalone RPC procedure (auto-generates contract from input/output).
 ```ts
 n.procedure({
   input: TType,              // t.* type schema for input validation
-  output: TType,             // t.* type schema for output validation
+  output: TType,             // t.* type schema for output serialization/validation
   stream?: true | number,    // true for streaming, or number for explicit stream timeout in ms
   dependencies?: Record<string, Injectable>,
   guards?: Guard[],
@@ -26,6 +26,10 @@ n.procedure({
   handler: (deps, input) => output | AsyncIterable<output>,
 })
 ```
+
+Attach `n.config.static({ serializeOutput: false })` in `meta` to skip
+runtime output serialization/validation for selected procedures or routers while
+keeping the output schema for static typing.
 
 ### `n.contractProcedure(contract, options)`
 
@@ -142,6 +146,23 @@ decodedAccess.factory({
 - `phase: 'beforeDecode'` receives raw `payload: unknown`.
 - `phase: 'afterDecode'` receives the decoded input type at the definition site.
 - Meta tokens are injectables, so they can be used in `dependencies`.
+
+### `n.config.static(value)`
+
+First-party runtime configuration metadata. Attach it through the existing
+`meta` arrays on applications, routers, or procedures. Narrower scopes override
+wider scopes.
+
+```ts
+n.config.static({
+  serializeOutput?: boolean, // default: true
+})
+```
+
+Set `serializeOutput: false` to skip runtime `output` schema serialization and
+validation for procedure responses or stream chunks. The schema still contributes
+static types, but the handler becomes responsible for returning values that the
+selected transport/client can consume.
 
 ### `n.filter(options)`
 

--- a/skills/use-neemata/references/rpc.md
+++ b/skills/use-neemata/references/rpc.md
@@ -21,6 +21,33 @@ export const pingProcedure = n.procedure({
 - `handler` receives `(dependencies, input)` — if no `dependencies` option, first arg is `{}`
 - Return value must match `output` type
 
+## Runtime Output Serialization
+
+By default, Neemata serializes and validates procedure outputs through the
+`output` schema before sending them to the client. This applies to both regular
+responses and each chunk yielded by stream procedures.
+
+When you want the schema only for static typing and you already return
+transport-ready values, attach the first-party runtime config metadata:
+
+```ts
+import { n, t } from 'nmtjs'
+
+export const fastProcedure = n.procedure({
+  output: t.object({ status: t.string() }),
+  meta: [n.config.static({ serializeOutput: false })],
+  handler: () => ({ status: 'ok' }),
+})
+```
+
+- `serializeOutput` defaults to `true`.
+- Set `serializeOutput: false` at application, router, or procedure scope.
+- Narrower scopes override wider scopes.
+- Input decoding, guards, middleware, and metadata phases are unchanged.
+- Disabling output serialization also skips runtime output validation and output
+  transforms, so use it only when the handler returns values compatible with the
+  selected transport/client.
+
 ## Procedure with Dependencies
 
 ```ts

--- a/tests/integration/tests/_setup.ts
+++ b/tests/integration/tests/_setup.ts
@@ -502,6 +502,7 @@ export { t } from '@nmtjs/type'
 export {
   ApiError,
   ApplicationApi,
+  config as runtimeConfig,
   createGuard,
   createProcedure,
   createRootRouter,

--- a/tests/integration/tests/simple-procedures.spec.ts
+++ b/tests/integration/tests/simple-procedures.spec.ts
@@ -12,6 +12,7 @@ import {
   ProtocolError,
   rpcAbortSignal,
   rpcClientAbortSignal,
+  runtimeConfig,
   t,
 } from './_setup.ts'
 
@@ -199,6 +200,22 @@ const guardedDateProcedure = createProcedure({
   handler: async (_, input) => ({ iso: input.createdAt.toISOString() }),
 })
 
+const outputMarker = t.custom({
+  decode: (value) => value,
+  encode: (value) => `encoded:${value}`,
+})
+
+const serializedOutputProcedure = createProcedure({
+  output: outputMarker,
+  handler: () => 'raw-output',
+})
+
+const rawOutputProcedure = createProcedure({
+  output: outputMarker,
+  meta: [runtimeConfig.static({ serializeOutput: false })],
+  handler: () => 'raw-output',
+})
+
 // For testing ProtocolError directly
 const failingWithProtocolErrorProcedure = createProcedure({
   input: t.object({}),
@@ -228,6 +245,8 @@ const router = createRootRouter(
         abortableWithState: abortableWithStateProcedure,
         clientAbortSignalState: clientAbortSignalStateProcedure,
         guardedDate: guardedDateProcedure,
+        serializedOutput: serializedOutputProcedure,
+        rawOutput: rawOutputProcedure,
       },
     }),
   ] as const,
@@ -362,6 +381,17 @@ describe('Simple RPC Calls', () => {
       expect(result).toEqual({ status: 'ok' })
 
       // Verify cleanup
+      await waitForCleanup()
+      expect(setup.gateway.rpcs.rpcs.size).toBe(0)
+      expect(setup.client.pendingCallsCount).toBe(0)
+    })
+
+    it('should allow procedures to skip runtime output serialization', async () => {
+      await expect(setup.client.call.serializedOutput()).resolves.toBe(
+        'encoded:raw-output',
+      )
+      await expect(setup.client.call.rawOutput()).resolves.toBe('raw-output')
+
       await waitForCleanup()
       expect(setup.gateway.rpcs.rpcs.size).toBe(0)
       expect(setup.client.pendingCallsCount).toBe(0)


### PR DESCRIPTION
## Summary
Add a first-party runtime config metadata token that allows procedures, routers, and applications to disable runtime output serialization while keeping output schemas for static typing.

## What changed
- add `n.config.static({ serializeOutput: false })`
- resolve runtime config through existing static metadata precedence rules
- skip server-side output encoding for regular responses and stream chunks when `serializeOutput` is disabled
- add focused unit coverage in `packages/nmtjs/tests/meta.spec.ts`
- add integration coverage in `tests/integration/tests/simple-procedures.spec.ts`
- document the new API in the Neemata skill references

## Why
This supports cases where the output schema is still useful for typing, but runtime output validation/serialization should be skipped for performance or because the handler already returns transport-ready values.

## Validation
- passed focused tests for:
  - `packages/nmtjs/tests/meta.spec.ts`
  - `tests/integration/tests/simple-procedures.spec.ts`
- passed targeted type-check for:
  - `packages/nmtjs/tsconfig.json`
  - `tests/integration/tsconfig.json`
- `pnpm run check` still reports an unrelated pre-existing type-check issue in `packages/gateway/tests/heartbeat.spec.ts` resolving `@nmtjs/tests-integration`
