### PR TITLE
Fix workflow dependency implementation inference

### DIFF
--- a/packages/workflows/src/implement/index.ts
+++ b/packages/workflows/src/implement/index.ts
@@ -296,6 +296,15 @@ type ActivityCaseDescriptor<
   readonly options?: WorkflowInputMapper<any, any, any, Input>
 }
 
+type AnyActivityImplementationValue<Input, Output> =
+  ActivityImplementationValue<Input, Output, any>
+
+type AnyActivityCaseDescriptor<Input, Output> = ActivityCaseDescriptor<
+  Input,
+  Output,
+  any
+>
+
 type RunnableCaseDescriptor<
   Target extends AnyTaskDefinition | AnyWorkflowDefinition,
   Input,
@@ -308,11 +317,14 @@ type RunnableCaseDescriptor<
 type CaseImplementationValue<Case> =
   Case extends BranchCaseDefinition<'activity', infer Input, infer Output>
     ?
-        | ActivityImplementationValue<
+        | AnyActivityImplementationValue<
             BoundaryOutput<Input>,
             BoundaryInput<Output>
           >
-        | ActivityCaseDescriptor<BoundaryOutput<Input>, BoundaryInput<Output>>
+        | AnyActivityCaseDescriptor<
+            BoundaryOutput<Input>,
+            BoundaryInput<Output>
+          >
     : Case extends BranchCaseDefinition<'task', any, any, infer Task>
       ? Task extends AnyTaskDefinition
         ? Task | RunnableCaseDescriptor<Task, TaskInput<Task>>
