### PR TITLE
Restore host-local gateway and identity options

### DIFF
--- a/packages/application/src/host.ts
+++ b/packages/application/src/host.ts
@@ -35,11 +35,23 @@ export interface ApplicationHostDefinition<
   [kApplicationHostDefinition]: any
   application: App
   transports: Transports
+  gateway?: Pick<
+    GatewayOptions<ApplicationResolvedProcedure>,
+    'streamTimeouts' | 'heartbeat'
+  >
+  identity?: ConnectionIdentity
 }
 
 export type ApplicationHostDefinitionOptions<
   Transports extends Record<string, ApplicationTransport>,
-> = { transports: Transports }
+> = {
+  transports: Transports
+  gateway?: Pick<
+    GatewayOptions<ApplicationResolvedProcedure>,
+    'streamTimeouts' | 'heartbeat'
+  >
+  identity?: ConnectionIdentity
+}
 
 export interface ApplicationHostOptions<
   Transports extends Record<string, ApplicationTransport> = Record<

--- a/packages/nmtjs/src/runtime/server/config.ts
+++ b/packages/nmtjs/src/runtime/server/config.ts
@@ -4,7 +4,6 @@ import type {
   TransportOptionsOf,
 } from '@nmtjs/application'
 import type { LoggingOptions } from '@nmtjs/core'
-import type { ConnectionIdentity, GatewayOptions } from '@nmtjs/gateway'
 import type { ApplicationOptions } from '@nmtjs/proxy'
 import type { Applications } from 'nmtjs/runtime/types'
 
@@ -36,16 +35,12 @@ export type ServerApplicationConfig<T = ApplicationHostDefinition> =
         threads: {
           [K in keyof Transports]: TransportOptionsOf<Transports[K]>
         }[]
-        gateway?: Pick<GatewayOptions, 'streamTimeouts' | 'heartbeat'>
-        identity?: ConnectionIdentity
       }
     : T extends ApplicationHost<infer Transports>
       ? {
           threads: {
             [K in keyof Transports]: TransportOptionsOf<Transports[K]>
           }[]
-          gateway?: Pick<GatewayOptions, 'streamTimeouts' | 'heartbeat'>
-          identity?: ConnectionIdentity
         }
       : any
 

--- a/packages/nmtjs/src/runtime/workers/application.ts
+++ b/packages/nmtjs/src/runtime/workers/application.ts
@@ -106,8 +106,8 @@ export class ApplicationWorkerRuntime extends BaseWorkerRuntime {
         this.hostDefinition.transports,
         this.runtimeOptions.transports,
       ),
-      gateway: config.gateway,
-      identity: config.identity,
+      gateway: this.hostDefinition.gateway,
+      identity: this.hostDefinition.identity,
     }
   }
 }

--- a/packages/nmtjs/tests/application-config.spec.ts
+++ b/packages/nmtjs/tests/application-config.spec.ts
@@ -1,4 +1,5 @@
 import type { TransportWorker, TransportWorkerParams } from '@nmtjs/gateway'
+import { createValueInjectable } from '@nmtjs/core'
 import { createTransport, StreamTimeout } from '@nmtjs/gateway'
 import { t } from '@nmtjs/type'
 import { describe, expect, it } from 'vitest'
