### PR TITLE
fix uWS HTTP abort handling

### DIFF
--- a/packages/http-transport/src/runtimes/bun.ts
+++ b/packages/http-transport/src/runtimes/bun.ts
@@ -12,7 +12,7 @@ import { createHTTPTransportWorker } from '../server.ts'
 import {
   InternalServerErrorHttpResponse,
   NotFoundHttpResponse,
-  StatusResponse,
+  OkResponse,
 } from '../utils.ts'
 
 function adapterFactory(params: HttpAdapterParams<'bun'>): HttpAdapterServer {
@@ -33,10 +33,7 @@ function adapterFactory(params: HttpAdapterParams<'bun'>): HttpAdapterServer {
           }
         : undefined,
       // @ts-expect-error
-      routes: {
-        ...params.runtime?.routes,
-        '/healthy': { GET: StatusResponse },
-      },
+      routes: { ...params.runtime?.routes, '/healthy': { GET: OkResponse } },
       async fetch(request, server) {
         const url = new URL(request.url)
         try {

--- a/packages/http-transport/src/runtimes/deno.ts
+++ b/packages/http-transport/src/runtimes/deno.ts
@@ -13,7 +13,7 @@ import { createHTTPTransportWorker } from '../server.ts'
 import {
   InternalServerErrorHttpResponse,
   NotFoundHttpResponse,
-  StatusResponse,
+  OkResponse,
 } from '../utils.ts'
 
 interface DenoNetAddr {
@@ -64,7 +64,7 @@ function adapterFactory(params: HttpAdapterParams<'deno'>): HttpAdapterServer {
         handler: async (request: Request, info: any) => {
           const url = new URL(request.url)
           if (url.pathname === '/healthy') {
-            return StatusResponse()
+            return OkResponse()
           }
           try {
             if (request.headers.get('upgrade') === 'websocket') {

--- a/packages/http-transport/src/runtimes/node.ts
+++ b/packages/http-transport/src/runtimes/node.ts
@@ -15,10 +15,13 @@ import { createHTTPTransportWorker } from '../server.ts'
 import {
   InternalServerErrorHttpResponse,
   NotFoundHttpResponse,
-  StatusResponse,
+  OkResponse,
 } from '../utils.ts'
 
 import { App, SSLApp, us_socket_local_port } from 'uWebSockets.js'
+
+const statusResponse = OkResponse()
+const statusResponseBuffer = await statusResponse.arrayBuffer()
 
 function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
   const server = params.tls
@@ -30,20 +33,25 @@ function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
     : App()
 
   server
-    .get('/healthy', async (res) => {
-      res.onAborted(() => {})
-      const response = StatusResponse()
-      res.cork(async () => {
+    .get('/healthy', (res) => {
+      res.cork(() => {
         res
-          .writeStatus(`${response.status} ${response.statusText}`)
-          .end(await response.arrayBuffer())
+          .writeStatus(`${statusResponse.status} ${statusResponse.statusText}`)
+          .end(statusResponseBuffer)
       })
     })
     .any('/*', async (res, req) => {
-      const controller = new AbortController()
+      const requestController = new AbortController()
+      let aborted = false
+      let bodyController: ReadableStreamDefaultController<Buffer> | undefined
+
       res.onAborted(() => {
-        res.aborted = true
-        controller.abort()
+        aborted = true
+        requestController.abort()
+
+        try {
+          bodyController?.error(requestController.signal.reason)
+        } catch {}
       })
 
       let response = NotFoundHttpResponse()
@@ -58,9 +66,11 @@ function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
       const url = new URL(req.getUrl(), `${proto}://${host}`)
       url.search = req.getQuery() ? `?${req.getQuery()}` : ''
       try {
-        const body = new ReadableStream({
+        const body = new ReadableStream<Buffer>({
           start(controller) {
+            bodyController = controller
             res.onData((chunk, isLast) => {
+              if (aborted) return
               if (chunk) {
                 const copy = Buffer.allocUnsafe(chunk.byteLength)
                 copy.set(new Uint8Array(chunk))
@@ -68,13 +78,12 @@ function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
               }
               if (isLast) controller.close()
             })
-            res.onAborted(() => controller.error())
           },
         })
         response = await params.fetchHandler(
           { url, method, headers },
           body,
-          controller.signal,
+          requestController.signal,
         )
       } catch (err) {
         // TODO: proper logging
@@ -82,10 +91,10 @@ function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
         // params.logger.error({ err }, 'Error in fetch handler')
         response = InternalServerErrorHttpResponse()
       }
-      if (res.aborted) return undefined
+      if (aborted) return undefined
       else {
         res.cork(() => {
-          if (res.aborted) return undefined
+          if (aborted) return undefined
           res.writeStatus(
             `${response.status.toString()} ${response.statusText}`,
           )
@@ -95,17 +104,18 @@ function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
           try {
             const reader = response.body.getReader()
             let chunk = await reader.read()
-            do {
-              if (res.aborted) break
+            while (!chunk.done) {
+              if (aborted) break
               if (chunk.value) res.cork(() => res.write(chunk.value!))
               chunk = await reader.read()
-            } while (!chunk.done)
-            if (!res.aborted) res.cork(() => res.end())
+            }
+            if (aborted) await reader.cancel().catch(() => {})
+            else res.cork(() => res.end())
           } catch {
-            if (!res.aborted) res.cork(() => res.close())
+            if (!aborted) res.cork(() => res.close())
           }
         } else {
-          if (!res.aborted) res.cork(() => res.end())
+          if (!aborted) res.cork(() => res.end())
         }
       }
     })

--- a/packages/http-transport/src/utils.ts
+++ b/packages/http-transport/src/utils.ts
@@ -25,4 +25,4 @@ export const InternalServerErrorHttpResponse = () =>
     headers: { 'Content-Type': 'text/plain' },
   })
 
-export const StatusResponse = () => new Response('OK', { status: 200 })
+export const OkResponse = () => new Response('OK', { status: 200 })

--- a/tests/e2e/src/basic/applications/main/procedures/slow-abort.ts
+++ b/tests/e2e/src/basic/applications/main/procedures/slow-abort.ts
@@ -1,0 +1,12 @@
+import { setTimeout } from 'node:timers/promises'
+
+import { n, t } from 'nmtjs'
+
+export const slowAbortProcedure = n.procedure({
+  input: t.object({}),
+  output: t.object({ ok: t.boolean() }),
+  handler: async () => {
+    await setTimeout(300)
+    return { ok: true }
+  },
+})

--- a/tests/e2e/src/basic/applications/main/router.ts
+++ b/tests/e2e/src/basic/applications/main/router.ts
@@ -2,6 +2,7 @@ import { n } from 'nmtjs'
 
 import { downloadBlobProcedure } from './procedures/download-blob.ts'
 import { pingProcedure } from './procedures/ping.ts'
+import { slowAbortProcedure } from './procedures/slow-abort.ts'
 import { streamBlobProcedure } from './procedures/stream-blob.ts'
 import { streamCountProcedure } from './procedures/stream-count.ts'
 import { uploadBlobProcedure } from './procedures/upload-blob.ts'
@@ -10,6 +11,7 @@ export const router = n.rootRouter([
   n.router({
     routes: {
       ping: pingProcedure,
+      slowAbort: slowAbortProcedure,
       streamCount: streamCountProcedure,
       streamBlob: streamBlobProcedure,
       uploadBlob: uploadBlobProcedure,

--- a/tests/e2e/tests/http.spec.ts
+++ b/tests/e2e/tests/http.spec.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from 'node:child_process'
 import { resolve } from 'node:path'
+import { setTimeout } from 'node:timers/promises'
 
 import { StaticClient } from '@nmtjs/client/static'
 import { c } from '@nmtjs/contract'
@@ -248,5 +249,61 @@ describe('Playground E2E - HTTP Streaming', { timeout: 30000 }, () => {
     }
 
     expect(result).toEqual([0, 1, 2, 3, 4])
+  })
+})
+
+describe('Playground E2E - HTTP request aborts', { timeout: 30000 }, () => {
+  let serverProcess: ChildProcess | null = null
+  let stderr = ''
+
+  beforeAll(async () => {
+    serverProcess = await startServer('preview', {
+      configPath: BASIC_CONFIG_PATH,
+    })
+    serverProcess.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString()
+    })
+  }, 20000)
+
+  afterAll(async () => {
+    if (serverProcess) {
+      await stopServerProcess(serverProcess)
+    }
+  })
+
+  it('does not access the uWS response after the client aborts', async () => {
+    const controller = new AbortController()
+    const format = new JsonFormat()
+    const payload = format.encodeRPC(
+      {},
+      {
+        addStream: () => {
+          throw new Error('Unexpected stream payload')
+        },
+      },
+    )
+
+    const request = fetch(`${SERVER_URL}/slowAbort`, {
+      method: 'POST',
+      headers: {
+        Accept: format.contentType,
+        'Content-Type': format.contentType,
+      },
+      body: new Uint8Array(
+        payload.buffer,
+        payload.byteOffset,
+        payload.byteLength,
+      ),
+      signal: controller.signal,
+    }).catch((error) => error)
+
+    await setTimeout(50)
+    controller.abort()
+    await request
+    await setTimeout(600)
+
+    expect(serverProcess?.exitCode).toBeNull()
+    expect(stderr).not.toContain('uWS.HttpResponse must not be accessed')
+    expect(stderr).not.toContain('Worker thread runtime error')
   })
 })


### PR DESCRIPTION
## Summary
- fixed node HTTP transport abort handling for uWS responses
- cleaned up health response handling across HTTP runtimes
- added e2e coverage for aborted HTTP RPC requests

## Validation
- lint
- e2e HTTP tests
- http-transport typecheck
- http-transport build typecheck
