### PR TITLE
[codex] limit HTTP client keepalive bodies

### DIFF
--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -34,6 +34,39 @@ const createDecodeBase64 = (
 }
 
 const NEEMATA_BLOB_HEADER = 'X-Neemata-Blob'
+const MAX_KEEPALIVE_BODY_BYTES = 64 * 1024
+
+const getBodyByteLength = (body: unknown): number | undefined => {
+  if (typeof body === 'string') {
+    return new TextEncoder().encode(body).byteLength
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    return body.byteLength
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return body.byteLength
+  }
+
+  if (typeof Blob !== 'undefined' && body instanceof Blob) {
+    return body.size
+  }
+
+  if (
+    typeof URLSearchParams !== 'undefined' &&
+    body instanceof URLSearchParams
+  ) {
+    return new TextEncoder().encode(body.toString()).byteLength
+  }
+
+  return undefined
+}
+
+const shouldUseKeepalive = (body: unknown): boolean => {
+  const byteLength = getBodyByteLength(body)
+  return byteLength !== undefined && byteLength <= MAX_KEEPALIVE_BODY_BYTES
+}
 
 export type HttpClientTransportOptions = {
   /**
@@ -112,7 +145,7 @@ export class HttpTransportClient implements UnidirectionalTransport {
         headers: requestHeaders,
         signal: options.signal,
         credentials: 'include',
-        keepalive: true,
+        ...(shouldUseKeepalive(body) ? { keepalive: true } : {}),
       })
 
       if (!response.ok) {
@@ -177,7 +210,7 @@ export class HttpTransportClient implements UnidirectionalTransport {
         headers: requestHeaders,
         signal: options.signal,
         credentials: 'include',
-        keepalive: true,
+        ...(shouldUseKeepalive(body) ? { keepalive: true } : {}),
       })
 
       if (response.ok) {

--- a/packages/http-client/tests/client-call.spec.ts
+++ b/packages/http-client/tests/client-call.spec.ts
@@ -81,6 +81,52 @@ describe('HttpTransportClient + StaticClient', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('uses keepalive for small HTTP request bodies', async () => {
+    const format = new TestJsonFormat()
+    const fetchSpy = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(format.encode({ ok: true }) as any, {
+          status: 200,
+          headers: { 'content-type': format.contentType },
+        }),
+      )
+
+    const client = new StaticClient(
+      { contract: {} as any, protocol: ProtocolVersion.v1, format },
+      HttpTransportFactory,
+      { url: 'http://localhost:4000', fetch: fetchSpy },
+    )
+
+    await (client.call as any).ping({ userId: 'u1' })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy.mock.calls[0]?.[1]?.keepalive).toBe(true)
+  })
+
+  it('omits keepalive for large HTTP request bodies', async () => {
+    const format = new TestJsonFormat()
+    const fetchSpy = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(format.encode({ ok: true }) as any, {
+          status: 200,
+          headers: { 'content-type': format.contentType },
+        }),
+      )
+
+    const client = new StaticClient(
+      { contract: {} as any, protocol: ProtocolVersion.v1, format },
+      HttpTransportFactory,
+      { url: 'http://localhost:4000', fetch: fetchSpy },
+    )
+
+    await (client.call as any).ping({ data: 'x'.repeat(64 * 1024) })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy.mock.calls[0]?.[1]?.keepalive).toBeUndefined()
+  })
+
   it('emits decoded rpc_response body in logging plugin', async () => {
     const emitted: unknown[] = []
     const format = new TestJsonFormat()


### PR DESCRIPTION
## Summary

- Gate HTTP client `keepalive` to request bodies with a known size up to 64 KiB
- Omit `keepalive` for large or unknown-size bodies to avoid fetch keepalive body limits
- Add regression coverage for small and large HTTP RPC request bodies

## Validation

- `pnpm vitest run packages/http-client/tests`
- `pnpm run fmt`
- `pnpm run check`