### PR TITLE
Fix Redis pubsub subscription race

### DIFF
--- a/packages/pubsub/src/redis.ts
+++ b/packages/pubsub/src/redis.ts
@@ -91,7 +91,23 @@ export class RedisPubSubAdapter implements PubSubAdapter {
 
     this.logger?.debug({ channel }, 'Opening channel listener')
 
+    let registered = false
+
     try {
+      const controllerSignal = this.controller?.signal
+      const finalSignal =
+        signal && controllerSignal
+          ? AbortSignal.any([signal, controllerSignal])
+          : controllerSignal
+
+      finalSignal?.throwIfAborted()
+
+      // Attach the local listener before Redis confirms SUBSCRIBE; otherwise a
+      // message delivered immediately after broker readiness can be dropped.
+      const messages = on(this.events, channel, {
+        signal: finalSignal,
+      })
+
       if (!this.listeners.has(channel)) {
         this.listeners.set(channel, 1)
         const promise = this.subClient.subscribe(channel)
@@ -111,17 +127,10 @@ export class RedisPubSubAdapter implements PubSubAdapter {
         )
       }
 
-      const finalSignal =
-        signal && this.controller?.signal
-          ? AbortSignal.any([signal, this.controller!.signal])
-          : this.controller?.signal
+      registered = true
 
-      finalSignal?.throwIfAborted()
-
-      for await (const args of on(this.events, channel, {
-        signal: finalSignal,
-      })) {
-        this.logger?.trace({ channel }, 'Delivering  message')
+      for await (const args of messages) {
+        this.logger?.trace({ channel }, 'Delivering message')
         yield { channel, data: args[0] }
       }
     } catch (error: any) {
@@ -132,7 +141,7 @@ export class RedisPubSubAdapter implements PubSubAdapter {
       this.logger?.warn({ channel, error }, 'Channel listener error')
       throw error
     } finally {
-      const count = this.listeners.get(channel)
+      const count = registered ? this.listeners.get(channel) : undefined
       if (count !== undefined) {
         if (count > 1) {
           const listeners = count - 1

--- a/packages/pubsub/tests/redis.spec.ts
+++ b/packages/pubsub/tests/redis.spec.ts
@@ -1,0 +1,98 @@
+import EventEmitter from 'node:events'
+
+import { describe, expect, it } from 'vitest'
+
+import { RedisPubSubAdapter, type RedisPubSubClient } from '../src/redis.ts'
+
+class TestRedisClient extends EventEmitter {
+  public readonly duplicateClient: TestRedisClient
+  public readonly subscribePayload: unknown
+  public subscribeCalls = 0
+  public unsubscribeCalls = 0
+
+  constructor(duplicateClient?: TestRedisClient, subscribePayload?: unknown) {
+    super()
+    this.duplicateClient = duplicateClient ?? this
+    this.subscribePayload = subscribePayload
+  }
+
+  duplicate() {
+    return this.duplicateClient
+  }
+
+  async connect() {}
+
+  async subscribe(channel: string) {
+    this.subscribeCalls++
+    this.emit('message', channel, JSON.stringify(this.subscribePayload))
+  }
+
+  async unsubscribe() {
+    this.unsubscribeCalls++
+  }
+
+  async quit() {}
+
+  async publish() {
+    return 1
+  }
+}
+
+describe('RedisPubSubAdapter', () => {
+  it('does not drop messages delivered as the broker subscription becomes ready', async () => {
+    const message = { event: 'message', payload: { text: 'hello' } }
+    const subscriber = new TestRedisClient(undefined, message)
+    const adapter = new RedisPubSubAdapter(
+      new TestRedisClient(subscriber) as unknown as RedisPubSubClient,
+    )
+    await adapter.initialize()
+
+    const iterator = adapter.subscribe('room').next()
+
+    try {
+      await expect(Promise.race([iterator, timeout(250)])).resolves.toEqual({
+        done: false,
+        value: { channel: 'room', data: message },
+      })
+    } finally {
+      await adapter.dispose()
+    }
+  })
+
+  it('does not unsubscribe an active channel when another subscriber is already aborted', async () => {
+    const subscriber = new TestRedisClient()
+    const adapter = new RedisPubSubAdapter(
+      new TestRedisClient(subscriber) as unknown as RedisPubSubClient,
+    )
+    await adapter.initialize()
+
+    const active = adapter.subscribe('room').next()
+    await waitFor(() => subscriber.subscribeCalls === 1)
+
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      adapter.subscribe('room', controller.signal).next(),
+    ).resolves.toEqual({ done: true, value: undefined })
+
+    expect(subscriber.unsubscribeCalls).toBe(0)
+
+    await adapter.dispose()
+    await active
+  })
+})
+
+function timeout(ms: number): Promise<never> {
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error('message not delivered')), ms)
+  })
+}
+
+async function waitFor(predicate: () => boolean) {
+  const deadline = Date.now() + 250
+  while (Date.now() < deadline) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 1))
+  }
+  throw new Error('condition not met')
+}


### PR DESCRIPTION
## Summary
- attach Redis pubsub async listeners before broker subscription readiness can deliver messages
- add a deterministic regression test for messages emitted as `SUBSCRIBE` resolves

## Root cause
The integration flake came from a race between broker subscription readiness and local `EventEmitter` listener attachment. `PUBSUB NUMSUB` could report subscribers before the adapter started consuming the local async iterator, so a message published in that window was emitted with no listener and dropped.

## Validation
- `pnpm --filter @nmtjs/pubsub exec vitest run --config vitest.config.ts tests/redis.spec.ts --reporter=agent`
- `pnpm run build`
- `env NMTJS_REQUIRE_SERVICE_TESTS=1 REDIS_URL=redis://localhost:16379 VALKEY_URL=redis://localhost:16380 pnpm --filter @nmtjs/pubsub exec vitest run --config vitest.config.ts tests/integration/redis.spec.ts --reporter=agent`
- 20x targeted Valkey loop for `Valkey integration.*publishes typed events to all subscribers`
- `pnpm run check:type --pretty false`
- `pnpm oxlint . --format=agent`