### PR TITLE
neem: resolve deploy-time config (proxy, health, metrics push) from env at start

### DIFF
--- a/packages/metrics/src/neem/env.ts
+++ b/packages/metrics/src/neem/env.ts
@@ -1,0 +1,163 @@
+import type { MetricsServerConfig } from '../server.ts'
+
+export type AppliedMetricsEnvOverride = {
+  source: string
+  path: string
+  from: string | number | undefined
+  to: string | number
+}
+
+export type MetricsServerEnvOverrides = {
+  config: MetricsServerConfig | undefined
+  applied: AppliedMetricsEnvOverride[]
+  warnings: string[]
+}
+
+// Plugin options are baked into the neem manifest at build time, but the
+// plugin factory runs at start in the deploy environment — so the metrics
+// server/push knobs are resolvable from env vars per deployment.
+export function applyMetricsServerEnvOverrides(
+  config: MetricsServerConfig | undefined,
+  env: NodeJS.ProcessEnv,
+): MetricsServerEnvOverrides {
+  const applied: AppliedMetricsEnvOverride[] = []
+  const warnings: string[] = []
+
+  const port = pickEnv(env, 'NEEM_METRICS_PORT')
+  const host = pickEnv(env, 'NEEM_METRICS_HOST')
+  const path = pickEnv(env, 'NEEM_METRICS_PATH')
+  const pushUrl = pickEnv(env, 'NEEM_METRICS_PUSH_URL')
+  const pushName = pickEnv(env, 'NEEM_METRICS_PUSH_NAME')
+  const pushInterval = pickEnv(env, 'NEEM_METRICS_PUSH_INTERVAL')
+
+  if (!port && !host && !path && !pushUrl && !pushName && !pushInterval)
+    return { config, applied, warnings }
+
+  const next: MetricsServerConfig = { ...config }
+
+  if (port) {
+    const value = parsePort(port.value, port.source)
+    if (value !== next.port) {
+      applied.push({
+        source: port.source,
+        path: 'server.port',
+        from: next.port,
+        to: value,
+      })
+      next.port = value
+    }
+  }
+
+  if (host && host.value !== next.host) {
+    applied.push({
+      source: host.source,
+      path: 'server.host',
+      from: next.host,
+      to: host.value,
+    })
+    next.host = host.value
+  }
+
+  if (path && path.value !== next.path) {
+    applied.push({
+      source: path.source,
+      path: 'server.path',
+      from: next.path,
+      to: path.value,
+    })
+    next.path = path.value
+  }
+
+  // Push activates from env alone (NEEM_METRICS_PUSH_URL) so a built image
+  // can opt into pushgateway delivery per deployment.
+  if (config?.push || pushUrl) {
+    const url = pushUrl?.value ?? config?.push?.url
+    const name = pushName?.value ?? config?.push?.name
+    const interval = pushInterval
+      ? parseInterval(pushInterval.value, pushInterval.source)
+      : config?.push?.interval
+
+    if (!name) {
+      throw new Error(
+        'Metrics push requires a job name: set NEEM_METRICS_PUSH_NAME or configure push.name',
+      )
+    }
+    if (interval === undefined) {
+      throw new Error(
+        'Metrics push requires an interval: set NEEM_METRICS_PUSH_INTERVAL (milliseconds) or configure push.interval',
+      )
+    }
+
+    if (pushUrl && pushUrl.value !== config?.push?.url) {
+      applied.push({
+        source: pushUrl.source,
+        path: 'server.push.url',
+        from: config?.push?.url,
+        to: pushUrl.value,
+      })
+    }
+    if (pushName && pushName.value !== config?.push?.name) {
+      applied.push({
+        source: pushName.source,
+        path: 'server.push.name',
+        from: config?.push?.name,
+        to: pushName.value,
+      })
+    }
+    if (pushInterval && interval !== config?.push?.interval) {
+      applied.push({
+        source: pushInterval.source,
+        path: 'server.push.interval',
+        from: config?.push?.interval,
+        to: interval,
+      })
+    }
+
+    next.push = url === undefined ? { name, interval } : { url, name, interval }
+  } else if (pushName || pushInterval) {
+    const sources = [pushName, pushInterval]
+      .filter((value) => value !== undefined)
+      .map((value) => value.source)
+    warnings.push(
+      `${sources.join(', ')} ignored: metrics push is not enabled (set NEEM_METRICS_PUSH_URL or configure push)`,
+    )
+  }
+
+  return { config: next, applied, warnings }
+}
+
+export function formatAppliedMetricsEnvOverride(
+  override: AppliedMetricsEnvOverride,
+): string {
+  const from = override.from === undefined ? '(unset)' : String(override.from)
+  return `Env override ${override.source}: ${override.path} ${from} -> ${override.to}`
+}
+
+type EnvValue = { source: string; value: string }
+
+function pickEnv(env: NodeJS.ProcessEnv, key: string): EnvValue | undefined {
+  // Empty values are common artifacts of compose/CI templating; treat as
+  // unset so they don't shadow configured values.
+  const value = env[key]
+  return value ? { source: key, value } : undefined
+}
+
+function parsePort(value: string, source: string): number {
+  const port = Number(value)
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(
+      `Invalid ${source}="${value}": expected an integer port between 0 and 65535`,
+    )
+  }
+  return port
+}
+
+function parseInterval(value: string, source: string): number {
+  const interval = Number(value)
+  if (!Number.isInteger(interval) || interval <= 0) {
+    throw new Error(
+      `Invalid ${source}="${value}": expected a positive integer of milliseconds`,
+    )
+  }
+  return interval
+}

