### PR TITLE
Fix subscription adapter DI ownership

### DIFF
--- a/packages/core/src/container.ts
+++ b/packages/core/src/container.ts
@@ -8,6 +8,7 @@ import type {
   Dependencies,
   DependencyContext,
   Provision,
+  ProvisionValue,
   ResolveInjectableType,
 } from './injectables.ts'
 import type { Logger } from './logger.ts'
@@ -175,11 +176,11 @@ export class Container {
   provide<T extends Provision[]>(provisions: T): void
   provide<T extends AnyInjectable>(
     injectable: T,
-    value: ResolveInjectableType<T>,
+    value: ProvisionValue<T>,
   ): void
   provide<T extends AnyInjectable | Provision[]>(
     injectable: T,
-    ...[value]: T extends AnyInjectable ? [value: ResolveInjectableType<T>] : []
+    ...[value]: T extends AnyInjectable ? [value: ProvisionValue<T>] : []
   ) {
     const provisions = Array.isArray(injectable)
       ? injectable

--- a/packages/core/src/injectables.ts
+++ b/packages/core/src/injectables.ts
@@ -348,13 +348,16 @@ export namespace CoreInjectables {
   export const dispose = disposeFnInjectable
 }
 
+export type ProvisionValue<T extends AnyInjectable<any, any>> =
+  T extends AnyInjectable<infer R, Scope> ? R | AnyInjectable<R> : never
+
 export type Provision<
   T extends AnyInjectable<any, any> = AnyInjectable<any, any>,
-> = { token: T; value: T extends AnyInjectable<infer R, Scope> ? R : never }
+> = { token: T; value: ProvisionValue<T> }
 
 export const provision = <
   T extends AnyInjectable<any, any>,
-  V extends T extends AnyInjectable<infer R, Scope> ? R : never,
+  V extends ProvisionValue<T>,
 >(
   token: T,
   value: V,

--- a/packages/nmtjs/src/runtime/injectables.ts
+++ b/packages/nmtjs/src/runtime/injectables.ts
@@ -1,4 +1,9 @@
-import { createLazyInjectable, Scope } from '@nmtjs/core'
+import {
+  CoreInjectables,
+  createFactoryInjectable,
+  createLazyInjectable,
+  Scope,
+} from '@nmtjs/core'
 
 import type { WorkerType } from './enums.ts'
 import type { JobManagerInstance } from './jobs/manager.ts'
@@ -9,6 +14,7 @@ import type {
   SubscribeFn,
   SubscriptionAdapterType,
 } from './subscription/manager.ts'
+import { SubscriptionManager } from './subscription/manager.ts'
 
 export const subscriptionAdapter =
   createLazyInjectable<SubscriptionAdapterType>(
@@ -16,10 +22,32 @@ export const subscriptionAdapter =
     'SubscriptionAdapter',
   )
 
-export const publish = createLazyInjectable<PublishFn>(Scope.Global, 'Publish')
+export const subscriptionManager = createFactoryInjectable(
+  {
+    dependencies: {
+      adapter: subscriptionAdapter,
+      logger: CoreInjectables.logger,
+    },
+    factory: ({ adapter, logger }) =>
+      new SubscriptionManager({ logger, adapter }),
+    dispose: (manager) => manager.dispose(),
+  },
+  'SubscriptionManager',
+)
 
-export const subscribe = createLazyInjectable<SubscribeFn>(
-  Scope.Global,
+export const publish = createFactoryInjectable(
+  {
+    dependencies: { manager: subscriptionManager },
+    factory: ({ manager }): PublishFn => manager.publish.bind(manager),
+  },
+  'Publish',
+)
+
+export const subscribe = createFactoryInjectable(
+  {
+    dependencies: { manager: subscriptionManager },
+    factory: ({ manager }): SubscribeFn => manager.subscribe.bind(manager),
+  },
   'Subscribe',
 )
 
@@ -60,6 +88,7 @@ export const currentJobInfo = createLazyInjectable<JobExecutionContext>(
 
 export const RuntimeInjectables = {
   subscriptionAdapter,
+  subscriptionManager,
   publish,
   subscribe,
   jobManager,

--- a/packages/nmtjs/src/runtime/subscription/manager.ts
+++ b/packages/nmtjs/src/runtime/subscription/manager.ts
@@ -7,11 +7,9 @@ import type {
   TAnyEventContract,
   TAnySubscriptionContract,
 } from '@nmtjs/contract'
-import type { Container, Logger } from '@nmtjs/core'
+import type { Logger } from '@nmtjs/core'
 import type { t } from '@nmtjs/type'
 import { isAbortError } from '@nmtjs/common'
-
-import { subscriptionAdapter } from '../injectables.ts'
 
 export type SubscriptionAdapterEvent = { channel: string; payload: any }
 
@@ -74,7 +72,7 @@ export type PublishFn = <
 
 export type SubscriptionManagerOptions = {
   logger: Logger
-  container: Container
+  adapter: SubscriptionAdapterType
 }
 
 export class SubscriptionManager {
@@ -85,13 +83,7 @@ export class SubscriptionManager {
     this.logger = options.logger.child({ component: SubscriptionManager.name })
   }
 
-  protected get adapter() {
-    return this.options.container.resolve(subscriptionAdapter)
-  }
-
   subscribe: SubscribeFn = async (subscription, events, options, signal) => {
-    const adapter = await this.adapter
-
     const eventKeys =
       Object.keys(events).length === 0
         ? Object.keys(subscription.events)
@@ -118,7 +110,7 @@ export class SubscriptionManager {
           'Reusing pubsub channel stream',
         )
       } else {
-        const iterable = adapter.subscribe(channel, signal)
+        const iterable = this.options.adapter.subscribe(channel, signal)
         const stream = this.createEventStream(iterable)
         stream.on('close', () => {
           this.subscriptions.delete(channel)
@@ -173,15 +165,13 @@ export class SubscriptionManager {
   }
 
   publish: PublishFn = async (event, options, data) => {
-    const adapter = await this.adapter
-
     const channel = getChannelName(event, options)
 
     this.logger.trace({ channel, event: event.name }, 'Publishing pubsub event')
 
     try {
       const payload = event.payload.encode(data)
-      const published = await adapter.publish(channel, payload)
+      const published = await this.options.adapter.publish(channel, payload)
 
       if (published) {
         this.logger.trace(
@@ -203,6 +193,13 @@ export class SubscriptionManager {
       )
       throw error
     }
+  }
+
+  async dispose(): Promise<void> {
+    for (const { stream } of this.subscriptions.values()) {
+      stream.destroy()
+    }
+    this.subscriptions.clear()
   }
 
   private createEventStream(

--- a/packages/nmtjs/src/runtime/subscription/redis.ts
+++ b/packages/nmtjs/src/runtime/subscription/redis.ts
@@ -3,7 +3,11 @@ import EventEmitter, { on } from 'node:events'
 import type { RuntimePlugin } from '@nmtjs/application'
 import type { Logger } from '@nmtjs/core'
 import { isAbortError } from '@nmtjs/common'
-import { createFactoryInjectable } from '@nmtjs/core'
+import {
+  CoreInjectables,
+  createFactoryInjectable,
+  provision,
+} from '@nmtjs/core'
 
 import type { Store } from '../types.ts'
 import type {
@@ -130,28 +134,26 @@ export class RedisSubscriptionAdapter implements SubscriptionAdapterType {
 }
 
 export const RedisSubscriptionAdapterPlugin = (): RuntimePlugin => {
-  return {
-    name: 'redis-subscription-adapter',
-    hooks: {
-      'lifecycle:beforeInitialize': async (ctx) => {
-        const adapter = await ctx.container.resolve(
-          createFactoryInjectable({
-            dependencies: { config: storeConfig },
-            factory: async ({ config }) => {
-              const connection = await createStoreClient(config)
-              const adapter = new RedisSubscriptionAdapter(
-                connection,
-                ctx.logger,
-              )
-              await adapter.initialize()
-              return { adapter, connection }
-            },
-            pick: ({ adapter }) => adapter,
-            dispose: ({ connection }) => connection.quit(),
-          }),
-        )
-        ctx.container.provide(subscriptionAdapter, adapter)
+  const adapterFactory = createFactoryInjectable(
+    {
+      dependencies: { config: storeConfig, logger: CoreInjectables.logger },
+      factory: async ({ config, logger }) => {
+        const connection = await createStoreClient(config)
+        const adapter = new RedisSubscriptionAdapter(connection, logger)
+        await adapter.initialize()
+        return { adapter, connection }
+      },
+      pick: ({ adapter }) => adapter,
+      dispose: async ({ adapter, connection }) => {
+        await adapter.dispose()
+        await connection.quit()
       },
     },
+    'RedisSubscriptionAdapter',
+  )
+
+  return {
+    name: 'redis-subscription-adapter',
+    injections: [provision(subscriptionAdapter, adapterFactory)],
   }
 }

--- a/packages/nmtjs/src/runtime/workers/base.ts
+++ b/packages/nmtjs/src/runtime/workers/base.ts
@@ -7,10 +7,8 @@ import type { ServerConfig } from '../server/config.ts'
 import * as injectables from '../injectables.ts'
 import { JobManager } from '../jobs/manager.ts'
 import { BaseRuntime } from '../runtime.ts'
-import { SubscriptionManager } from '../subscription/manager.ts'
 
 export abstract class BaseWorkerRuntime extends BaseRuntime {
-  subscriptionManager: SubscriptionManager
   jobManager?: JobManager
 
   constructor(
@@ -19,11 +17,6 @@ export abstract class BaseWorkerRuntime extends BaseRuntime {
     readonly workerType: WorkerType,
   ) {
     super(options)
-
-    this.subscriptionManager = new SubscriptionManager({
-      logger: this.logger,
-      container: this.container,
-    })
 
     if (this.config.store) {
       this.jobManager = new JobManager(
@@ -37,18 +30,19 @@ export abstract class BaseWorkerRuntime extends BaseRuntime {
     const injections: Provision[] = [
       provision(CoreInjectables.logger, this.logger),
       provision(injectables.workerType, this.workerType),
-      provision(
-        injectables.publish,
-        this.subscriptionManager.publish.bind(this.subscriptionManager),
-      ),
-      provision(
-        injectables.subscribe,
-        this.subscriptionManager.subscribe.bind(this.subscriptionManager),
-      ),
     ]
 
     if (this.config.store) {
       injections.push(provision(injectables.storeConfig, this.config.store))
+    }
+
+    if (this.config.subscription) {
+      injections.push(
+        provision(
+          injectables.subscriptionAdapter,
+          this.config.subscription.adapter,
+        ),
+      )
     }
 
     if (this.jobManager) {

--- a/packages/nmtjs/tests/application-config.spec.ts
+++ b/packages/nmtjs/tests/application-config.spec.ts
@@ -1,5 +1,11 @@
 import type { TransportWorker, TransportWorkerParams } from '@nmtjs/gateway'
-import { createValueInjectable } from '@nmtjs/core'
+import type {
+  SubscriptionAdapterEvent,
+  SubscriptionAdapterType,
+} from '../src/runtime/index.ts'
+import type { RuntimePlugin } from '@nmtjs/application'
+import { EventContract, SubscriptionContract } from '@nmtjs/contract'
+import { createValueInjectable, provision } from '@nmtjs/core'
 import { createTransport, StreamTimeout } from '@nmtjs/gateway'
 import { t } from '@nmtjs/type'
 import { describe, expect, it } from 'vitest'
@@ -12,6 +18,8 @@ import {
   defineApplication,
   defineApplicationHost,
   defineServer,
+  publish,
+  subscriptionAdapter,
 } from '../src/runtime/index.ts'
 
 type TestGatewayConfig = {
@@ -21,16 +29,37 @@ type TestGatewayConfig = {
 
 type TestTransportOptions = { marker: string; listen: { port: number } }
 
+class TestSubscriptionAdapter implements SubscriptionAdapterType {
+  published: Array<{ channel: string; payload: any }> = []
+
+  async initialize() {}
+
+  async dispose() {}
+
+  async publish(channel: string, payload: any): Promise<boolean> {
+    this.published.push({ channel, payload })
+    return true
+  }
+
+  async *subscribe(): AsyncGenerator<SubscriptionAdapterEvent> {}
+}
+
 function createRuntime(
   options: {
     gateway?: TestGatewayConfig
     identity?: ReturnType<typeof createValueInjectable<string>>
+    plugins?: RuntimePlugin[]
+    publishDependency?: boolean
+    serverSubscriptionAdapter?: SubscriptionAdapterType
     transportOptions?: TestTransportOptions
   } = {},
 ) {
   const {
     gateway = {},
     identity,
+    plugins = [],
+    publishDependency = false,
+    serverSubscriptionAdapter,
     transportOptions = { marker: 'default', listen: { port: 0 } },
   } = options
 
@@ -64,13 +93,14 @@ function createRuntime(
         ping: createProcedure({
           input: t.object({ ok: t.boolean() }),
           output: t.object({ ok: t.boolean() }),
+          dependencies: publishDependency ? { publish } : {},
           handler: async (_ctx, input) => input,
         }),
       },
     }),
   ] as const)
 
-  const appConfig = defineApplication({ router })
+  const appConfig = defineApplication({ router, plugins })
   const hostDefinition = defineApplicationHost(appConfig, {
     transports: { test: transport },
     gateway,
@@ -80,6 +110,9 @@ function createRuntime(
   const serverConfig = defineServer({
     logger: { pinoOptions: { enabled: false } },
     applications: { 'test-app': { threads: [{ test: transportOptions }] } },
+    subscription: serverSubscriptionAdapter
+      ? { adapter: serverSubscriptionAdapter }
+      : undefined,
   })
 
   return {
@@ -173,5 +206,89 @@ describe('application config', () => {
     }
 
     expect(transportState.stopParams).toHaveLength(1)
+  })
+
+  it('uses subscription adapters provided by application plugin injections', async () => {
+    const adapter = new TestSubscriptionAdapter()
+    const plugin: RuntimePlugin = {
+      name: 'test-subscription-adapter',
+      injections: [provision(subscriptionAdapter, adapter)],
+    }
+    const subscription = SubscriptionContract.withOptions<{ roomId: string }>()(
+      {
+        name: 'chat',
+        events: {
+          message: EventContract({ payload: t.object({ text: t.string() }) }),
+        },
+      },
+    )
+    const { runtime } = createRuntime({
+      plugins: [plugin],
+      publishDependency: true,
+    })
+
+    let started = false
+
+    try {
+      await runtime.start()
+      started = true
+
+      const appPublish = await runtime.application.container.resolve(publish)
+      await expect(
+        appPublish(
+          subscription.events.message,
+          { roomId: 'room-1' },
+          { text: 'hello' },
+        ),
+      ).resolves.toBe(true)
+    } finally {
+      if (started) await runtime.stop()
+    }
+
+    expect(adapter.published).toHaveLength(1)
+  })
+
+  it('uses server subscription adapters as parent fallback', async () => {
+    const adapter = new TestSubscriptionAdapter()
+    const subscription = SubscriptionContract.withOptions<{ roomId: string }>()(
+      {
+        name: 'chat',
+        events: {
+          message: EventContract({ payload: t.object({ text: t.string() }) }),
+        },
+      },
+    )
+    const { runtime } = createRuntime({
+      publishDependency: true,
+      serverSubscriptionAdapter: adapter,
+    })
+
+    let started = false
+
+    try {
+      await runtime.start()
+      started = true
+
+      const appPublish = await runtime.application.container.resolve(publish)
+      await expect(
+        appPublish(
+          subscription.events.message,
+          { roomId: 'room-1' },
+          { text: 'hello' },
+        ),
+      ).resolves.toBe(true)
+    } finally {
+      if (started) await runtime.stop()
+    }
+
+    expect(adapter.published).toHaveLength(1)
+  })
+
+  it('fails application initialization when publish is injected without an adapter', async () => {
+    const { runtime } = createRuntime({ publishDependency: true })
+
+    await expect(runtime.start()).rejects.toThrow(
+      'No instance provided for SubscriptionAdapter injectable',
+    )
   })
 })

--- a/packages/nmtjs/tests/subscription.spec.ts
+++ b/packages/nmtjs/tests/subscription.spec.ts
@@ -2,7 +2,7 @@ import EventEmitter from 'node:events'
 import { Writable } from 'node:stream'
 
 import { EventContract, SubscriptionContract } from '@nmtjs/contract'
-import { Container, createLogger } from '@nmtjs/core'
+import { createLogger } from '@nmtjs/core'
 import { t } from '@nmtjs/type'
 import { describe, expect, it } from 'vitest'
 
@@ -11,7 +11,6 @@ import type {
   SubscriptionAdapterType,
 } from '../src/runtime/subscription/manager.ts'
 import type { Store } from '../src/runtime/types.ts'
-import { subscriptionAdapter } from '../src/runtime/injectables.ts'
 import { SubscriptionManager } from '../src/runtime/subscription/manager.ts'
 import { RedisSubscriptionAdapter } from '../src/runtime/subscription/redis.ts'
 
@@ -107,11 +106,8 @@ function createCapturingLogger(label = 'test') {
 
 function createSubscriptionManagerHarness(adapter: SubscriptionAdapterType) {
   const { logger, getLogs } = createCapturingLogger('pubsub-test')
-  const container = new Container({ logger })
 
-  container.provide(subscriptionAdapter, adapter)
-
-  return { manager: new SubscriptionManager({ logger, container }), getLogs }
+  return { manager: new SubscriptionManager({ logger, adapter }), getLogs }
 }
 
 const chatSubscription = SubscriptionContract.withOptions<{ roomId: string }>()(


### PR DESCRIPTION
## Summary

Reworks subscription DI so `publish` and `subscribe` are factory injectables backed by a container-owned `SubscriptionManager` instead of worker-bound functions.

## Root Cause

Application plugins provide `subscriptionAdapter` into the application container, but the previous worker-owned `SubscriptionManager` resolved the adapter from the worker parent container. Parent containers cannot see child provisions, so app-level subscription adapter plugins initialized successfully but `publish()` failed when resolving the adapter.

## Changes

- Adds `subscriptionManager` as a factory injectable depending on `subscriptionAdapter` and logger.
- Makes `publish` and `subscribe` factory injectables that wrap the resolved manager.
- Removes worker-owned `SubscriptionManager` binding from `BaseWorkerRuntime`.
- Wires `ServerConfig.subscription.adapter` as the worker-level fallback adapter.
- Changes `RedisSubscriptionAdapterPlugin` to provide its adapter through plugin `injections`, so dependency initialization can validate it strictly.
- Updates provision typing to allow injectable-backed provisions.
- Adds tests for app plugin adapter resolution, server fallback adapter resolution, and strict startup failure when `publish` is injected without an adapter.

## Validation

- `pnpm vitest run packages/core/tests/container.spec.ts packages/nmtjs/tests/application-config.spec.ts packages/nmtjs/tests/subscription.spec.ts`
- `pnpm run check:type`
- `pnpm run check:lint`
- `pnpm biome format --diagnostic-level=error packages/core/src/container.ts packages/core/src/injectables.ts packages/nmtjs/src/runtime/injectables.ts packages/nmtjs/src/runtime/subscription/manager.ts packages/nmtjs/src/runtime/subscription/redis.ts packages/nmtjs/src/runtime/workers/base.ts packages/nmtjs/tests/application-config.spec.ts packages/nmtjs/tests/subscription.spec.ts`