@@ -950,7 +962,7 @@ function isActivityImplementation(
 
 function isActivityCaseDescriptor(
   value: unknown,
-): value is ActivityCaseDescriptor<unknown, unknown> {
+): value is ActivityCaseDescriptor<unknown, unknown, any> {
   return Boolean(
     value &&
     typeof value === 'object' &&

--- a/packages/workflows/src/neem/runtime.ts
+++ b/packages/workflows/src/neem/runtime.ts
@@ -5,14 +5,24 @@ import type {
 import type { WorkflowRuntimeAdapter } from '../runtime/client.ts'
 import type { AnyScheduleDefinition, MaybePromise } from '../types/index.ts'
 
+export type AnyWorkflowImplementation = Omit<
+  WorkflowImplementation,
+  'finish'
+> & {
+  readonly finish: (...args: any[]) => unknown
+}
+export type AnyTaskImplementation = Omit<TaskImplementation, 'handler'> & {
+  readonly handler: (...args: any[]) => unknown
+}
+
 export type WorkflowsRuntimeFactory = () => MaybePromise<WorkflowRuntimeAdapter>
 
 export type WorkflowsImplementationsFactory<
-  Implementation = WorkflowImplementation,
+  Implementation = AnyWorkflowImplementation,
 > = () => MaybePromise<readonly Implementation[]>
 
 export type WorkflowTaskImplementationsFactory<
-  Implementation = TaskImplementation,
+  Implementation = AnyTaskImplementation,
 > = () => MaybePromise<readonly Implementation[]>
 
 export type WorkflowSchedulesFactory<
@@ -40,9 +50,9 @@ export type WorkflowsWorkersConfig = {
 }
 
 export type WorkflowsConfig<
-  TWorkflowImplementation extends WorkflowImplementation =
-    WorkflowImplementation,
-  TTaskImplementation extends TaskImplementation = TaskImplementation,
+  TWorkflowImplementation extends AnyWorkflowImplementation =
+    AnyWorkflowImplementation,
+  TTaskImplementation extends AnyTaskImplementation = AnyTaskImplementation,
   TScheduleDefinition extends AnyScheduleDefinition = AnyScheduleDefinition,
 > = {
   readonly runtime: WorkflowsRuntimeFactory
@@ -53,9 +63,9 @@ export type WorkflowsConfig<
 }
 
 export type ResolvedWorkflowsConfig<
-  TWorkflowImplementation extends WorkflowImplementation =
-    WorkflowImplementation,
-  TTaskImplementation extends TaskImplementation = TaskImplementation,
+  TWorkflowImplementation extends AnyWorkflowImplementation =
+    AnyWorkflowImplementation,
+  TTaskImplementation extends AnyTaskImplementation = AnyTaskImplementation,
   TScheduleDefinition extends AnyScheduleDefinition = AnyScheduleDefinition,
 > = {
   readonly runtime: WorkflowsRuntimeFactory
@@ -82,8 +92,9 @@ const defaultWorkerConfig = {
 } as const
 
 export function defineWorkflows<
-  const TWorkflowImplementation extends WorkflowImplementation,
-  const TTaskImplementation extends TaskImplementation = TaskImplementation,
+  const TWorkflowImplementation extends AnyWorkflowImplementation,
+  const TTaskImplementation extends AnyTaskImplementation =
+    AnyTaskImplementation,
   const TScheduleDefinition extends AnyScheduleDefinition =
     AnyScheduleDefinition,
 >(
@@ -101,8 +112,9 @@ export function defineWorkflows<
 }
 
 export async function resolveWorkflowsConfig<
-  const TWorkflowImplementation extends WorkflowImplementation,
-  const TTaskImplementation extends TaskImplementation = TaskImplementation,
+  const TWorkflowImplementation extends AnyWorkflowImplementation,
+  const TTaskImplementation extends AnyTaskImplementation =
+    AnyTaskImplementation,
   const TScheduleDefinition extends AnyScheduleDefinition =
     AnyScheduleDefinition,
 >(

--- a/packages/workflows/src/neem/worker-entry.ts
+++ b/packages/workflows/src/neem/worker-entry.ts
@@ -1,12 +1,10 @@
 import { Container, provision, CoreInjectables } from '@nmtjs/core'
 import { defineRuntimeWorker } from '@nmtjs/neem'
 
-import type {
-  TaskImplementation,
-  WorkflowImplementation,
-} from '../implement/index.ts'
 import type { WorkflowRuntimeAdapter } from '../runtime/client.ts'
 import type {
+  AnyTaskImplementation,
+  AnyWorkflowImplementation,
   ResolvedWorkflowsConfig,
   WorkflowsConfig,
   WorkflowsWorkerData,
@@ -19,14 +17,15 @@ import {
 import { resolveWorkflowsConfig } from './runtime.ts'
 
 export type WorkflowsWorkerConfig<
-  TWorkflowImplementation extends WorkflowImplementation =
-    WorkflowImplementation,
-  TTaskImplementation extends TaskImplementation = TaskImplementation,
+  TWorkflowImplementation extends AnyWorkflowImplementation =
+    AnyWorkflowImplementation,
+  TTaskImplementation extends AnyTaskImplementation = AnyTaskImplementation,
 > = WorkflowsConfig<TWorkflowImplementation, TTaskImplementation>
 
 export function defineWorkflowsWorker<
-  const TWorkflowImplementation extends WorkflowImplementation,
-  const TTaskImplementation extends TaskImplementation = TaskImplementation,
+  const TWorkflowImplementation extends AnyWorkflowImplementation,
+  const TTaskImplementation extends AnyTaskImplementation =
+    AnyTaskImplementation,
 >(config: WorkflowsWorkerConfig<TWorkflowImplementation, TTaskImplementation>) {
   return defineRuntimeWorker<WorkflowsWorkerData, WorkflowsWorkerConfig>({
     definition: config,

--- a/packages/workflows/tests/implementation-chain.spec.ts
+++ b/packages/workflows/tests/implementation-chain.spec.ts
@@ -163,6 +163,62 @@ describe('workflow implementation chain', () => {
     expect(annotated.workflow).toBe(activityWorkflow)
   })
 
+  it('keeps activity implementation dependencies typed in branch and parallel cases', () => {
+    const service = createValueInjectable({
+      decorate: (text: string) => `${text}!`,
+    })
+    const io = t.object({ text: t.string() })
+    const activity = {
+      dependencies: { service },
+      handler: (
+        ctx: DependencyContext<{ service: typeof service }>,
+        input: t.infer.decode.output<typeof io>,
+      ) => ({ text: ctx.service.decorate(input.text) }),
+    }
+    const branched = defineWorkflow({
+      name: 'branch-case-activity-dependencies',
+      input: io,
+      output: io,
+    })
+      .branch('chosen', {
+        output: io,
+        cases: (helpers) => ({
+          normal: helpers.activity({ input: io, output: io }),
+        }),
+      })
+      .build()
+    const parallel = defineWorkflow({
+      name: 'parallel-case-activity-dependencies',
+      input: io,
+      output: io,
+    })
+      .parallel('cases', (helpers) => ({
+        normal: helpers.activity({ input: io, output: io }),
+      }))
+      .build()
+
+    const branchImplementation = implementWorkflow(branched)
+      .chosen({
+        select: () => 'normal',
+        cases: ({ activity: defineActivity }) => ({
+          normal: defineActivity(activity, {
+            input: (_ctx, _outputs, input) => input,
+          }),
+        }),
+      })
+      .finish((_ctx, { chosen }) => chosen)
+    const parallelImplementation = implementWorkflow(parallel)
+      .cases(({ activity: defineActivity }) => ({
+        normal: defineActivity(activity, {
+          input: (_ctx, _outputs, input) => input,
+        }),
+      }))
+      .finish((_ctx, { cases }) => cases.normal)
+
+    expect(branchImplementation.workflow).toBe(branched)
+    expect(parallelImplementation.workflow).toBe(parallel)
+  })
+
   it('accepts schema-derived annotations for optional parallel activity input', () => {
     const activityInput = t.object({
       caseBlueprint: t.string(),

--- a/packages/workflows/tests/neem-integration.spec.ts
+++ b/packages/workflows/tests/neem-integration.spec.ts
@@ -1,6 +1,6 @@
 import { MessageChannel } from 'node:worker_threads'
 
-import { createLogger } from '@nmtjs/core'
+import { createLogger, createValueInjectable } from '@nmtjs/core'
 import {
   isNeemRuntimeDeclaration,
   isNeemRuntimeHostFactory,
@@ -76,6 +76,26 @@ describe('workflows Neem integration', () => {
       activity: [{ role: 'activity' }],
       task: [],
     })
+  })
+
+  it('accepts task implementations with typed dependencies', async () => {
+    const prefix = createValueInjectable('typed')
+    const task = defineTask({
+      name: 'neem.integration.typed-task-dependencies',
+      input: t.object({ text: t.string() }),
+      output: t.object({ text: t.string() }),
+    })
+    const taskImpl = implementTask(task, {
+      dependencies: { prefix },
+      handler: (ctx, input) => ({ text: `${ctx.prefix}:${input.text}` }),
+    })
+    const config = defineWorkflows({
+      runtime: () => createInMemoryWorkflowRuntime(),
+      workflows: () => [],
+      tasks: () => [taskImpl],
+    })
+
+    expect(await config.tasks?.()).toStrictEqual([taskImpl])
   })
 
   it('rejects invalid worker thread counts by role', async () => {


### PR DESCRIPTION
## Summary
- preserve typed dependency inference for activity branch and parallel case implementations
- relax Neem workflow config implementation constraints so typed-dependency task implementations are accepted
- add regression coverage for branch/parallel cases and Neem typed task implementations

## Validation
- pnpm run build
- pnpm --filter @nmtjs/workflows exec vitest run tests/implementation-chain.spec.ts tests/neem-integration.spec.ts --reporter=agent
- pnpm run check:fmt
- pnpm run check:type
- pnpm run check:lint -- --format=agent

Closes #235
