### PR TITLE
Use published @nmtjs/prom-client

### DIFF
--- a/packages/nmtjs/package.json
+++ b/packages/nmtjs/package.json
@@ -83,7 +83,7 @@
     "ioredis": "^5.10.1",
     "iovalkey": "^0.3.3",
     "oxc-resolver": "11.19.1",
-    "prom-client": "git@github.com:siimon/prom-client.git#d4d2dcb366384833951e0116caca707b5f62aa5e",
+    "@nmtjs/prom-client": "1.0.1",
     "vite": "catalog:"
   },
   "devDependencies": {

--- a/packages/nmtjs/src/runtime/metrics/metric.ts
+++ b/packages/nmtjs/src/runtime/metrics/metric.ts
@@ -1,6 +1,6 @@
 import type { ClassConstructorArgs } from '@nmtjs/common'
-import type { Metric, MetricConfiguration } from 'prom-client'
-import { Counter, Gauge, Histogram, Summary } from 'prom-client'
+import type { Metric, MetricConfiguration } from '@nmtjs/prom-client'
+import { Counter, Gauge, Histogram, Summary } from '@nmtjs/prom-client'
 
 import { registry } from './registry.ts'
 

--- a/packages/nmtjs/src/runtime/metrics/registry.ts
+++ b/packages/nmtjs/src/runtime/metrics/registry.ts
@@ -1,4 +1,8 @@
-import { collectDefaultMetrics, register, WorkerRegistry } from 'prom-client'
+import {
+  collectDefaultMetrics,
+  register,
+  WorkerRegistry,
+} from '@nmtjs/prom-client'
 
 export const workerRegistry = new WorkerRegistry()
 

--- a/packages/nmtjs/src/runtime/metrics/server.ts
+++ b/packages/nmtjs/src/runtime/metrics/server.ts
@@ -1,7 +1,7 @@
 import { createServer } from 'node:http'
 
 import type { Logger } from '@nmtjs/core'
-import { Pushgateway } from 'prom-client'
+import { Pushgateway } from '@nmtjs/prom-client'
 
 import type { ServerConfig } from '../server/config.ts'
 

--- a/packages/nmtjs/src/vite/server.ts
+++ b/packages/nmtjs/src/vite/server.ts
@@ -7,7 +7,7 @@ import type { ViteConfigOptions } from './config.ts'
 // When externalized, Vite's ModuleRunner uses native Node import() which has
 // a separate module cache from Vite's cache, causing the same module to be
 // loaded twice with different object references.
-const noExternalPackages = ['nmtjs', /^@nmtjs\//]
+const noExternalPackages = ['nmtjs', /^@nmtjs\/(?!prom-client$)/]
 
 export function createServer(
   options: ViteConfigOptions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       '@nmtjs/msgpack-format':
         specifier: workspace:*
         version: link:../msgpack-format
+      '@nmtjs/prom-client':
+        specifier: 1.0.1
+        version: 1.0.1
       '@nmtjs/protocol':
         specifier: workspace:*
         version: link:../protocol
@@ -269,9 +272,6 @@ importers:
       oxc-resolver:
         specifier: 11.19.1
         version: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      prom-client:
-        specifier: git@github.com:siimon/prom-client.git#d4d2dcb366384833951e0116caca707b5f62aa5e
-        version: https://codeload.github.com/siimon/prom-client/tar.gz/d4d2dcb366384833951e0116caca707b5f62aa5e
       vite:
         specifier: 'catalog:'
         version: 8.0.14(@types/node@24.10.1)
@@ -602,6 +602,10 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nmtjs/prom-client@1.0.1':
+    resolution: {integrity: sha512-Ai7azff5W0NOwes9Mq57YYDS1MUbGp7mKWYN8wNj8vhxmT2yDphcVn6sKQrTmE4WuNH/XTCdZL8jh8lWtD8KqA==}
+    engines: {node: ^22 || ^24 || >=26}
 
   '@nmtjs/proxy-darwin-arm64@1.0.0-beta.6':
     resolution: {integrity: sha512-T5FASbDMkRSXmHRKETNK6nmoeytahyUJ49yA0MeDCGodC9vc4BU37jOW4uG5zDsdmgf3FO3wiAyiOevbQESlDw==}
@@ -998,9 +1002,6 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
-  bintrees@1.0.2:
-    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
-
   bullmq@5.77.0:
     resolution: {integrity: sha512-J8CBvBgov4hqj/5CipTLtgfINvNRDeTl9p2Et/Dah/KBY2ERcnMT1m3ZxW4R1QC68ZX6yQk5nONtslpbbTs2gw==}
     engines: {node: '>=12.22.0'}
@@ -1044,8 +1045,8 @@ packages:
       srvx:
         optional: true
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
@@ -1344,11 +1345,6 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
-  prom-client@https://codeload.github.com/siimon/prom-client/tar.gz/d4d2dcb366384833951e0116caca707b5f62aa5e:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/siimon/prom-client/tar.gz/d4d2dcb366384833951e0116caca707b5f62aa5e}
-    version: 15.1.3
-    engines: {node: ^20 || ^22 || >=24}
-
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
 
@@ -1423,9 +1419,6 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  tdigest@0.1.2:
-    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   temporal-polyfill@0.3.2:
     resolution: {integrity: sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==}
@@ -1687,6 +1680,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@nmtjs/prom-client@1.0.1':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@nmtjs/proxy-darwin-arm64@1.0.0-beta.6':
     optional: true
 
@@ -1874,7 +1871,7 @@ snapshots:
 
   '@types/react@19.1.9':
     dependencies:
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
     optional: true
@@ -2015,8 +2012,6 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  bintrees@1.0.2: {}
-
   bullmq@5.77.0:
     dependencies:
       cron-parser: 4.9.0
@@ -2049,7 +2044,7 @@ snapshots:
 
   crossws@0.4.5: {}
 
-  csstype@3.1.3: {}
+  csstype@3.2.3: {}
 
   dateformat@4.6.3: {}
 
@@ -2342,11 +2337,6 @@ snapshots:
 
   process-warning@5.0.0: {}
 
-  prom-client@https://codeload.github.com/siimon/prom-client/tar.gz/d4d2dcb366384833951e0116caca707b5f62aa5e:
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      tdigest: 0.1.2
-
   pump@3.0.2:
     dependencies:
       end-of-stream: 1.4.4
@@ -2418,10 +2408,6 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-
-  tdigest@0.1.2:
-    dependencies:
-      bintrees: 1.0.2
 
   temporal-polyfill@0.3.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,6 @@ catalog:
   vite: 8.0.14
   zod: ^4.0.0
 
+minimumReleaseAgeExclude:
+  - "@nmtjs/prom-client"
+  - "@nmtjs/proxy"


### PR DESCRIPTION
## Summary
- replace the git `prom-client` dependency with published `@nmtjs/prom-client`
- update metrics runtime imports to use `@nmtjs/prom-client`
- exclude `@nmtjs/prom-client` from pnpm minimum release age gating

## Validation
- `pnpm run check`