--- a/packages/metrics/src/neem/plugin.ts
+++ b/packages/metrics/src/neem/plugin.ts
@@ -9,12 +9,22 @@ import {
   createCombinedMetricsCollector,
   createMetricsServer,
 } from '../server.ts'
+import {
+  applyMetricsServerEnvOverrides,
+  formatAppliedMetricsEnvOverride,
+} from './env.ts'
 import { createNeemMetricsLifecycle } from './observer.ts'
 
 type MetricsPluginOptions = { server?: MetricsServerConfig }
 
 export default definePluginHooks((ctx) => {
   const options = parseOptions(ctx.options)
+  // Options were frozen into the manifest at build time; the factory runs at
+  // start, so the live environment gets the final say on server/push knobs.
+  const overrides = applyMetricsServerEnvOverrides(options.server, process.env)
+  for (const override of overrides.applied)
+    ctx.logger.info(formatAppliedMetricsEnvOverride(override))
+  for (const warning of overrides.warnings) ctx.logger.warn(warning)
   const registry = createMetricsRegistry()
   const workerRegistry = createMetricsWorkerRegistry({ primary: true })
   const lifecycle = createNeemMetricsLifecycle({
@@ -23,7 +33,7 @@ export default definePluginHooks((ctx) => {
   })
   const server = createMetricsServer({
     logger: ctx.logger,
-    config: options.server,
+    config: overrides.config,
     registry: createCombinedMetricsCollector(registry, workerRegistry),
   })
 

--- a/packages/metrics/src/server.ts
+++ b/packages/metrics/src/server.ts
@@ -7,6 +7,13 @@ import { Pushgateway, WorkerRegistry } from '@nmtjs/prom-client'
 
 import { metricsWorkerRegistry } from './registry.ts'
 
+/**
+ * When used via the Neem plugin, options are baked into the manifest at build
+ * time; deploy-time env vars resolved at start override them:
+ * `NEEM_METRICS_PORT`, `NEEM_METRICS_HOST`, `NEEM_METRICS_PATH`,
+ * `NEEM_METRICS_PUSH_URL` (enables push when not configured here),
+ * `NEEM_METRICS_PUSH_NAME`, `NEEM_METRICS_PUSH_INTERVAL` (milliseconds).
+ */
 export type MetricsServerConfig = {
   path?: string
   port?: number

--- a/packages/metrics/tests/neem-env.spec.ts
+++ b/packages/metrics/tests/neem-env.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MetricsServerConfig } from '../src/server.ts'
+import {
+  applyMetricsServerEnvOverrides,
+  formatAppliedMetricsEnvOverride,
+} from '../src/neem/env.ts'
+
+describe('@nmtjs/metrics/neem env overrides', () => {
+  it('returns the config untouched when no override vars are set', () => {
+    const config: MetricsServerConfig = { port: 9187 }
+    const result = applyMetricsServerEnvOverrides(config, {})
+
+    expect(result.config).toBe(config)
+    expect(result.applied).toEqual([])
+    expect(result.warnings).toEqual([])
+  })
+
+  it('overrides server port, host, and path', () => {
+    const result = applyMetricsServerEnvOverrides(
+      { port: 9187, host: '0.0.0.0', path: '/metrics' },
+      {
+        NEEM_METRICS_PORT: '9999',
+        NEEM_METRICS_HOST: '127.0.0.1',
+        NEEM_METRICS_PATH: '/custom',
+      },
+    )
+
+    expect(result.config).toEqual({
+      port: 9999,
+      host: '127.0.0.1',
+      path: '/custom',
+    })
+    expect(result.applied).toHaveLength(3)
+  })
+
+  it('creates the server config from env when none was configured', () => {
+    const result = applyMetricsServerEnvOverrides(undefined, {
+      NEEM_METRICS_PORT: '9999',
+    })
+
+    expect(result.config).toEqual({ port: 9999 })
+  })
+
+  it('enables push from env vars alone', () => {
+    const result = applyMetricsServerEnvOverrides(undefined, {
+      NEEM_METRICS_PUSH_URL: 'http://gateway:9091',
+      NEEM_METRICS_PUSH_NAME: 'api',
+      NEEM_METRICS_PUSH_INTERVAL: '15000',
+    })
+
+    expect(result.config?.push).toEqual({
+      url: 'http://gateway:9091',
+      name: 'api',
+      interval: 15000,
+    })
+  })
+
+  it('overrides individual push fields of a configured push', () => {
+    const result = applyMetricsServerEnvOverrides(
+      { push: { url: 'http://old:9091', name: 'api', interval: 15000 } },
+      { NEEM_METRICS_PUSH_URL: 'http://new:9091' },
+    )
+
+    expect(result.config?.push).toEqual({
+      url: 'http://new:9091',
+      name: 'api',
+      interval: 15000,
+    })
+    expect(result.applied).toEqual([
+      {
+        source: 'NEEM_METRICS_PUSH_URL',
+        path: 'server.push.url',
+        from: 'http://old:9091',
+        to: 'http://new:9091',
+      },
+    ])
+  })
+
+  it('requires a job name when enabling push from env', () => {
+    expect(() =>
+      applyMetricsServerEnvOverrides(undefined, {
+        NEEM_METRICS_PUSH_URL: 'http://gateway:9091',
+        NEEM_METRICS_PUSH_INTERVAL: '15000',
+      }),
+    ).toThrow(/NEEM_METRICS_PUSH_NAME/)
+  })
+
+  it('requires an interval when enabling push from env', () => {
+    expect(() =>
+      applyMetricsServerEnvOverrides(undefined, {
+        NEEM_METRICS_PUSH_URL: 'http://gateway:9091',
+        NEEM_METRICS_PUSH_NAME: 'api',
+      }),
+    ).toThrow(/NEEM_METRICS_PUSH_INTERVAL/)
+  })
+
+  it('rejects invalid port and interval values', () => {
+    expect(() =>
+      applyMetricsServerEnvOverrides(undefined, { NEEM_METRICS_PORT: 'nope' }),
+    ).toThrow(/Invalid NEEM_METRICS_PORT="nope"/)
+    expect(() =>
+      applyMetricsServerEnvOverrides(
+        { push: { name: 'api', interval: 15000 } },
+        { NEEM_METRICS_PUSH_INTERVAL: '-5' },
+      ),
+    ).toThrow(/Invalid NEEM_METRICS_PUSH_INTERVAL="-5"/)
+  })
+
+  it('warns about push field vars when push is not enabled', () => {
+    const result = applyMetricsServerEnvOverrides(undefined, {
+      NEEM_METRICS_PUSH_NAME: 'api',
+      NEEM_METRICS_PUSH_INTERVAL: '15000',
+    })
+
+    expect(result.config?.push).toBeUndefined()
+    expect(result.warnings).toEqual([
+      'NEEM_METRICS_PUSH_NAME, NEEM_METRICS_PUSH_INTERVAL ignored: metrics push is not enabled (set NEEM_METRICS_PUSH_URL or configure push)',
+    ])
+  })
+
+  it('treats empty values as unset', () => {
+    const config: MetricsServerConfig = { port: 9187 }
+    const result = applyMetricsServerEnvOverrides(config, {
+      NEEM_METRICS_PORT: '',
+      NEEM_METRICS_PUSH_URL: '',
+    })
+
+    expect(result.config).toBe(config)
+    expect(result.applied).toEqual([])
+  })
+
+  it('formats applied overrides for logging', () => {
+    expect(
+      formatAppliedMetricsEnvOverride({
+        source: 'NEEM_METRICS_PUSH_URL',
+        path: 'server.push.url',
+        from: undefined,
+        to: 'http://gateway:9091',
+      }),
+    ).toBe(
+      'Env override NEEM_METRICS_PUSH_URL: server.push.url (unset) -> http://gateway:9091',
+    )
+  })
+})

--- a/packages/neem/src/internal/manifest/env-overrides.ts
+++ b/packages/neem/src/internal/manifest/env-overrides.ts
@@ -1,0 +1,209 @@
+import type { NeemHealthConfig, NeemProxyConfig } from '../../shared/types.ts'
+import type { ManifestConfig } from './manifest.ts'
+
+export type AppliedEnvOverride = {
+  source: string
+  path: string
+  from: string | number | undefined
+  to: string | number
+}
+
+export type HostConfigEnvOverrides = {
+  config: ManifestConfig
+  applied: AppliedEnvOverride[]
+  warnings: string[]
+}
+
+// The manifest freezes neem.config.ts values at build time, which makes
+// deploy-time knobs (ports, hostnames, TLS paths) unconfigurable after the
+// image is built. A documented set of env vars is resolved at start so the
+// live environment can adjust host networking per deployment.
+export function applyHostConfigEnvOverrides(
+  config: ManifestConfig,
+  env: NodeJS.ProcessEnv,
+): HostConfigEnvOverrides {
+  const applied: AppliedEnvOverride[] = []
+  const warnings: string[] = []
+
+  const proxy = overrideProxy(config.proxy, env, applied, warnings)
+  const health = overrideHealth(config.health, env, applied, warnings)
+
+  if (proxy === config.proxy && health === config.health)
+    return { config, applied, warnings }
+
+  const next = { ...config }
+  if (proxy) next.proxy = proxy
+  if (health) next.health = health
+  return { config: next, applied, warnings }
+}
+
+export function formatAppliedEnvOverride(override: AppliedEnvOverride): string {
+  const from = override.from === undefined ? '(unset)' : String(override.from)
+  return `Env override ${override.source}: ${override.path} ${from} -> ${override.to}`
+}
+
+function overrideProxy(
+  proxy: NeemProxyConfig | undefined,
+  env: NodeJS.ProcessEnv,
+  applied: AppliedEnvOverride[],
+  warnings: string[],
+): NeemProxyConfig | undefined {
+  const port = pickEnv(env, 'NEEM_PROXY_PORT', 'PORT')
+  const hostname = pickEnv(env, 'NEEM_PROXY_HOSTNAME')
+  const tlsKeyPath = pickEnv(env, 'NEEM_PROXY_TLS_KEY_PATH')
+  const tlsCertPath = pickEnv(env, 'NEEM_PROXY_TLS_CERT_PATH')
+
+  if (!proxy) {
+    // PORT is a platform-wide convention (PaaS injects it unconditionally),
+    // so only neem-specific vars warrant a warning when there is no proxy.
+    warnIgnored(warnings, 'no proxy is configured', [
+      port?.source === 'NEEM_PROXY_PORT' ? port : undefined,
+      hostname,
+      tlsKeyPath,
+      tlsCertPath,
+    ])
+    return proxy
+  }
+
+  let changed = false
+  const next = { ...proxy }
+
+  if (port) {
+    const value = parsePort(port.value, port.source)
+    if (value !== next.port) {
+      applied.push({
+        source: port.source,
+        path: 'proxy.port',
+        from: next.port,
+        to: value,
+      })
+      next.port = value
+      changed = true
+    }
+  }
+
+  if (hostname && hostname.value !== next.hostname) {
+    applied.push({
+      source: hostname.source,
+      path: 'proxy.hostname',
+      from: next.hostname,
+      to: hostname.value,
+    })
+    next.hostname = hostname.value
+    changed = true
+  }
+
+  if (tlsKeyPath || tlsCertPath) {
+    if (!next.tls && !(tlsKeyPath && tlsCertPath)) {
+      throw new Error(
+        'Both NEEM_PROXY_TLS_KEY_PATH and NEEM_PROXY_TLS_CERT_PATH must be set to enable proxy TLS at start time',
+      )
+    }
+    const tls = { ...next.tls } as { keyPath: string; certPath: string }
+    if (tlsKeyPath && tlsKeyPath.value !== tls.keyPath) {
+      applied.push({
+        source: tlsKeyPath.source,
+        path: 'proxy.tls.keyPath',
+        from: tls.keyPath,
+        to: tlsKeyPath.value,
+      })
+      tls.keyPath = tlsKeyPath.value
+      changed = true
+    }
+    if (tlsCertPath && tlsCertPath.value !== tls.certPath) {
+      applied.push({
+        source: tlsCertPath.source,
+        path: 'proxy.tls.certPath',
+        from: tls.certPath,
+        to: tlsCertPath.value,
+      })
+      tls.certPath = tlsCertPath.value
+      changed = true
+    }
+    next.tls = tls
+  }
+
+  return changed ? next : proxy
+}
+
+function overrideHealth(
+  health: NeemHealthConfig | undefined,
+  env: NodeJS.ProcessEnv,
+  applied: AppliedEnvOverride[],
+  warnings: string[],
+): NeemHealthConfig | undefined {
+  const port = pickEnv(env, 'NEEM_HEALTH_PORT')
+  const hostname = pickEnv(env, 'NEEM_HEALTH_HOSTNAME')
+
+  if (!health) {
+    warnIgnored(warnings, 'no health server is configured', [port, hostname])
+    return health
+  }
+
+  let changed = false
+  const next = { ...health }
+
+  if (port) {
+    const value = parsePort(port.value, port.source)
+    if (value !== next.port) {
+      applied.push({
+        source: port.source,
+        path: 'health.port',
+        from: next.port,
+        to: value,
+      })
+      next.port = value
+      changed = true
+    }
+  }
+
+  if (hostname && hostname.value !== next.hostname) {
+    applied.push({
+      source: hostname.source,
+      path: 'health.hostname',
+      from: next.hostname,
+      to: hostname.value,
+    })
+    next.hostname = hostname.value
+    changed = true
+  }
+
+  return changed ? next : health
+}
+
+type EnvValue = { source: string; value: string }
+
+function pickEnv(
+  env: NodeJS.ProcessEnv,
+  ...keys: readonly string[]
+): EnvValue | undefined {
+  for (const key of keys) {
+    // Empty values are common artifacts of compose/CI templating; treat as
+    // unset so they don't shadow lower-priority vars or manifest values.
+    const value = env[key]
+    if (value) return { source: key, value }
+  }
+  return undefined
+}
+
+function parsePort(value: string, source: string): number {
+  const port = Number(value)
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(
+      `Invalid ${source}="${value}": expected an integer port between 0 and 65535`,
+    )
+  }
+  return port
+}
+
+function warnIgnored(
+  warnings: string[],
+  reason: string,
+  values: readonly (EnvValue | undefined)[],
+): void {
+  const sources = values.filter((value) => value !== undefined)
+  if (sources.length === 0) return
+  warnings.push(
+    `${sources.map((value) => value.source).join(', ')} ignored: ${reason}`,
+  )
+}

--- a/packages/neem/src/internal/manifest/snapshot.ts
+++ b/packages/neem/src/internal/manifest/snapshot.ts
@@ -7,6 +7,10 @@ import type { ScopedArtifactRegistry } from './artifacts.ts'
 import type { Manifest, ManifestArtifact, ManifestConfig } from './manifest.ts'
 import { createDefaultLogger } from '../logger.ts'
 import { createArtifactRegistry } from './artifacts.ts'
+import {
+  applyHostConfigEnvOverrides,
+  formatAppliedEnvOverride,
+} from './env-overrides.ts'
 
 export type RuntimeSnapshot = {
   mode: NeemMode
@@ -28,14 +32,26 @@ export function createRuntimeSnapshot(options: {
   manifestFile?: string
   logger?: Logger
 }): RuntimeSnapshot {
+  const logger = options.logger ?? createDefaultLogger(options.mode)
+  // Snapshot creation is the single choke point shared by `neem start`,
+  // standalone start.js, and reloads, so deploy-time env overrides applied
+  // here reach every consumer of the effective host config.
+  const { config, applied, warnings } = applyHostConfigEnvOverrides(
+    options.manifest.config,
+    { ...process.env, ...options.env },
+  )
+  for (const override of applied)
+    logger.info(formatAppliedEnvOverride(override))
+  for (const warning of warnings) logger.warn(warning)
+
   return {
     mode: options.mode,
     outDir: options.outDir,
     env: options.env,
     manifestFile: options.manifestFile,
     manifest: options.manifest,
-    config: options.manifest.config,
-    logger: options.logger ?? createDefaultLogger(options.mode),
+    config,
+    logger,
     artifacts: createArtifactRegistry(
       resolveManifestArtifacts(options.outDir, options.manifest),
     ),

--- a/packages/neem/src/shared/types.ts
+++ b/packages/neem/src/shared/types.ts
@@ -272,6 +272,13 @@ export type NeemRuntimeProxyConfig = {
   sni?: string
 }
 
+/**
+ * Values are baked into the manifest at build time. Deploy-time env vars,
+ * resolved when the server starts, override them: `NEEM_PROXY_PORT` (or the
+ * platform-conventional `PORT` as a fallback), `NEEM_PROXY_HOSTNAME`,
+ * `NEEM_PROXY_TLS_KEY_PATH` and `NEEM_PROXY_TLS_CERT_PATH` (both required to
+ * enable TLS when not configured here).
+ */
 export type NeemProxyConfig = {
   hostname: string
   port: number
@@ -286,6 +293,11 @@ export type NeemProxyConfig = {
   tls?: { keyPath: string; certPath: string }
 }
 
+/**
+ * Values are baked into the manifest at build time. Deploy-time env vars,
+ * resolved when the server starts, override them: `NEEM_HEALTH_PORT` and
+ * `NEEM_HEALTH_HOSTNAME`.
+ */
 export type NeemHealthConfig = {
   hostname?: string
   port: number

--- a/packages/neem/tests/unit/env-overrides.spec.ts
+++ b/packages/neem/tests/unit/env-overrides.spec.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ManifestConfig } from '../../src/internal/manifest/manifest.ts'
+import {
+  applyHostConfigEnvOverrides,
+  formatAppliedEnvOverride,
+} from '../../src/internal/manifest/env-overrides.ts'
+
+const baseConfig: ManifestConfig = {
+  proxy: { hostname: '127.0.0.1', port: 8000 },
+  health: { hostname: '127.0.0.1', port: 8081 },
+  runtimes: {},
+}
+
+describe('Neem host config env overrides', () => {
+  it('returns the config untouched when no override vars are set', () => {
+    const result = applyHostConfigEnvOverrides(baseConfig, {})
+
+    expect(result.config).toBe(baseConfig)
+    expect(result.applied).toEqual([])
+    expect(result.warnings).toEqual([])
+  })
+
+  it('overrides proxy port and hostname from NEEM_PROXY_* vars', () => {
+    const result = applyHostConfigEnvOverrides(baseConfig, {
+      NEEM_PROXY_PORT: '3000',
+      NEEM_PROXY_HOSTNAME: '0.0.0.0',
+    })
+
+    expect(result.config.proxy).toEqual({ hostname: '0.0.0.0', port: 3000 })
+    expect(result.applied).toEqual([
+      {
+        source: 'NEEM_PROXY_PORT',
+        path: 'proxy.port',
+        from: 8000,
+        to: 3000,
+      },
+      {
+        source: 'NEEM_PROXY_HOSTNAME',
+        path: 'proxy.hostname',
+        from: '127.0.0.1',
+        to: '0.0.0.0',
+      },
+    ])
+  })
+
+  it('falls back to the platform PORT convention for the proxy port', () => {
+    const result = applyHostConfigEnvOverrides(baseConfig, { PORT: '5000' })
+
+    expect(result.config.proxy?.port).toBe(5000)
+    expect(result.applied).toEqual([
+      { source: 'PORT', path: 'proxy.port', from: 8000, to: 5000 },
+    ])
+  })
+
+  it('prefers NEEM_PROXY_PORT over PORT', () => {
+    const result = applyHostConfigEnvOverrides(baseConfig, {
+      NEEM_PROXY_PORT: '3000',
+      PORT: '5000',
+    })
+
+    expect(result.config.proxy?.port).toBe(3000)
+  })
+
+  it('overrides health port and hostname from NEEM_HEALTH_* vars', () => {
+    const result = applyHostConfigEnvOverrides(baseConfig, {
+      NEEM_HEALTH_PORT: '9000',
+      NEEM_HEALTH_HOSTNAME: '::',
+    })
+
+    expect(result.config.health).toEqual({ hostname: '::', port: 9000 })
+  })
+
+  it('does not mutate the input config', () => {
+    applyHostConfigEnvOverrides(baseConfig, {
+      NEEM_PROXY_PORT: '3000',
+      NEEM_HEALTH_PORT: '9000',
+    })
+
+    expect(baseConfig.proxy?.port).toBe(8000)
+    expect(baseConfig.health?.port).toBe(8081)
+  })
+
+  it('enables proxy TLS when both path vars are set', () => {
+    const result = applyHostConfigEnvOverrides(baseConfig, {
+      NEEM_PROXY_TLS_KEY_PATH: '/secrets/key.pem',
+      NEEM_PROXY_TLS_CERT_PATH: '/secrets/cert.pem',
+    })
+
+    expect(result.config.proxy?.tls).toEqual({
+      keyPath: '/secrets/key.pem',
+      certPath: '/secrets/cert.pem',
+    })
+  })
+
+  it('overrides a single TLS path when TLS is already configured', () => {
+    const config: ManifestConfig = {
+      ...baseConfig,
+      proxy: {
+        hostname: '127.0.0.1',
+        port: 8000,
+        tls: { keyPath: '/old/key.pem', certPath: '/old/cert.pem' },
+      },
+    }
+    const result = applyHostConfigEnvOverrides(config, {
+      NEEM_PROXY_TLS_KEY_PATH: '/new/key.pem',
+    })
+
+    expect(result.config.proxy?.tls).toEqual({
+      keyPath: '/new/key.pem',
+      certPath: '/old/cert.pem',
+    })
+  })
+
+  it('rejects enabling TLS with only one of the path vars', () => {
+    expect(() =>
+      applyHostConfigEnvOverrides(baseConfig, {
+        NEEM_PROXY_TLS_KEY_PATH: '/secrets/key.pem',
+      }),
+    ).toThrow(/Both NEEM_PROXY_TLS_KEY_PATH and NEEM_PROXY_TLS_CERT_PATH/)
+  })
+
+  it('rejects non-numeric ports', () => {
+    expect(() =>
+      applyHostConfigEnvOverrides(baseConfig, { NEEM_PROXY_PORT: 'nope' }),
+    ).toThrow(/Invalid NEEM_PROXY_PORT="nope"/)
+    expect(() =>
+      applyHostConfigEnvOverrides(baseConfig, { NEEM_HEALTH_PORT: '70000' }),
+    ).toThrow(/Invalid NEEM_HEALTH_PORT="70000"/)
+  })
+
+  it('treats empty values as unset', () => {
+    const result = applyHostConfigEnvOverrides(baseConfig, {
+      NEEM_PROXY_PORT: '',
+      PORT: '5000',
+      NEEM_PROXY_HOSTNAME: '',
+    })
+
+    expect(result.config.proxy).toEqual({ hostname: '127.0.0.1', port: 5000 })
+  })
+
+  it('skips no-op overrides matching the manifest value', () => {
+    const result = applyHostConfigEnvOverrides(baseConfig, {
+      NEEM_PROXY_PORT: '8000',
+    })
+
+    expect(result.config).toBe(baseConfig)
+    expect(result.applied).toEqual([])
+  })
+
+  it('warns about neem-specific vars when the target is not configured', () => {
+    const config: ManifestConfig = { runtimes: {} }
+    const result = applyHostConfigEnvOverrides(config, {
+      NEEM_PROXY_PORT: '3000',
+      NEEM_HEALTH_PORT: '9000',
+      PORT: '5000',
+    })
+
+    expect(result.config).toBe(config)
+    expect(result.warnings).toEqual([
+      'NEEM_PROXY_PORT ignored: no proxy is configured',
+      'NEEM_HEALTH_PORT ignored: no health server is configured',
+    ])
+  })
+
+  it('stays silent about a stray PORT when no proxy is configured', () => {
+    const config: ManifestConfig = { runtimes: {} }
+    const result = applyHostConfigEnvOverrides(config, { PORT: '5000' })
+
+    expect(result.warnings).toEqual([])
+  })
+
+  it('formats applied overrides for logging', () => {
+    expect(
+      formatAppliedEnvOverride({
+        source: 'NEEM_PROXY_PORT',
+        path: 'proxy.port',
+        from: 8000,
+        to: 3000,
+      }),
+    ).toBe('Env override NEEM_PROXY_PORT: proxy.port 8000 -> 3000')
+    expect(
+      formatAppliedEnvOverride({
+        source: 'NEEM_PROXY_TLS_KEY_PATH',
+        path: 'proxy.tls.keyPath',
+        from: undefined,
+        to: '/secrets/key.pem',
+      }),
+    ).toBe(
+      'Env override NEEM_PROXY_TLS_KEY_PATH: proxy.tls.keyPath (unset) -> /secrets/key.pem',
+    )
+  })
+})


### PR DESCRIPTION
Closes #223

## Problem

`neem.config.ts` is evaluated at build time and its values are frozen into `dist/neem.manifest.json`, so deploy-time knobs (proxy port/hostname, TLS paths, health port, metrics push settings) are unconfigurable after the image is built.

## Approach

Instead of a placeholder DSL or CLI flags, a documented set of env vars is resolved when the server starts. Two observations shaped this:

- Both boot paths (`neem start` and standalone `dist/start.js`) converge on `createRuntimeSnapshot`, so host overrides applied there reach `ProxyController`/`HealthProbe` everywhere with no manifest schema change.
- Plugin factories already run at start in the deploy environment, so the metrics plugin resolves its own env vars — plugin options stay opaque to neem.

## Supported vars

Host (`@nmtjs/neem`):
- `NEEM_PROXY_PORT` — falls back to platform-conventional `PORT`, so Railway/Heroku-style injection works with zero config
- `NEEM_PROXY_HOSTNAME`
- `NEEM_PROXY_TLS_KEY_PATH` / `NEEM_PROXY_TLS_CERT_PATH` — override existing paths individually, or enable TLS when both are set
- `NEEM_HEALTH_PORT`, `NEEM_HEALTH_HOSTNAME`

Metrics (`@nmtjs/metrics` neem plugin):
- `NEEM_METRICS_PORT`, `NEEM_METRICS_HOST`, `NEEM_METRICS_PATH`
- `NEEM_METRICS_PUSH_URL` (enables push when not configured), `NEEM_METRICS_PUSH_NAME`, `NEEM_METRICS_PUSH_INTERVAL`

## Semantics

- Every applied override is logged (`Env override NEEM_PROXY_PORT: proxy.port 8000 -> 3000`) so the implicit channel stays visible
- Invalid ports/intervals fail at boot instead of being silently ignored; enabling push from env without a job name/interval fails with a message naming the missing var
- Empty values are treated as unset (compose/CI templating artifacts)
- Neem-specific vars targeting an unconfigured proxy/health/push log a warning; a stray `PORT` with no proxy stays silent since it is a platform-wide convention
- Env vars are documented in the JSDoc of `NeemProxyConfig`, `NeemHealthConfig`, and `MetricsServerConfig`

## Testing

- 26 new unit tests (`packages/neem/tests/unit/env-overrides.spec.ts`, `packages/metrics/tests/neem-env.spec.ts`)
- Full neem unit + metrics suites pass; `recovery-health-proxy` and `production-portability` e2e specs pass
- Typecheck, lint, and formatting clean