@@ -23,11 +24,13 @@ type TestTransportOptions = { marker: string; listen: { port: number } }
 function createRuntime(
   options: {
     gateway?: TestGatewayConfig
+    identity?: ReturnType<typeof createValueInjectable<string>>
     transportOptions?: TestTransportOptions
   } = {},
 ) {
   const {
     gateway = {},
+    identity,
     transportOptions = { marker: 'default', listen: { port: 0 } },
   } = options
 
@@ -70,13 +73,13 @@ function createRuntime(
   const appConfig = defineApplication({ router })
   const hostDefinition = defineApplicationHost(appConfig, {
     transports: { test: transport },
+    gateway,
+    identity,
   })
 
   const serverConfig = defineServer({
     logger: { pinoOptions: { enabled: false } },
-    applications: {
-      'test-app': { threads: [{ test: transportOptions }], gateway },
-    },
+    applications: { 'test-app': { threads: [{ test: transportOptions }] } },
   })
 
   return {
@@ -95,8 +98,10 @@ function createRuntime(
 }
 
 describe('application config', () => {
-  it('propagates gateway heartbeat and stream timeout overrides to the runtime gateway', async () => {
+  it('propagates host gateway and identity overrides to the runtime gateway', async () => {
+    const identity = createValueInjectable('test-identity')
     const { runtime } = createRuntime({
+      identity,
       gateway: {
         heartbeat: { interval: 4321, timeout: 8765 },
         streamTimeouts: {
@@ -121,6 +126,7 @@ describe('application config', () => {
         [StreamTimeout.Consume]: 15000,
         [StreamTimeout.Finish]: 2222,
       })
+      expect(runtime.gateway.options.identity).toBe(identity)
     } finally {
       if (started) await runtime.stop()
     }

--- a/packages/nmtjs/tests/server-application-host-types.spec.ts
+++ b/packages/nmtjs/tests/server-application-host-types.spec.ts
@@ -1,4 +1,4 @@
-import { createTransport } from '@nmtjs/gateway'
+import { createTransport, StreamTimeout } from '@nmtjs/gateway'
 import { describe, expect, it } from 'vitest'
 
 import type { ServerApplicationConfig } from '../src/runtime/index.ts'
@@ -34,7 +34,10 @@ const second = createTransport({
   }),
 })
 
-const host = defineApplicationHost(app, { transports: { first, second } })
+const host = defineApplicationHost(app, {
+  transports: { first, second },
+  gateway: { heartbeat: false, streamTimeouts: { [StreamTimeout.Pull]: 1000 } },
+})
 
 describe('server application host types', () => {
   it('infers thread options from application host transports', () => {

--- a/skills/use-neemata/SKILL.md
+++ b/skills/use-neemata/SKILL.md
@@ -71,16 +71,17 @@ Neemata uses a layered architecture:
 
 1. **Config** (`neemata.config.ts`) — defines applications and server entry point via `defineConfig()`
 2. **Server** (`n.server()`) — orchestrates workers, proxy, store, metrics
-3. **Application Host** (`n.host(app, { transports })`) — binds one app definition to concrete serving surfaces such as HTTP or WebSocket transport factories
+3. **Application Host** (`n.host(app, { transports, gateway, identity })`) — binds one app definition to concrete serving surfaces such as HTTP or WebSocket transport factories and host-local gateway settings
 4. **Application** (`n.app()`) — pure application definition: router, guards, middleware, filters, hooks, dependencies, API options, and app-level meta
 5. **Router** (`n.rootRouter()` / `n.router()`) — groups procedures
 6. **Procedure** (`n.procedure()`) — individual RPC endpoint with input/output types and handler
 7. **Client** (`StaticClient` / `RuntimeClient`) — type-safe RPC calls via `@nmtjs/client`
 
 Application definitions must not own transport factories, gateway options, listen
-options, or connection identity. Put transport factories in the host entry with
-`n.host(app, { transports })`. Server config owns per-thread transport options
-and infers their types from the host's transport map.
+options, or connection identity. Put transport factories, gateway options, and
+connection identity in the host entry with `n.host(app, { transports, gateway,
+identity })`. Server config owns per-thread transport options and infers their
+types from the host's transport map.
 
 ### Dependency Injection Scopes
 


### PR DESCRIPTION
## Summary
- Restored `n.host(app, { transports, gateway, identity })` so gateway settings and connection identity live with the application host again.
- Removed `gateway` and `identity` from server application config so `n.server(...)` stays focused on per-thread transport options.
- Updated worker wiring, tests, and Neemata guidance to match the restored boundary.

## Testing
- Added and updated unit coverage for host-level gateway and identity propagation.
- Updated type coverage for host definitions.
- `vitest` and package typecheck passed for the touched packages.