### PR TITLE
fix record enum generic type

### DIFF
--- a/packages/gateway/tests/heartbeat.spec.ts
+++ b/packages/gateway/tests/heartbeat.spec.ts
@@ -8,16 +8,16 @@ import {
   ServerMessageType,
 } from '@nmtjs/protocol'
 import { ProtocolFormats } from '@nmtjs/protocol/server'
-import {
-  createTestContainer,
-  createTestLogger,
-  createTestServerFormat,
-} from './_helpers/test-utils.ts'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { GatewayApi } from '../src/api.ts'
 import { createGatewayStaticMetaView } from '../src/api.ts'
 import { Gateway } from '../src/gateway.ts'
+import {
+  createTestContainer,
+  createTestLogger,
+  createTestServerFormat,
+} from './_helpers/test-utils.ts'
 
 const encodeUInt32 = (value: number) => {
   const buffer = Buffer.allocUnsafe(4)

--- a/packages/type/src/types/object.ts
+++ b/packages/type/src/types/object.ts
@@ -74,7 +74,7 @@ export type AnyLooseObjectType = LooseObjectType<ObjectTypeProps>
 export type AnyObjectLikeType = AnyObjectType | AnyLooseObjectType
 
 export class RecordType<
-  K extends LiteralType<string | number> | EnumType | StringType,
+  K extends LiteralType<string | number> | EnumType<any> | StringType,
   E extends BaseType,
 > extends BaseType<
   ZodMiniRecord<K['encodeZodType'], E['encodeZodType']>,
@@ -82,7 +82,7 @@ export class RecordType<
   { key: K; element: E }
 > {
   static factory<
-    K extends LiteralType<string | number> | EnumType | StringType,
+    K extends LiteralType<string | number> | EnumType<any> | StringType,
     E extends BaseType,
   >(key: K, element: E) {
     return new RecordType<K, E>({

--- a/packages/type/tests/index.spec.ts
+++ b/packages/type/tests/index.spec.ts
@@ -240,3 +240,14 @@ describe('Unknown type', () => {
     >().toEqualTypeOf<unknown>()
   })
 })
+
+describe('Record type', () => {
+  it('accepts generic enum keys', () => {
+    const key: t.EnumType<any> = t.enum(['a', 'b'] as const)
+    const schema = t.record(key, t.number())
+
+    expectTypeOf<typeof schema>().toEqualTypeOf<
+      t.RecordType<t.EnumType<any>, t.NumberType>
+    >()
+  })
+})

--- a/tests/integration/tests/_setup.ts
+++ b/tests/integration/tests/_setup.ts
@@ -31,17 +31,18 @@ import { Gateway } from '@nmtjs/gateway'
 import { ConnectionType, ProtocolVersion } from '@nmtjs/protocol'
 import { ProtocolFormats } from '@nmtjs/protocol/server'
 import {
-  createTestClientFormat,
-  createTestLogger,
-  createTestServerFormat,
-} from './_helpers/index.ts'
-import {
   ApplicationApi,
   isProcedure,
   isRouter,
   kDefaultProcedure,
   kRootRouter,
 } from 'nmtjs/runtime'
+
+import {
+  createTestClientFormat,
+  createTestLogger,
+  createTestServerFormat,
+} from './_helpers/index.ts'
 
 const kUnknownProcedureForDefaultTest = '__tests__/unknown-procedure'
 
@@ -492,12 +493,6 @@ export {
   ProtocolVersion,
 } from '@nmtjs/protocol'
 export { ProtocolError, ProtocolFormats } from '@nmtjs/protocol/server'
-// Re-export useful types and utilities for tests
-export {
-  createTestClientFormat,
-  createTestLogger,
-  createTestServerFormat,
-} from './_helpers/index.ts'
 export { t } from '@nmtjs/type'
 export {
   ApiError,
@@ -508,3 +503,10 @@ export {
   createRootRouter,
   createRouter,
 } from 'nmtjs/runtime'
+
+// Re-export useful types and utilities for tests
+export {
+  createTestClientFormat,
+  createTestLogger,
+  createTestServerFormat,
+} from './_helpers/index.ts'


### PR DESCRIPTION
## Summary
- Allow RecordType keys to use generic EnumType<any>
- Add a type regression test for record enum keys
- Apply formatter import ordering from pnpm run fmt

## Verification
- pnpm run fmt
- pnpm run check
- pnpm run test