### PR TITLE
Support custom job pools

### DIFF
--- a/packages/nmtjs/src/index.ts
+++ b/packages/nmtjs/src/index.ts
@@ -97,7 +97,6 @@ export {
 } from '@nmtjs/application'
 
 export {
-  JobWorkerPool,
   StoreType,
   WorkerType,
 } from './runtime/index.ts'

--- a/packages/nmtjs/src/runtime/enums.ts
+++ b/packages/nmtjs/src/runtime/enums.ts
@@ -3,11 +3,6 @@ export enum StoreType {
   Valkey = 'Valkey',
 }
 
-export enum JobWorkerPool {
-  Io = 'Io',
-  Compute = 'Compute',
-}
-
 export enum WorkerType {
   Application = 'Application',
   Job = 'Job',

--- a/packages/nmtjs/src/runtime/injectables.ts
+++ b/packages/nmtjs/src/runtime/injectables.ts
@@ -1,6 +1,6 @@
 import { createLazyInjectable, Scope } from '@nmtjs/core'
 
-import type { JobWorkerPool, WorkerType } from './enums.ts'
+import type { WorkerType } from './enums.ts'
 import type { JobManagerInstance } from './jobs/manager.ts'
 import type { JobExecutionContext, SaveJobProgress } from './jobs/types.ts'
 import type { ServerStoreConfig } from './server/config.ts'
@@ -38,7 +38,7 @@ export const workerType = createLazyInjectable<WorkerType>(
   'WorkerType',
 )
 
-export const jobWorkerPool = createLazyInjectable<JobWorkerPool>(
+export const jobWorkerPool = createLazyInjectable<string>(
   Scope.Global,
   'JobWorkerPool',
 )

--- a/packages/nmtjs/src/runtime/jobs/job.ts
+++ b/packages/nmtjs/src/runtime/jobs/job.ts
@@ -4,7 +4,6 @@ import type { t } from '@nmtjs/type'
 import type { AnyObjectLikeType, ObjectType } from '@nmtjs/type/object'
 import { tryCaptureStackTrace } from '@nmtjs/common'
 
-import type { JobWorkerPool } from '../enums.ts'
 import type { AnyJobStep, JobStep } from './step.ts'
 import { kJobKey } from '../constants.ts'
 import { isJobStep } from './step.ts'
@@ -200,7 +199,7 @@ export interface JobOptions<
   Data = any,
 > {
   name: Name
-  pool: JobWorkerPool
+  pool: string
   input: Input
   output: Output
   progress?: Progress

--- a/packages/nmtjs/src/runtime/server/config.ts
+++ b/packages/nmtjs/src/runtime/server/config.ts
@@ -6,7 +6,7 @@ import type { LoggingOptions } from '@nmtjs/core'
 import type { ApplicationOptions } from '@nmtjs/proxy'
 import type { Applications } from 'nmtjs/runtime/types'
 
-import type { JobWorkerPool, StoreType } from '../enums.ts'
+import type { StoreType } from '../enums.ts'
 import type { AnyJob } from '../jobs/job.ts'
 import type { JobsSchedulerOptions } from '../scheduler/index.ts'
 import type { SubscriptionAdapterType } from '../subscription/manager.ts'
@@ -43,10 +43,7 @@ export type ServerApplicationConfig<T = ApplicationConfig> =
     : any
 
 export type ServerJobsConfig = {
-  pools: {
-    [JobWorkerPool.Io]: ServerPoolOptions
-    [JobWorkerPool.Compute]: ServerPoolOptions
-  }
+  pools: Record<string, ServerPoolOptions>
   jobs?: AnyJob[]
   /**
    * @deprecated Scheduler is currently being refactored and is not available.

--- a/packages/nmtjs/src/runtime/server/jobs.ts
+++ b/packages/nmtjs/src/runtime/server/jobs.ts
@@ -14,9 +14,11 @@ import type {
   WorkerPoolConfig,
   WorkerPoolFactory,
 } from './worker-pool.ts'
-import { JobWorkerPool, WorkerType } from '../enums.ts'
+import { WorkerType } from '../enums.ts'
 import { getJobQueueName } from '../jobs/manager.ts'
 import { JobRunnersPool } from './worker-pool.ts'
+
+type JobsPoolConfig = Exclude<ServerConfig['jobs'], undefined>['pools']
 
 function enrichBullMqErrorStack(error: unknown): Error {
   const normalized =
@@ -31,6 +33,38 @@ function enrichBullMqErrorStack(error: unknown): Error {
   return normalized
 }
 
+function getJobsByPool(jobs: Iterable<AnyJob>): Map<string, AnyJob[]> {
+  const jobsByPool = new Map<string, AnyJob[]>()
+
+  for (const job of jobs) {
+    const poolJobs = jobsByPool.get(job.options.pool)
+    if (poolJobs) {
+      poolJobs.push(job)
+    } else {
+      jobsByPool.set(job.options.pool, [job])
+    }
+  }
+
+  return jobsByPool
+}
+
+function assertActiveJobPoolsConfigured(
+  jobsByPool: Map<string, AnyJob[]>,
+  pools: JobsPoolConfig,
+) {
+  const missingPoolMessages = [...jobsByPool]
+    .filter(([poolName]) => !pools[poolName])
+    .flatMap(([poolName, jobs]) =>
+      jobs.map((job) => `${job.name} -> ${poolName}`),
+    )
+
+  if (missingPoolMessages.length > 0) {
+    throw new Error(
+      `Invalid jobs pool configuration: missing pool config for jobs: ${missingPoolMessages.join(', ')}`,
+    )
+  }
+}
+
 /**
  * ApplicationServerJobs manages job worker pools and BullMQ queue workers.
  *
@@ -38,7 +72,7 @@ function enrichBullMqErrorStack(error: unknown): Error {
  * - Uses JobRunnersPool (extends WorkerPool) for worker management
  * - Uses ManagedWorker for restart logic and state tracking
  * - Integrates with ErrorPolicy for restart decisions
- * - Proper health tracking per job pool type
+ * - Proper health tracking per job pool
  */
 export class ApplicationServerJobs {
   /**
@@ -49,10 +83,10 @@ export class ApplicationServerJobs {
   jobs: Map<string, AnyJob>
 
   /**
-   * Shared resource pools by pool type (Io, Compute).
-   * All jobs of a given pool type share the same pool for resource management.
+   * Shared resource pools by configured pool name.
+   * All jobs using the same pool name share the same pool for resource management.
    */
-  protected pools = new Map<JobWorkerPool, JobRunnersPool>()
+  protected pools = new Map<string, JobRunnersPool>()
 
   constructor(
     readonly params: {
@@ -86,16 +120,16 @@ export class ApplicationServerJobs {
       return
     }
 
-    // Step 1: Initialize shared resource pools (Io, Compute)
-    const poolTypes = Object.values(JobWorkerPool)
+    const jobsByPool = getJobsByPool(this.jobs.values())
+    assertActiveJobPoolsConfigured(jobsByPool, jobsConfig.pools)
 
-    for (const poolType of poolTypes) {
-      const poolConfig = jobsConfig.pools[poolType]
-      if (!poolConfig) continue
+    // Step 1: Initialize shared resource pools used by active jobs
+    for (const poolName of jobsByPool.keys()) {
+      const poolConfig = jobsConfig.pools[poolName]!
 
-      // Create a JobRunnersPool for this pool type
+      // Create a JobRunnersPool for this pool
       const config: WorkerPoolConfig = {
-        name: `job-pool-${poolType}`,
+        name: `job-pool-${poolName}`,
         workerType: WorkerType.Job,
         path: workerConfig.path,
         workerData: { ...workerConfig.workerData },
@@ -111,15 +145,15 @@ export class ApplicationServerJobs {
 
       // Add workers to the pool
       for (let i = 0; i < poolConfig.threads; i++) {
-        pool.add({ runtime: { type: 'jobs', jobWorkerPool: poolType } }, i)
+        pool.add({ runtime: { type: 'jobs', jobWorkerPool: poolName } }, i)
       }
 
       await pool.startAll()
-      this.pools.set(poolType, pool)
+      this.pools.set(poolName, pool)
 
       logger.info(
         {
-          pool: poolType,
+          pool: poolName,
           threads: poolConfig.threads,
           jobsPerThread: poolConfig.jobs,
         },
@@ -129,28 +163,18 @@ export class ApplicationServerJobs {
 
     // Step 2: Create a dedicated BullMQ Worker for each job
     // Calculate how many jobs use each pool for fair concurrency distribution
-    const jobsPerPool = new Map<JobWorkerPool, number>()
-    for (const job of this.jobs.values()) {
-      const count = jobsPerPool.get(job.options.pool) ?? 0
-      jobsPerPool.set(job.options.pool, count + 1)
-    }
-
     for (const job of this.jobs.values()) {
       const queueName = getJobQueueName(job)
-      const poolType = job.options.pool
-      const pool = this.pools.get(poolType)
+      const poolName = job.options.pool
+      const pool = this.pools.get(poolName)
 
       if (!pool) {
-        logger.warn(
-          { job: job.name, pool: poolType },
-          'No pool configured for job, skipping worker creation',
-        )
-        continue
+        throw new Error(`Job "${job.name}" pool "${poolName}" is not started`)
       }
 
-      const poolConfig = jobsConfig.pools[poolType]
+      const poolConfig = jobsConfig.pools[poolName]!
       const poolCapacity = poolConfig.threads * poolConfig.jobs
-      const jobCountInPool = jobsPerPool.get(poolType) ?? 1
+      const jobCountInPool = jobsByPool.get(poolName)?.length ?? 1
       // Use job-specific concurrency if provided, otherwise distribute pool capacity evenly
       const defaultConcurrency = Math.max(
         1,
@@ -192,7 +216,7 @@ export class ApplicationServerJobs {
 
       this.queueWorkers.add(queueWorker)
       logger.info(
-        { job: job.name, queue: queueName, pool: poolType, concurrency },
+        { job: job.name, queue: queueName, pool: poolName, concurrency },
         'Job queue worker started',
       )
     }
@@ -234,9 +258,9 @@ export class ApplicationServerJobs {
   }
 
   /**
-   * Get a job pool by type.
+   * Get a job pool by name.
    */
-  getPool(poolType: JobWorkerPool): JobRunnersPool | undefined {
-    return this.pools.get(poolType)
+  getPool(poolName: string): JobRunnersPool | undefined {
+    return this.pools.get(poolName)
   }
 }

--- a/packages/nmtjs/src/runtime/workers/job.ts
+++ b/packages/nmtjs/src/runtime/workers/job.ts
@@ -3,7 +3,6 @@ import type { MessagePort } from 'node:worker_threads'
 import { LifecycleHook } from '@nmtjs/application'
 import { UnrecoverableError } from 'bullmq'
 
-import type { JobWorkerPool } from '../enums.ts'
 import type { JobProgressCheckpoint } from '../jobs/types.ts'
 import type { ServerConfig } from '../server/config.ts'
 import type { ServerPortMessage, ThreadPortMessage } from '../types.ts'
@@ -53,10 +52,7 @@ export class JobWorkerRuntime extends BaseWorkerRuntime {
       }
     }
 
-    this.container.provide(
-      jobWorkerPool,
-      this.runtimeOptions.poolName as JobWorkerPool,
-    )
+    this.container.provide(jobWorkerPool, this.runtimeOptions.poolName)
     await super.initialize()
   }
 

--- a/packages/nmtjs/tests/jobs.spec.ts
+++ b/packages/nmtjs/tests/jobs.spec.ts
@@ -1,7 +1,6 @@
 import { t } from '@nmtjs/type'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 
-import { JobWorkerPool } from '../src/runtime/enums.ts'
 import { createJob } from '../src/runtime/jobs/job.ts'
 import { JobManager } from '../src/runtime/jobs/manager.ts'
 import { createJobsRouter } from '../src/runtime/jobs/router.ts'
@@ -58,7 +57,7 @@ describe('jobs builder', () => {
 
     const job = createJob({
       name: 'builder-shape',
-      pool: JobWorkerPool.Compute,
+      pool: 'compute',
       input: t.object({ seed: t.number() }),
       output: t.object({ done: t.number() }),
     })
@@ -98,7 +97,7 @@ describe('jobs builder', () => {
 
     const job = createJob({
       name: 'builder-condition',
-      pool: JobWorkerPool.Compute,
+      pool: 'compute',
       input: t.object({ seed: t.number() }),
       output: t.object({
         a: t.number().optional(),
@@ -149,7 +148,7 @@ describe('jobs types', () => {
 
     const job = createJob({
       name: 'types-parallel',
-      pool: JobWorkerPool.Compute,
+      pool: 'compute',
       input: t.object({ seed: t.number() }),
       output: t.object({ done: t.number() }),
     })
@@ -180,7 +179,7 @@ describe('jobs types', () => {
 
     createJob({
       name: 'types-invalid',
-      pool: JobWorkerPool.Compute,
+      pool: 'compute',
       input: t.object({ seed: t.number() }),
       output: t.object({ done: t.number() }),
     })
@@ -196,7 +195,7 @@ describe('jobs types', () => {
 
     createJob({
       name: 'types-invalid-parallel-input',
-      pool: JobWorkerPool.Compute,
+      pool: 'compute',
       input: t.object({ seed: t.number() }),
       output: t.object({ done: t.number() }),
     })
@@ -238,7 +237,7 @@ describe('jobs types', () => {
 
     createJob({
       name: 'types-job-data-compatible',
-      pool: JobWorkerPool.Compute,
+      pool: 'compute',
       input: t.object({ seed: t.number() }),
       output: t.object({ done: t.number() }),
       data: async () => ({ progress: { tick: 1 } }),
@@ -248,7 +247,7 @@ describe('jobs types', () => {
 
     createJob({
       name: 'types-job-data-incompatible-step',
-      pool: JobWorkerPool.Compute,
+      pool: 'compute',
       input: t.object({ seed: t.number() }),
       output: t.object({ done: t.number() }),
       data: async () => ({ progress: { tick: 1 } }),
@@ -259,7 +258,7 @@ describe('jobs types', () => {
 
     createJob({
       name: 'types-job-data-incompatible-parallel',
-      pool: JobWorkerPool.Compute,
+      pool: 'compute',
       input: t.object({ seed: t.number() }),
       output: t.object({ value: t.number(), done: t.number() }),
       data: async () => ({ progress: { tick: 1 } }),
@@ -307,7 +306,7 @@ describe('jobs info metadata', () => {
 
     const job = createJob({
       name: 'info-parallel-manager',
-      pool: JobWorkerPool.Compute,
+      pool: 'compute',
       input: t.object({ seed: t.number() }),
       output: t.object({ total: t.number() }),
     })
@@ -364,7 +363,7 @@ describe('jobs info metadata', () => {
 
     const job = createJob({
       name: 'info-parallel-router',
-      pool: JobWorkerPool.Compute,
+      pool: 'compute',
       input: t.object({ seed: t.number() }),
       output: t.object({ total: t.number() }),
       progress: t.object({}),
@@ -398,7 +397,7 @@ describe('jobs router', () => {
   function createRouterFixtureJob(name: string) {
     return createJob({
       name,
-      pool: JobWorkerPool.Compute,
+      pool: 'compute',
       input: t.object({ seed: t.number() }),
       output: t.object({ value: t.number() }),
       progress: t.object({}),

--- a/packages/nmtjs/tests/server-jobs.spec.ts
+++ b/packages/nmtjs/tests/server-jobs.spec.ts
@@ -1,0 +1,160 @@
+import EventEmitter from 'node:events'
+
+import type { Logger } from '@nmtjs/core'
+import { t } from '@nmtjs/type'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ManagedWorkerConfig } from '../src/runtime/server/managed-worker.ts'
+import type { ManagedWorkerFactory } from '../src/runtime/server/worker-pool.ts'
+import { createJob, defineServer } from '../src/runtime/index.ts'
+import { DevErrorPolicy } from '../src/runtime/server/error-policy.ts'
+import { ApplicationServerJobs } from '../src/runtime/server/jobs.ts'
+import { WorkerPool } from '../src/runtime/server/worker-pool.ts'
+
+const bullmqState = vi.hoisted(() => ({
+  workers: [] as Array<{
+    queueName: string
+    processor: unknown
+    options: { concurrency?: number }
+  }>,
+}))
+
+vi.mock('bullmq', () => {
+  class Worker {
+    constructor(
+      queueName: string,
+      processor: unknown,
+      options: { concurrency?: number },
+    ) {
+      bullmqState.workers.push({ queueName, processor, options })
+    }
+
+    async close() {}
+  }
+
+  return {
+    UnrecoverableError: class UnrecoverableError extends Error {},
+    Worker,
+  }
+})
+
+const logger = {
+  child: () => logger,
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  trace: () => {},
+  error: () => {},
+} as unknown as Logger
+
+const workerFactory: ManagedWorkerFactory = (config: ManagedWorkerConfig) => {
+  const worker = new EventEmitter() as EventEmitter & {
+    config: ManagedWorkerConfig
+    context: { consecutiveFailures: number; totalFailures: number }
+    currentState: 'ready'
+    isHealthy: boolean
+    start: () => Promise<void>
+    stop: () => Promise<void>
+    run: () => Promise<never>
+    resetFailureCount: () => void
+  }
+
+  worker.config = config
+  worker.context = { consecutiveFailures: 0, totalFailures: 0 }
+  worker.currentState = 'ready'
+  worker.isHealthy = true
+  worker.start = async () => {}
+  worker.stop = async () => {}
+  worker.run = async () => {
+    throw new Error('not used in this test')
+  }
+  worker.resetFailureCount = () => {}
+
+  return worker as any
+}
+
+function createTestJob(name: string, pool: string) {
+  return createJob({
+    name,
+    pool,
+    input: t.object({}),
+    output: t.object({}),
+  }).return()
+}
+
+function createServerJobs(params: {
+  jobs: ReturnType<typeof createTestJob>[]
+  pools: Record<string, { threads: number; jobs: number }>
+}) {
+  const serverConfig = defineServer({
+    logger: { pinoOptions: { enabled: false } },
+    applications: {},
+    jobs: params,
+  })
+
+  return new ApplicationServerJobs({
+    logger,
+    serverConfig,
+    workerConfig: { path: '/virtual/worker.ts', workerData: {} },
+    store: {} as any,
+    errorPolicy: DevErrorPolicy,
+    workerFactory,
+    poolFactory: (config, policy, factory, poolLogger) =>
+      new WorkerPool(config, policy, factory, poolLogger),
+  })
+}
+
+describe('server jobs pools', () => {
+  beforeEach(() => {
+    bullmqState.workers.length = 0
+  })
+
+  it('starts custom pools used by active jobs', async () => {
+    const jobs = createServerJobs({
+      jobs: [
+        createTestJob('test-job-1', 'test-pool-1'),
+        createTestJob('test-job-2', 'test-pool-1'),
+      ],
+      pools: { 'test-pool-1': { threads: 2, jobs: 5 } },
+    })
+
+    await jobs.start()
+
+    expect(jobs.getPool('test-pool-1')?.workerCount).toBe(2)
+    expect(bullmqState.workers).toHaveLength(2)
+    expect(
+      bullmqState.workers.map((worker) => worker.options.concurrency),
+    ).toEqual([5, 5])
+
+    await jobs.stop()
+  })
+
+  it('throws when an active job references a missing pool config', async () => {
+    const jobs = createServerJobs({
+      jobs: [createTestJob('test-job-1', 'test-pool-1')],
+      pools: {},
+    })
+
+    await expect(jobs.start()).rejects.toThrow(
+      'Invalid jobs pool configuration: missing pool config for jobs: test-job-1 -> test-pool-1',
+    )
+    expect(bullmqState.workers).toHaveLength(0)
+  })
+
+  it('ignores pool configs unused by active jobs', async () => {
+    const jobs = createServerJobs({
+      jobs: [createTestJob('test-job-1', 'test-pool-1')],
+      pools: {
+        'test-pool-1': { threads: 1, jobs: 1 },
+        'test-pool-2': { threads: 1, jobs: 1 },
+      },
+    })
+
+    await jobs.start()
+
+    expect(jobs.getPool('test-pool-1')?.workerCount).toBe(1)
+    expect(jobs.getPool('test-pool-2')).toBeUndefined()
+
+    await jobs.stop()
+  })
+})

--- a/skills/use-neemata/references/api-reference.md
+++ b/skills/use-neemata/references/api-reference.md
@@ -242,7 +242,7 @@ n.server({
     tls?: TlsConfig,
   },
   jobs?: {
-    pools: { Io?: PoolConfig, Compute?: PoolConfig },
+    pools: Record<string, PoolConfig>,
     jobs?: Job[],
   },
   metrics?: { port?: number, path?: string },

--- a/skills/use-neemata/references/jobs.md
+++ b/skills/use-neemata/references/jobs.md
@@ -14,11 +14,11 @@ in a separate worker thread pool. Jobs require a store (Redis or Valkey).
 Jobs are built with a chainable API: define options, add steps, then finalize with `.return()`:
 
 ```ts
-import { n, t, JobWorkerPool } from 'nmtjs'
+import { n, t } from 'nmtjs'
 
 const processUserJob = n.job({
   name: 'processUser',
-  pool: JobWorkerPool.Io,
+  pool: 'io',
   input: t.object({ userId: t.string() }),
   output: t.object({ success: t.boolean() }),
   attempts: 3,
@@ -68,7 +68,7 @@ the group fails with a key-conflict error.
 | Option | Type | Description |
 |---|---|---|
 | `name` | `string` | Unique job name (used as queue name) |
-| `pool` | `JobWorkerPool` | `Io` or `Compute` — which worker pool runs this job |
+| `pool` | `string` | Custom pool name configured in `jobs.pools` |
 | `input` | `t.*` schema | Input data schema |
 | `output` | `t.*` schema | Final output schema |
 | `progress` | `t.*` schema | Optional user-defined progress state schema |
@@ -113,7 +113,7 @@ type SyncUsersData = {
 
 const syncUsersJob = n.job({
   name: 'syncUsers',
-  pool: JobWorkerPool.Io,
+  pool: 'io',
   input: t.object({ tenantId: t.string() }),
   output: t.object({ synced: t.number() }),
   progress: t.object({ cursor: t.string().optional() }),
@@ -178,7 +178,7 @@ Use `.steps(...)` when independent steps can run in parallel against the same in
 const job = n
   .job({
     name: 'parallel-example',
-    pool: JobWorkerPool.Io,
+    pool: 'io',
     input: t.object({ id: t.string() }),
     output: t.object({ left: t.number(), right: t.number(), total: t.number() }),
   })
@@ -285,7 +285,7 @@ These are available inside job step handlers and job hooks:
 | `n.inject.jobAbortSignal` | Global | `AbortSignal` | Cancellation signal for current job |
 | `n.inject.saveJobProgress` | Global | `() => Promise<void>` | Manually persist progress mid-step |
 | `n.inject.currentJobInfo` | Global | `JobExecutionContext` | Current job metadata (name, id, attempts) |
-| `n.inject.jobWorkerPool` | Global | `JobWorkerPool` | Current worker's pool type |
+| `n.inject.jobWorkerPool` | Global | `string` | Current worker's pool name |
 
 ### Saving Progress Mid-Step
 
@@ -403,7 +403,7 @@ const jobManagementRouter = n.jobRouter({
 Jobs require a store and pool configuration in `n.server()`:
 
 ```ts
-import { n, StoreType, JobWorkerPool } from 'nmtjs'
+import { n, StoreType } from 'nmtjs'
 
 export default n.server({
   store: {
@@ -412,8 +412,8 @@ export default n.server({
   },
   jobs: {
     pools: {
-      [JobWorkerPool.Io]: { threads: 2, jobs: 5 },
-      [JobWorkerPool.Compute]: { threads: 1, jobs: 2 },
+      io: { threads: 2, jobs: 5 },
+      compute: { threads: 1, jobs: 2 },
     },
     jobs: [processUserJob],
   },
@@ -421,12 +421,10 @@ export default n.server({
 })
 ```
 
-### Pool Types
+### Pool Configuration
 
-| Pool | Use for |
-|---|---|
-| `JobWorkerPool.Io` | I/O-bound jobs (API calls, database queries, file processing) |
-| `JobWorkerPool.Compute` | CPU-bound jobs (data processing, calculations) |
+Pool names are application-defined strings. Use separate pools to isolate workloads
+with different capacity and latency requirements.
 
 Each pool gets `threads` worker threads. `jobs` is the number of concurrent jobs per thread.
 

--- a/tests/e2e/src/jobs/applications/main/jobs.ts
+++ b/tests/e2e/src/jobs/applications/main/jobs.ts
@@ -1,4 +1,4 @@
-import { JobWorkerPool, n, t } from 'nmtjs'
+import { n, t } from 'nmtjs'
 
 type JobKind =
   | 'quick'
@@ -78,7 +78,7 @@ async function wait(ms: number, signal: AbortSignal) {
 const quick = n
   .job({
     name: 'playground-quick',
-    pool: JobWorkerPool.Io,
+    pool: 'io',
     input: t.object({ value: t.string() }),
     output: t.object({ value: t.string() }),
     progress: t.object({}),
@@ -96,7 +96,7 @@ const quick = n
 const slow = n
   .job({
     name: 'playground-slow',
-    pool: JobWorkerPool.Io,
+    pool: 'io',
     input: t.object({ ticks: t.number(), delayMs: t.number() }),
     output: t.object({ ticks: t.number() }),
     oneoff: false,
@@ -132,7 +132,7 @@ const slow = n
 const checkpoint = n
   .job({
     name: 'playground-checkpoint',
-    pool: JobWorkerPool.Io,
+    pool: 'io',
     input: t.object({ total: t.number(), failAt: t.number() }),
     output: t.object({ processed: t.number() }),
     oneoff: false,
@@ -177,7 +177,7 @@ const checkpoint = n
 const hung = n
   .job({
     name: 'playground-hung',
-    pool: JobWorkerPool.Io,
+    pool: 'io',
     input: t.object({ durationMs: t.number() }),
     output: t.object({ done: t.boolean() }),
     progress: t.object({}),
@@ -199,7 +199,7 @@ const hung = n
 const parallel = n
   .job({
     name: 'playground-parallel',
-    pool: JobWorkerPool.Io,
+    pool: 'io',
     input: t.object({
       base: t.number(),
       delayMs: t.number(),
@@ -345,7 +345,7 @@ const parallel = n
 const parallelConflict = n
   .job({
     name: 'playground-parallel-conflict',
-    pool: JobWorkerPool.Io,
+    pool: 'io',
     input: t.object({ base: t.number(), delayMs: t.number() }),
     output: t.object({ shared: t.number() }),
     progress: t.object({}),

--- a/tests/e2e/src/jobs/server.jobs.redis.ts
+++ b/tests/e2e/src/jobs/server.jobs.redis.ts
@@ -1,4 +1,4 @@
-import { JobWorkerPool, n, StoreType } from 'nmtjs'
+import { n, StoreType } from 'nmtjs'
 
 import { jobs } from './applications/main/jobs.ts'
 
@@ -26,10 +26,7 @@ export default n.server({
     },
   },
   jobs: {
-    pools: {
-      [JobWorkerPool.Io]: { threads: 1, jobs: 1 },
-      [JobWorkerPool.Compute]: { threads: 1, jobs: 1 },
-    },
+    pools: { io: { threads: 1, jobs: 1 }, compute: { threads: 1, jobs: 1 } },
     jobs: [
       jobs.quick,
       jobs.slow,

--- a/tests/e2e/src/jobs/server.jobs.valkey.ts
+++ b/tests/e2e/src/jobs/server.jobs.valkey.ts
@@ -1,4 +1,4 @@
-import { JobWorkerPool, n, StoreType } from 'nmtjs'
+import { n, StoreType } from 'nmtjs'
 
 import { jobs } from './applications/main/jobs.ts'
 
@@ -26,10 +26,7 @@ export default n.server({
     },
   },
   jobs: {
-    pools: {
-      [JobWorkerPool.Io]: { threads: 1, jobs: 1 },
-      [JobWorkerPool.Compute]: { threads: 1, jobs: 1 },
-    },
+    pools: { io: { threads: 1, jobs: 1 }, compute: { threads: 1, jobs: 1 } },
     jobs: [
       jobs.quick,
       jobs.slow,


### PR DESCRIPTION
## Summary

- Replace fixed `JobWorkerPool` categories with user-defined string job pools.
- Start job runner pools from active jobs and require every active job pool to have config.
- Keep extra configured pools harmless so shared server configs remain valid.
- Update tests, e2e fixtures, and Neemata skill docs for custom pool names.

## Validation

- `fnm exec --using v24.14.0 pnpm run check:type`
- `fnm exec --using v24.14.0 pnpm build`
- `fnm exec --using v24.14.0 pnpm vitest run packages/nmtjs/tests/server-jobs.spec.ts`
- `fnm exec --using v24.14.0 pnpm run test:unit`
