### PR TITLE
fix(workflows): preserve activity dependency types

### DIFF
--- a/packages/workflows/src/implement/index.ts
+++ b/packages/workflows/src/implement/index.ts
@@ -51,7 +51,7 @@ export type TaskIdempotency<Deps extends Dependencies, Input> =
 
 export type TaskImplementation<
   Task extends AnyTaskDefinition = AnyTaskDefinition,
-  Deps extends Dependencies = {},
+  Deps extends Dependencies = Dependencies,
 > = Handler<
   Deps,
   [input: TaskDecodedInput<Task>, lifecycle?: AttemptLifecycle],
@@ -293,19 +293,31 @@ type ActivityImplementationOptions<
   NodeInput,
 > = WorkflowInputMapper<WorkflowDeps, Outputs, Input, NodeInput>
 
-type LegacyActivityHandlerObject<Input, Output> = {
-  readonly dependencies: Dependencies
-  readonly handler: (ctx: any, input: Input) => MaybePromise<Output>
+type LegacyActivityHandlerObject<Input, Output, Deps extends Dependencies> = {
+  readonly dependencies: Deps
+  readonly handler: (
+    ctx: DependencyContext<Deps>,
+    input: Input,
+    lifecycle?: AttemptLifecycle,
+  ) => MaybePromise<Output>
 }
 
-type ActivityImplementationValue<Input, Output> =
-  | ActivityHandlerInput<Input, Output, any>
-  | LegacyActivityHandlerObject<Input, Output>
-  | ActivityImplementation<Input, Output, any>
+type ActivityImplementationValue<
+  Input,
+  Output,
+  Deps extends Dependencies = Dependencies,
+> =
+  | ActivityHandlerInput<Input, Output, Deps>
+  | LegacyActivityHandlerObject<Input, Output, Deps>
+  | ActivityImplementation<Input, Output, Deps>
 
-type ActivityCaseDescriptor<Input, Output> = {
+type ActivityCaseDescriptor<
+  Input,
+  Output,
+  Deps extends Dependencies = Dependencies,
+> = {
   readonly kind: 'activityCase'
-  readonly value: ActivityImplementationValue<Input, Output>
+  readonly value: ActivityImplementationValue<Input, Output, Deps>
   readonly options?: WorkflowInputMapper<any, any, any, Input>
 }
 
@@ -349,10 +361,14 @@ type CaseImplementers<
   Outputs extends object,
   Input,
 > = {
-  readonly activity: <NodeInput, Output>(
-    value: ActivityImplementationValue<NodeInput, Output>,
+  readonly activity: <
+    NodeInput,
+    Output,
+    Deps extends Dependencies = Dependencies,
+  >(
+    value: ActivityImplementationValue<NodeInput, Output, Deps>,
     options?: WorkflowInputMapper<WorkflowDeps, Outputs, Input, NodeInput>,
-  ) => ActivityCaseDescriptor<NodeInput, Output>
+  ) => ActivityCaseDescriptor<NodeInput, Output, Deps>
   readonly task: <Task extends AnyTaskDefinition>(
     task: Task,
     options?: WorkflowInputMapper<
@@ -431,10 +447,11 @@ export type WorkflowImplementationChain<
       infer Output
     >
     ? {
-        readonly [Key in Name]: (
+        readonly [Key in Name]: <Deps extends Dependencies = Dependencies>(
           value: ActivityImplementationValue<
             BoundaryOutput<Input>,
-            BoundaryInput<Output>
+            BoundaryInput<Output>,
+            Deps
           >,
           options?: ActivityImplementationOptions<
             WorkflowDeps,
@@ -834,15 +851,15 @@ function nextChain(
 
 function createCaseImplementers(): CaseImplementers<any, any, any> {
   const helpers: CaseImplementers<any, any, any> = {
-    activity: <NodeInput, Output>(
-      value: ActivityImplementationValue<NodeInput, Output>,
+    activity: <NodeInput, Output, Deps extends Dependencies = Dependencies>(
+      value: ActivityImplementationValue<NodeInput, Output, Deps>,
       options?: WorkflowInputMapper<any, any, any, NodeInput>,
     ) =>
       Object.freeze({
         kind: 'activityCase',
         value,
         options,
-      }) as ActivityCaseDescriptor<NodeInput, Output>,
+      }) as ActivityCaseDescriptor<NodeInput, Output, Deps>,
     task: <Task extends AnyTaskDefinition>(
       task: Task,
       options?: WorkflowInputMapper<any, any, any, any>,

--- a/packages/workflows/tests/implementation-chain.spec.ts
+++ b/packages/workflows/tests/implementation-chain.spec.ts
@@ -1,4 +1,4 @@
-import { createValueInjectable } from '@nmtjs/core'
+import { createValueInjectable, type DependencyContext } from '@nmtjs/core'
 import { t } from '@nmtjs/type'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 
@@ -118,6 +118,49 @@ describe('workflow implementation chain', () => {
     if (saveCaseNode?.kind !== 'activity') throw new Error('Expected activity')
     expect(saveCaseNode.input).toBeTypeOf('function')
     expect(implementation.finish).toBeTypeOf('function')
+  })
+
+  it('keeps activity implementation dependencies typed in workflow nodes', () => {
+    const service = createValueInjectable({
+      save: (text: string) => text.length,
+    })
+    const activityWorkflow = defineWorkflow({
+      name: 'activity-dependencies',
+      input: t.object({ text: t.string() }),
+      output: t.object({ size: t.number() }),
+    })
+      .activity('save', {
+        input: t.object({ text: t.string() }),
+        output: t.object({ size: t.number() }),
+      })
+      .build()
+
+    const inferred = implementWorkflow(activityWorkflow)
+      .save({
+        dependencies: { service },
+        handler: (ctx, input) => {
+          expectTypeOf(ctx.service.save).toEqualTypeOf<
+            (text: string) => number
+          >()
+          expectTypeOf(input.text).toEqualTypeOf<string>()
+
+          return { size: ctx.service.save(input.text) }
+        },
+      })
+      .finish((_ctx, { save }) => save)
+
+    const annotated = implementWorkflow(activityWorkflow)
+      .save({
+        dependencies: { service },
+        handler: (
+          ctx: DependencyContext<{ service: typeof service }>,
+          input,
+        ) => ({ size: ctx.service.save(input.text) }),
+      })
+      .finish((_ctx, { save }) => save)
+
+    expect(inferred.workflow).toBe(activityWorkflow)
+    expect(annotated.workflow).toBe(activityWorkflow)
   })
 
   it('infers branch output union when no common output is declared', () => {


### PR DESCRIPTION
## Summary

- keep workflow activity implementations generic over their handler dependencies
- preserve typed dependency context for object-form activity handlers and branch/parallel activity helpers
- add a regression covering inferred and explicitly annotated activity dependency contexts

## Root cause

Workflow activity node implementation values erased handler dependencies to `any`, so object-form handlers received `DependencyContext<any>` instead of the dependency shape supplied by `dependencies`.

Fixes #219.

## Checks

- `pnpm -C packages/workflows exec vitest run tests/implementation-chain.spec.ts --reporter=agent`
- `pnpm check:type --pretty false`
- `pnpm check:fmt`
- `pnpm oxlint . --format=agent`