### PR TITLE
Fix pubsub plugin injection timing

### DIFF
--- a/packages/pubsub/src/plugin.ts
+++ b/packages/pubsub/src/plugin.ts
@@ -1,7 +1,10 @@
 import type { RuntimePlugin } from '@nmtjs/application'
 import type { AnyInjectable } from '@nmtjs/core'
-import { LifecycleHook } from '@nmtjs/application'
-import { provision } from '@nmtjs/core'
+import {
+  CoreInjectables,
+  createFactoryInjectable,
+  provision,
+} from '@nmtjs/core'
 
 import type { PubSubAdapter } from './adapter.ts'
 import { publish, pubsubAdapter, subscribe } from './injectables.ts'
@@ -12,18 +15,32 @@ export type PubSubPluginOptions = { adapter: AnyInjectable<PubSubAdapter> }
 export function createPubSubPlugin(
   options: PubSubPluginOptions,
 ): RuntimePlugin {
+  const manager = createFactoryInjectable({
+    dependencies: {
+      adapter: options.adapter,
+      logger: CoreInjectables.logger,
+    },
+    create: ({ adapter, logger }) => new PubSubManager({ logger, adapter }),
+  })
+
   return {
     name: 'pubsub',
-    hooks: {
-      [LifecycleHook.BeforeInitialize]: async (ctx) => {
-        const adapter = await ctx.container.resolve(options.adapter)
-        const manager = new PubSubManager({ logger: ctx.logger, adapter })
-        ctx.container.provide([
-          provision(pubsubAdapter, adapter),
-          provision(publish, manager.publish.bind(manager)),
-          provision(subscribe, manager.subscribe.bind(manager)),
-        ])
-      },
-    },
+    injections: [
+      provision(pubsubAdapter, options.adapter),
+      provision(
+        publish,
+        createFactoryInjectable({
+          dependencies: { manager },
+          create: ({ manager }) => manager.publish.bind(manager),
+        }),
+      ),
+      provision(
+        subscribe,
+        createFactoryInjectable({
+          dependencies: { manager },
+          create: ({ manager }) => manager.subscribe.bind(manager),
+        }),
+      ),
+    ],
   }
 }

--- a/packages/pubsub/tests/plugin.spec.ts
+++ b/packages/pubsub/tests/plugin.spec.ts
@@ -1,0 +1,77 @@
+import {
+  createProcedure,
+  createRootRouter,
+  createRouter,
+  defineApplication,
+  NeemataApplication,
+} from '@nmtjs/application'
+import { EventContract, SubscriptionContract } from '@nmtjs/contract'
+import { createFactoryInjectable, createLogger } from '@nmtjs/core'
+import { t } from '@nmtjs/type'
+import { expect, it } from 'vitest'
+
+import type { PubSubAdapter } from '../src/adapter.ts'
+import { createPubSubPlugin, publish } from '../src/index.ts'
+
+class TestPubSubAdapter implements PubSubAdapter {
+  readonly published: Array<{ channel: string; payload: unknown }> = []
+
+  async publish(channel: string, payload: unknown): Promise<boolean> {
+    this.published.push({ channel, payload })
+    return true
+  }
+
+  async *subscribe(): AsyncIterable<never> {}
+}
+
+it('provides publish before global application dependencies initialize', async () => {
+  const adapter = new TestPubSubAdapter()
+  const adapterInjectable = createFactoryInjectable(() => adapter)
+  const channel = SubscriptionContract({
+    namespace: 'chat',
+    params: t.object({ roomId: t.string() }),
+    key: ({ roomId }) => roomId,
+    events: {
+      message: EventContract({ payload: t.object({ text: t.string() }) }),
+    },
+  })
+  const publisherService = createFactoryInjectable({
+    dependencies: { publish },
+    create: ({ publish }) => ({
+      notify: () =>
+        publish(channel.events.message, { roomId: 'general' }, { text: 'hi' }),
+    }),
+  })
+  const router = createRootRouter([
+    createRouter({
+      routes: {
+        notify: createProcedure({
+          dependencies: { publisherService },
+          handler: async () => ({ ok: true }),
+        }),
+      },
+    }),
+  ] as const)
+  const runtime = new NeemataApplication(
+    defineApplication({
+      router,
+      plugins: [createPubSubPlugin({ adapter: adapterInjectable })],
+    }),
+    { logger: createLogger({ pinoOptions: { enabled: false } }, 'test') },
+  )
+
+  try {
+    await runtime.initialize()
+    const service = await runtime.container.resolve(publisherService)
+
+    await expect(service.notify()).resolves.toBe(true)
+    expect(adapter.published).toEqual([
+      {
+        channel: 'chat:general',
+        payload: { event: 'message', payload: { text: 'hi' } },
+      },
+    ])
+  } finally {
+    await runtime.dispose()
+  }
+})


### PR DESCRIPTION
## Summary

Fixes #220.

- Move pubsub `publish`/`subscribe` provisioning from `BeforeInitialize` into plugin `injections` so global-scope consumers can resolve them during application startup.
- Back the injected pubsub functions with lazy factory injectables that create a shared `PubSubManager` from the configured adapter and runtime logger.
- Add a regression test covering a global application dependency that injects `publish` during eager initialization.

## Validation

- `pnpm --filter @nmtjs/pubsub test -- --reporter=agent`
- `pnpm build`
- `pnpm check:type --pretty false`
- `pnpm oxlint . --format=agent`
- `pnpm check:fmt`

Note: `pnpm oxlint . --format=agent` reports an existing warning in `packages/application/src/api/procedure.ts` but exits 0.