### PR TITLE
workflows: Postgres LISTEN/NOTIFY wake-ups for command dispatch and cancellation

### DIFF
--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -82,7 +82,11 @@ const runtime = createPostgresWorkflowRuntime({ connection, wakeEvents })
 Notifications are fire-and-forget hints: a missed one (disconnect, restart)
 degrades to the existing polling behavior, never to lost work. With wake
 events enabled, generous poll intervals and lease durations keep idle database
-traffic low without sacrificing dispatch or stop latency. The listener
+traffic low without sacrificing dispatch or stop latency. The tradeoff: every
+immediate command enqueue and cancellation adds a `NOTIFY` to its transaction,
+and Postgres serializes commits of notifying transactions — under very high
+dispatch throughput this can reduce commit parallelism. Delayed commands skip
+the hint entirely. The listener
 reconnects automatically after connection loss; `wakeEvents.dispose()` runs as
 part of `runtime.dispose()`.
 

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -51,6 +51,41 @@ const runtime = createPostgresWorkflowRuntime({ connection })
 
 Other clients can pass a custom object that satisfies `WorkflowPostgresConnection`.
 
+## Wake Events (LISTEN/NOTIFY)
+
+Command dispatch and cancellation are poll-based by default: dispatch latency
+is bounded by the worker poll interval, cancellation latency by the attempt
+heartbeat cadence (`leaseMs / 3`). The Postgres runtime can layer
+`LISTEN/NOTIFY` wake-up hints on top so idle workers wake immediately when a
+command is enqueued and running attempts observe cancellation right away:
+
+```ts
+import { Client, Pool } from 'pg'
+import {
+  createPostgresWorkflowConnection,
+  createPostgresWorkflowRuntime,
+  createPostgresWorkflowWakeEvents,
+} from '@nmtjs/workflows/postgres'
+
+const wakeEvents = createPostgresWorkflowWakeEvents({
+  // dedicated LISTEN connection, one per worker process
+  connect: async () => {
+    const client = new Client({ connectionString })
+    await client.connect()
+    return client
+  },
+})
+
+const runtime = createPostgresWorkflowRuntime({ connection, wakeEvents })
+```
+
+Notifications are fire-and-forget hints: a missed one (disconnect, restart)
+degrades to the existing polling behavior, never to lost work. With wake
+events enabled, generous poll intervals and lease durations keep idle database
+traffic low without sacrificing dispatch or stop latency. The listener
+reconnects automatically after connection loss; `wakeEvents.dispose()` runs as
+part of `runtime.dispose()`.
+
 ## Postgres Schema
 
 Applications own production migrations. The package exports Drizzle schema

--- a/packages/workflows/src/adapters/postgres.ts
+++ b/packages/workflows/src/adapters/postgres.ts
@@ -12,4 +12,11 @@ export {
   WORKFLOW_POSTGRES_SCHEMA_VERSION,
 } from './postgres/manifest.ts'
 export { createPostgresWorkflowRuntime } from './postgres/runtime.ts'
+export {
+  createPostgresWorkflowWakeEvents,
+  type CreatePostgresWorkflowWakeEventsParams,
+  type PostgresWorkflowWakeEvents,
+  type WorkflowPostgresListenerClient,
+  type WorkflowPostgresNotification,
+} from './postgres/wake-events.ts'
 export { verifyPostgresWorkflowSchema } from './postgres/verify.ts'

--- a/packages/workflows/src/adapters/postgres/executor.ts
+++ b/packages/workflows/src/adapters/postgres/executor.ts
@@ -8,7 +8,7 @@ import type { AttemptExecutor } from '../../runtime/executors.ts'
 import type { StoredRun } from '../../runtime/state.ts'
 import type { PostgresWorkflowCommandContext } from './queue.ts'
 import { createPostgresWorkflowCommandHelpers } from './queue.ts'
-import { id, json, many, one } from './sql.ts'
+import { WORKFLOW_COMMANDS_CHANNEL, id, json, many, one } from './sql.ts'
 
 export const createAttemptExecutor = (
   ctx: PostgresWorkflowCommandContext,
@@ -38,21 +38,27 @@ export const createAttemptExecutor = (
       await ready
       await db.query(
         `
-        INSERT INTO workflow_commands (
-          id,
-          kind,
-          run_id,
-          workflow_name,
-          activity_name,
-          node_name,
-          attempt_id,
-          payload,
-          run_at
+        WITH inserted AS (
+          INSERT INTO workflow_commands (
+            id,
+            kind,
+            run_id,
+            workflow_name,
+            activity_name,
+            node_name,
+            attempt_id,
+            payload,
+            run_at
+          )
+          SELECT $1, 'activity', $2, $3, $4, $5, $6, $7::jsonb, COALESCE($8, now())
+          WHERE NOT EXISTS (
+            SELECT 1 FROM workflow_commands WHERE attempt_id = $6
+          )
+          RETURNING run_at
         )
-        SELECT $1, 'activity', $2, $3, $4, $5, $6, $7::jsonb, COALESCE($8, now())
-        WHERE NOT EXISTS (
-          SELECT 1 FROM workflow_commands WHERE attempt_id = $6
-        )
+        SELECT pg_notify('${WORKFLOW_COMMANDS_CHANNEL}', 'activity')
+        FROM inserted
+        WHERE run_at <= now()
       `,
         [
           id(),
@@ -70,21 +76,27 @@ export const createAttemptExecutor = (
       await ready
       await db.query(
         `
-        INSERT INTO workflow_commands (
-          id,
-          kind,
-          run_id,
-          workflow_name,
-          task_name,
-          node_name,
-          attempt_id,
-          payload,
-          run_at
+        WITH inserted AS (
+          INSERT INTO workflow_commands (
+            id,
+            kind,
+            run_id,
+            workflow_name,
+            task_name,
+            node_name,
+            attempt_id,
+            payload,
+            run_at
+          )
+          SELECT $1, 'task', $2, $3, $4, $5, $6, $7::jsonb, COALESCE($8, now())
+          WHERE NOT EXISTS (
+            SELECT 1 FROM workflow_commands WHERE attempt_id = $6
+          )
+          RETURNING run_at
         )
-        SELECT $1, 'task', $2, $3, $4, $5, $6, $7::jsonb, COALESCE($8, now())
-        WHERE NOT EXISTS (
-          SELECT 1 FROM workflow_commands WHERE attempt_id = $6
-        )
+        SELECT pg_notify('${WORKFLOW_COMMANDS_CHANNEL}', 'task')
+        FROM inserted
+        WHERE run_at <= now()
       `,
         [
           id(),

--- a/packages/workflows/src/adapters/postgres/queue.ts
+++ b/packages/workflows/src/adapters/postgres/queue.ts
@@ -9,6 +9,7 @@ import {
   MAX_ERROR_BACKOFF_MS,
   RELEASE_BACKOFF_MS,
   UNROUTABLE_BACKOFF_MS,
+  WORKFLOW_COMMANDS_CHANNEL,
   id,
   json,
   one,
@@ -29,17 +30,26 @@ export const createPostgresWorkflowCommandHelpers = (
     command: ContinueRunCommand,
     runAt?: Date,
   ) => {
+    // pg_notify piggybacks on the upsert so no enqueue path can forget the
+    // wake-up hint; inside a transaction it is delivered on commit. Delayed
+    // commands stay poll-only — waking workers for future work is noise.
     await db.query(
       `
-      INSERT INTO workflow_commands (
-        id, kind, run_id, workflow_name, payload, run_at
+      WITH upserted AS (
+        INSERT INTO workflow_commands (
+          id, kind, run_id, workflow_name, payload, run_at
+        )
+        VALUES ($1, 'continue', $2, $3, $4::jsonb, COALESCE($5, now()))
+        ON CONFLICT (run_id) WHERE kind = 'continue' AND lease_token IS NULL
+        DO UPDATE
+        SET run_at = LEAST(workflow_commands.run_at, EXCLUDED.run_at),
+            payload = EXCLUDED.payload,
+            workflow_name = EXCLUDED.workflow_name
+        RETURNING run_at
       )
-      VALUES ($1, 'continue', $2, $3, $4::jsonb, COALESCE($5, now()))
-      ON CONFLICT (run_id) WHERE kind = 'continue' AND lease_token IS NULL
-      DO UPDATE
-      SET run_at = LEAST(workflow_commands.run_at, EXCLUDED.run_at),
-          payload = EXCLUDED.payload,
-          workflow_name = EXCLUDED.workflow_name
+      SELECT pg_notify('${WORKFLOW_COMMANDS_CHANNEL}', 'continue')
+      FROM upserted
+      WHERE run_at <= now()
     `,
       [id(), command.runId, command.workflowName, json(command), runAt ?? null],
     )

--- a/packages/workflows/src/adapters/postgres/runtime.ts
+++ b/packages/workflows/src/adapters/postgres/runtime.ts
@@ -5,6 +5,7 @@ import type {
   WorkflowRuntimeAtomicCompletion,
   WorkflowRuntimeAtomicContinuation,
 } from '../../runtime/worker.ts'
+import type { WorkflowWakeEvents } from '../../runtime/wake-events.ts'
 import type { WorkflowPostgresConnection } from './connection.ts'
 import { SELF_CHILD_KEY } from '../../runtime/child-key.ts'
 import { createAttemptExecutor } from './executor.ts'
@@ -24,6 +25,11 @@ type PostgresWorkflowRuntime = WorkflowRuntimeAdapter & {
 export function createPostgresWorkflowRuntime(params: {
   readonly connection: WorkflowPostgresConnection
   readonly maxDeliveries?: number
+  /**
+   * Optional LISTEN/NOTIFY wake-up hints (see createPostgresWorkflowWakeEvents).
+   * Without it dispatch/cancellation latency is bounded by polling alone.
+   */
+  readonly wakeEvents?: WorkflowWakeEvents
 }): PostgresWorkflowRuntime {
   const db = params.connection
   const ready = Promise.resolve()
@@ -164,5 +170,11 @@ export function createPostgresWorkflowRuntime(params: {
     atomicContinuation,
     atomicCompletion,
     connection: db,
+    ...(params.wakeEvents === undefined
+      ? {}
+      : {
+          wakeEvents: params.wakeEvents,
+          dispose: () => params.wakeEvents?.dispose?.(),
+        }),
   }
 }

--- a/packages/workflows/src/adapters/postgres/runtime.ts
+++ b/packages/workflows/src/adapters/postgres/runtime.ts
@@ -1,11 +1,11 @@
 import type { WorkflowRuntimeAdapter } from '../../runtime/client.ts'
 import type { WorkflowRuntimeAtomicStart } from '../../runtime/coordinator.ts'
 import type { PruneTerminalRunsParams } from '../../runtime/store.ts'
+import type { WorkflowWakeEvents } from '../../runtime/wake-events.ts'
 import type {
   WorkflowRuntimeAtomicCompletion,
   WorkflowRuntimeAtomicContinuation,
 } from '../../runtime/worker.ts'
-import type { WorkflowWakeEvents } from '../../runtime/wake-events.ts'
 import type { WorkflowPostgresConnection } from './connection.ts'
 import { SELF_CHILD_KEY } from '../../runtime/child-key.ts'
 import { createAttemptExecutor } from './executor.ts'

--- a/packages/workflows/src/adapters/postgres/sql.ts
+++ b/packages/workflows/src/adapters/postgres/sql.ts
@@ -38,6 +38,10 @@ export const DEFAULT_PRUNE_STATUSES = [
 ] as const satisfies readonly TerminalRunStatus[]
 
 export const TASK_RUN_NODE_NAME = '$task'
+// LISTEN/NOTIFY wake-up hint channels; payloads are the command kind and the
+// run id respectively. Delivery is best-effort — polling remains the fallback.
+export const WORKFLOW_COMMANDS_CHANNEL = 'workflow_commands'
+export const WORKFLOW_CANCELLATIONS_CHANNEL = 'workflow_run_cancellations'
 export const id = () => randomUUID()
 export const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i

--- a/packages/workflows/src/adapters/postgres/store-nodes.ts
+++ b/packages/workflows/src/adapters/postgres/store-nodes.ts
@@ -11,6 +11,7 @@ import {
   isTerminalRunStatus,
 } from '../../runtime/status.ts'
 import {
+  WORKFLOW_CANCELLATIONS_CHANNEL,
   id,
   json,
   many,
@@ -486,16 +487,23 @@ export const createPostgresWorkflowNodeStore = (
       ) {
         return mapRun(run)
       }
+      // pg_notify rides on the status flip so a worker holding the attempt
+      // can abort immediately instead of waiting out its heartbeat cycle.
       const row = await one(
         db,
         `
-        UPDATE workflow_runs
-        SET status = 'cancelling',
-            version = version + 1,
-            updated_at = now()
-        WHERE id = $1
-          AND status IN (${runStatusSourcesSql('cancelling')})
-        RETURNING *
+        WITH updated AS (
+          UPDATE workflow_runs
+          SET status = 'cancelling',
+              version = version + 1,
+              updated_at = now()
+          WHERE id = $1
+            AND status IN (${runStatusSourcesSql('cancelling')})
+          RETURNING *
+        )
+        SELECT updated.*,
+          pg_notify('${WORKFLOW_CANCELLATIONS_CHANNEL}', updated.id::text)
+        FROM updated
       `,
         [runId],
       )

--- a/packages/workflows/src/adapters/postgres/wake-events.ts
+++ b/packages/workflows/src/adapters/postgres/wake-events.ts
@@ -1,0 +1,156 @@
+import type {
+  WorkflowCommandWakeKind,
+  WorkflowWakeEvents,
+} from '../../runtime/wake-events.ts'
+import {
+  WORKFLOW_CANCELLATIONS_CHANNEL,
+  WORKFLOW_COMMANDS_CHANNEL,
+} from './sql.ts'
+
+const DEFAULT_RECONNECT_DELAY_MS = 1_000
+
+export type WorkflowPostgresNotification = {
+  readonly channel: string
+  readonly payload?: string | undefined
+}
+
+/**
+ * Minimal surface of a dedicated LISTEN connection; a connected `pg` Client
+ * satisfies it as-is.
+ */
+export type WorkflowPostgresListenerClient = {
+  query(sql: string): Promise<unknown>
+  on(
+    event: 'notification' | 'error' | 'end',
+    listener: (arg?: any) => void,
+  ): unknown
+  end(): Promise<void> | void
+}
+
+export type CreatePostgresWorkflowWakeEventsParams = {
+  /**
+   * Creates a connected client dedicated to LISTEN. Called again after
+   * connection loss; keep it cheap and side-effect free beyond connecting.
+   */
+  readonly connect: () => Promise<WorkflowPostgresListenerClient>
+  readonly reconnectDelayMs?: number
+  readonly onError?: (error: unknown) => void
+}
+
+export type PostgresWorkflowWakeEvents = WorkflowWakeEvents & {
+  dispose(): Promise<void>
+}
+
+/**
+ * LISTEN/NOTIFY-backed wake events for the Postgres workflow runtime. Purely
+ * a latency optimization: notifications lost to disconnects are absorbed by
+ * the poll/heartbeat fallback, so reconnection is best-effort with backoff.
+ */
+export function createPostgresWorkflowWakeEvents(
+  params: CreatePostgresWorkflowWakeEventsParams,
+): PostgresWorkflowWakeEvents {
+  const reconnectDelayMs = params.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS
+  const commandListeners = new Map<WorkflowCommandWakeKind, Set<() => void>>()
+  const cancellationListeners = new Map<string, Set<() => void>>()
+
+  let disposed = false
+  let client: WorkflowPostgresListenerClient | undefined
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined
+
+  const fire = (listeners: Set<() => void> | undefined) => {
+    if (!listeners) return
+    for (const listener of listeners) {
+      try {
+        listener()
+      } catch (error) {
+        params.onError?.(error)
+      }
+    }
+  }
+
+  const handleNotification = (message: WorkflowPostgresNotification) => {
+    if (message.channel === WORKFLOW_COMMANDS_CHANNEL) {
+      fire(commandListeners.get(message.payload as WorkflowCommandWakeKind))
+      return
+    }
+    if (message.channel === WORKFLOW_CANCELLATIONS_CHANNEL) {
+      if (message.payload) fire(cancellationListeners.get(message.payload))
+    }
+  }
+
+  const scheduleReconnect = () => {
+    if (disposed || reconnectTimer) return
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = undefined
+      void connect()
+    }, reconnectDelayMs)
+    // don't hold the process open just to keep a wake-up hint alive
+    if (typeof reconnectTimer === 'object' && 'unref' in reconnectTimer) {
+      reconnectTimer.unref()
+    }
+  }
+
+  const connect = async () => {
+    if (disposed || client) return
+    try {
+      const connected = await params.connect()
+      if (disposed) {
+        await connected.end()
+        return
+      }
+      client = connected
+      let lost = false
+      const onLost = (error?: unknown) => {
+        if (error) params.onError?.(error)
+        if (lost) return
+        lost = true
+        client = undefined
+        scheduleReconnect()
+      }
+      connected.on('notification', handleNotification)
+      connected.on('error', onLost)
+      connected.on('end', () => onLost())
+      await connected.query(
+        `LISTEN "${WORKFLOW_COMMANDS_CHANNEL}"; LISTEN "${WORKFLOW_CANCELLATIONS_CHANNEL}"`,
+      )
+    } catch (error) {
+      params.onError?.(error)
+      scheduleReconnect()
+    }
+  }
+
+  void connect()
+
+  const subscribe = <K>(
+    listeners: Map<K, Set<() => void>>,
+    key: K,
+    listener: () => void,
+  ) => {
+    const set = listeners.get(key) ?? new Set<() => void>()
+    listeners.set(key, set)
+    set.add(listener)
+    return () => {
+      set.delete(listener)
+      if (set.size === 0) listeners.delete(key)
+    }
+  }
+
+  return {
+    onCommand: (kind, listener) => subscribe(commandListeners, kind, listener),
+    onCancellation: (runId, listener) =>
+      subscribe(cancellationListeners, runId, listener),
+    async dispose() {
+      disposed = true
+      if (reconnectTimer) clearTimeout(reconnectTimer)
+      commandListeners.clear()
+      cancellationListeners.clear()
+      const current = client
+      client = undefined
+      try {
+        await current?.end()
+      } catch (error) {
+        params.onError?.(error)
+      }
+    },
+  }
+}

--- a/packages/workflows/src/adapters/postgres/wake-events.ts
+++ b/packages/workflows/src/adapters/postgres/wake-events.ts
@@ -57,20 +57,28 @@ export function createPostgresWorkflowWakeEvents(
   let client: WorkflowPostgresListenerClient | undefined
   let reconnectTimer: ReturnType<typeof setTimeout> | undefined
 
+  // shutdown intentionally interrupts in-flight connect/LISTEN work; don't
+  // surface those interruptions as errors
+  const reportError = (error: unknown) => {
+    if (!disposed) params.onError?.(error)
+  }
+
   const fire = (listeners: Set<() => void> | undefined) => {
     if (!listeners) return
     for (const listener of listeners) {
       try {
         listener()
       } catch (error) {
-        params.onError?.(error)
+        reportError(error)
       }
     }
   }
 
   const handleNotification = (message: WorkflowPostgresNotification) => {
     if (message.channel === WORKFLOW_COMMANDS_CHANNEL) {
-      fire(commandListeners.get(message.payload as WorkflowCommandWakeKind))
+      if (message.payload) {
+        fire(commandListeners.get(message.payload as WorkflowCommandWakeKind))
+      }
       return
     }
     if (message.channel === WORKFLOW_CANCELLATIONS_CHANNEL) {
@@ -101,7 +109,7 @@ export function createPostgresWorkflowWakeEvents(
       client = connected
       let lost = false
       const onLost = (error?: unknown) => {
-        if (error) params.onError?.(error)
+        if (error) reportError(error)
         if (lost) return
         lost = true
         client = undefined
@@ -114,7 +122,7 @@ export function createPostgresWorkflowWakeEvents(
         `LISTEN "${WORKFLOW_COMMANDS_CHANNEL}"; LISTEN "${WORKFLOW_CANCELLATIONS_CHANNEL}"`,
       )
     } catch (error) {
-      params.onError?.(error)
+      reportError(error)
       scheduleReconnect()
     }
   }

--- a/packages/workflows/src/neem/worker-entry.ts
+++ b/packages/workflows/src/neem/worker-entry.ts
@@ -85,6 +85,12 @@ export function defineWorkflowsWorker<
   })
 }
 
+const ROLE_WAKE_KIND = {
+  coordinator: 'continue',
+  activity: 'activity',
+  task: 'task',
+} as const
+
 async function runRoleLoop(input: {
   readonly role: WorkflowsWorkerData['role']
   readonly runtime: WorkflowRuntimeAdapter
@@ -93,6 +99,22 @@ async function runRoleLoop(input: {
   readonly workerId: string
   readonly signal: AbortSignal
 }): Promise<void> {
+  // Between loop iterations the poll-interval sleep races the adapter's wake
+  // hint (if any), so a fresh command interrupts idle waiting immediately.
+  const idleSleep = async (ms: number) => {
+    const wakeEvents = input.runtime.wakeEvents
+    if (!wakeEvents) return sleep(ms, input.signal)
+    let unsubscribe = () => {}
+    const woken = new Promise<void>((resolve) => {
+      unsubscribe = wakeEvents.onCommand(ROLE_WAKE_KIND[input.role], resolve)
+    })
+    try {
+      await Promise.race([sleep(ms, input.signal), woken])
+    } finally {
+      unsubscribe()
+    }
+  }
+
   while (!input.signal.aborted) {
     switch (input.role) {
       case 'coordinator':
@@ -109,10 +131,7 @@ async function runRoleLoop(input: {
             input.config.schedules.length === 0 ? undefined : { everyMs: 1000 },
           signal: input.signal,
         })
-        await sleep(
-          input.config.workers.coordinator.pollIntervalMs,
-          input.signal,
-        )
+        await idleSleep(input.config.workers.coordinator.pollIntervalMs)
         continue
 
       case 'activity':
@@ -128,7 +147,7 @@ async function runRoleLoop(input: {
           idleDelayMs: input.config.workers.activity.pollIntervalMs,
           signal: input.signal,
         })
-        await sleep(input.config.workers.activity.pollIntervalMs, input.signal)
+        await idleSleep(input.config.workers.activity.pollIntervalMs)
         continue
 
       case 'task':
@@ -143,7 +162,7 @@ async function runRoleLoop(input: {
           idleDelayMs: input.config.workers.task.pollIntervalMs,
           signal: input.signal,
         })
-        await sleep(input.config.workers.task.pollIntervalMs, input.signal)
+        await idleSleep(input.config.workers.task.pollIntervalMs)
         continue
     }
   }

--- a/packages/workflows/src/runtime/client.ts
+++ b/packages/workflows/src/runtime/client.ts
@@ -23,6 +23,7 @@ import type {
   WorkflowRetentionPruner,
   WorkflowStore,
 } from './store.ts'
+import type { WorkflowWakeEvents } from './wake-events.ts'
 import type {
   WorkflowRuntimeAtomicCompletion,
   WorkflowRuntimeAtomicContinuation,
@@ -48,6 +49,7 @@ export type WorkflowRuntimeAdapter = {
   readonly attemptExecutor: AttemptExecutor
   readonly retentionPruner?: WorkflowRetentionPruner
   readonly scheduler?: WorkflowScheduler
+  readonly wakeEvents?: WorkflowWakeEvents
   readonly atomicStart?: WorkflowRuntimeAtomicStart
   readonly atomicContinuation?: WorkflowRuntimeAtomicContinuation
   readonly atomicCompletion?: WorkflowRuntimeAtomicCompletion

--- a/packages/workflows/src/runtime/index.ts
+++ b/packages/workflows/src/runtime/index.ts
@@ -74,6 +74,10 @@ export {
 } from './transitions.ts'
 export type { TransitionMap } from './transitions.ts'
 export type {
+  WorkflowCommandWakeKind,
+  WorkflowWakeEvents,
+} from './wake-events.ts'
+export type {
   CancelNodeParams,
   CancelNonTerminalRunNodesParams,
   CreateAttemptInput,

--- a/packages/workflows/src/runtime/wake-events.ts
+++ b/packages/workflows/src/runtime/wake-events.ts
@@ -1,0 +1,15 @@
+export type WorkflowCommandWakeKind = 'continue' | 'activity' | 'task'
+
+/**
+ * Optional adapter port for push-style wake-up hints layered over polling.
+ * Notifications are fire-and-forget: a missed event only costs one poll
+ * interval (or heartbeat cycle), never correctness — every consumer
+ * re-checks durable state before acting.
+ */
+export type WorkflowWakeEvents = {
+  /** Fires when a command of the given kind may be claimable. */
+  onCommand(kind: WorkflowCommandWakeKind, listener: () => void): () => void
+  /** Fires when cancellation has been requested for the given run. */
+  onCancellation(runId: string, listener: () => void): () => void
+  dispose?(): Promise<void> | void
+}

--- a/packages/workflows/src/runtime/worker/activity-attempt.ts
+++ b/packages/workflows/src/runtime/worker/activity-attempt.ts
@@ -15,6 +15,7 @@ import type {
 import type { ActivityAttemptCommand, ClaimedAttempt } from '../commands.ts'
 import type { AttemptExecutor, RunCoordinationExecutor } from '../executors.ts'
 import type { WorkflowStore } from '../store.ts'
+import type { WorkflowWakeEvents } from '../wake-events.ts'
 import { parseChildKey } from '../child-key.ts'
 import { parseDurationMs } from '../duration.ts'
 import { createWorkflowRuntimeRegistry } from '../registry.ts'
@@ -60,6 +61,7 @@ export type RunActivityAttemptInput = {
   readonly claimed: ClaimedAttempt
   readonly leaseMs?: number
   readonly signal?: AbortSignal
+  readonly wakeEvents?: WorkflowWakeEvents
   readonly container: Pick<Container, 'createContext'>
 }
 

--- a/packages/workflows/src/runtime/worker/entry.ts
+++ b/packages/workflows/src/runtime/worker/entry.ts
@@ -10,6 +10,10 @@ import type {
 } from '../../types/index.ts'
 import type { AttemptExecutor, RunCoordinationExecutor } from '../executors.ts'
 import type { WorkflowStore } from '../store.ts'
+import type {
+  WorkflowCommandWakeKind,
+  WorkflowWakeEvents,
+} from '../wake-events.ts'
 import { continueWorkflowRun } from '../coordinator.ts'
 import { runActivityAttempt } from './activity-attempt.ts'
 import {
@@ -58,6 +62,7 @@ export type RunWorkflowWorkerInput = WorkerLoopOptions & {
   readonly runCoordinationExecutor: RunCoordinationExecutor
   readonly attemptExecutor: AttemptExecutor
   readonly atomicContinuation?: WorkflowRuntimeAtomicContinuation
+  readonly wakeEvents?: WorkflowWakeEvents
   readonly workflows: readonly AnyWorkflowImplementation[]
   readonly container: Pick<Container, 'createContext'>
   readonly reaping?: false | WorkerReapingOptions
@@ -69,6 +74,7 @@ export type RunActivityWorkerInput = WorkerLoopOptions & {
   readonly runCoordinationExecutor: RunCoordinationExecutor
   readonly attemptExecutor: AttemptExecutor
   readonly atomicCompletion?: WorkflowRuntimeAtomicCompletion
+  readonly wakeEvents?: WorkflowWakeEvents
   readonly workflows: readonly AnyWorkflowImplementation[]
   readonly activityNames?: readonly string[]
   readonly container: Pick<Container, 'createContext'>
@@ -80,6 +86,7 @@ export type RunTaskWorkerInput = WorkerLoopOptions & {
   readonly runCoordinationExecutor: RunCoordinationExecutor
   readonly attemptExecutor: AttemptExecutor
   readonly atomicCompletion?: WorkflowRuntimeAtomicCompletion
+  readonly wakeEvents?: WorkflowWakeEvents
   readonly tasks: readonly AnyTaskImplementation[]
   readonly container: Pick<Container, 'createContext'>
   readonly reaping?: false | WorkerReapingOptions
@@ -140,6 +147,15 @@ function withRunTimeoutsHook(
   ]
 }
 
+
+function commandWake(
+  wakeEvents: WorkflowWakeEvents | undefined,
+  kind: WorkflowCommandWakeKind,
+): ((listener: () => void) => () => void) | undefined {
+  if (!wakeEvents) return undefined
+  return (listener) => wakeEvents.onCommand(kind, listener)
+}
+
 export async function runWorkflowWorker(
   input: RunWorkflowWorkerInput,
 ): Promise<WorkerLoopResult> {
@@ -149,7 +165,11 @@ export async function runWorkflowWorker(
   const maintenance = withRunTimeoutsHook(input, withReapingHook(input))
 
   return runWorkerLoop(
-    withDefaultRetentionPruner({ ...input, maintenance }),
+    withDefaultRetentionPruner({
+      ...input,
+      maintenance,
+      onWake: commandWake(input.wakeEvents, 'continue'),
+    }),
     async () => {
       const claimed = await input.runCoordinationExecutor.claim({
         workerId: input.workerId,
@@ -204,6 +224,7 @@ export async function runActivityWorker(
     withDefaultRetentionPruner({
       ...input,
       maintenance: withReapingHook(input),
+      onWake: commandWake(input.wakeEvents, 'activity'),
     }),
     async () => {
       const claimed = await input.attemptExecutor.claimActivity({
@@ -244,6 +265,7 @@ export async function runTaskWorker(
     withDefaultRetentionPruner({
       ...input,
       maintenance: withReapingHook(input),
+      onWake: commandWake(input.wakeEvents, 'task'),
     }),
     async () => {
       const claimed = await input.attemptExecutor.claimTask({

--- a/packages/workflows/src/runtime/worker/entry.ts
+++ b/packages/workflows/src/runtime/worker/entry.ts
@@ -147,7 +147,6 @@ function withRunTimeoutsHook(
   ]
 }
 
-
 function commandWake(
   wakeEvents: WorkflowWakeEvents | undefined,
   kind: WorkflowCommandWakeKind,

--- a/packages/workflows/src/runtime/worker/heartbeat.ts
+++ b/packages/workflows/src/runtime/worker/heartbeat.ts
@@ -93,6 +93,7 @@ export async function runWithAttemptHeartbeat<T>(
   const heartbeatFailure = new Promise<never>((_resolve, reject) => {
     rejectHeartbeat = reject
   })
+  let beatPending = false
   const beat = () => {
     if (heartbeatRunning || heartbeatFailed) return
     heartbeatRunning = true
@@ -119,15 +120,27 @@ export async function runWithAttemptHeartbeat<T>(
       })
       .finally(() => {
         heartbeatRunning = false
+        if (beatPending) {
+          beatPending = false
+          beat()
+        }
       })
   }
   const interval = setInterval(beat, intervalMs)
   // Cancellation wake hint: run the heartbeat check immediately instead of
   // waiting out the interval. The DB read stays authoritative — a spurious
-  // notification just costs one extra heartbeat query.
+  // notification just costs one extra heartbeat query. A wake arriving while
+  // a heartbeat is in flight is latched: that snapshot may predate the
+  // cancellation commit, so a follow-up check must run once it settles.
   const unsubscribeCancellationWake = input.wakeEvents?.onCancellation(
     input.claimed.command.runId,
-    beat,
+    () => {
+      if (heartbeatRunning) {
+        beatPending = true
+        return
+      }
+      beat()
+    },
   )
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined
   const timeoutFailure =

--- a/packages/workflows/src/runtime/worker/heartbeat.ts
+++ b/packages/workflows/src/runtime/worker/heartbeat.ts
@@ -1,5 +1,6 @@
 import type { ClaimedAttempt } from '../commands.ts'
 import type { AttemptExecutor } from '../executors.ts'
+import type { WorkflowWakeEvents } from '../wake-events.ts'
 import { isTerminalRunStatus } from '../status.ts'
 import { DEFAULT_LEASE_MS, isAttemptHeartbeatLeaseLost } from './loop.ts'
 
@@ -72,6 +73,7 @@ export async function runWithAttemptHeartbeat<T>(
     readonly claimed: ClaimedAttempt
     readonly leaseMs?: number
     readonly signal?: AbortSignal
+    readonly wakeEvents?: Pick<WorkflowWakeEvents, 'onCancellation'>
   },
   handler: (lifecycle: { readonly signal: AbortSignal }) => Promise<T>,
   timeout?: {
@@ -91,7 +93,7 @@ export async function runWithAttemptHeartbeat<T>(
   const heartbeatFailure = new Promise<never>((_resolve, reject) => {
     rejectHeartbeat = reject
   })
-  const interval = setInterval(() => {
+  const beat = () => {
     if (heartbeatRunning || heartbeatFailed) return
     heartbeatRunning = true
     void input.attemptExecutor
@@ -118,7 +120,15 @@ export async function runWithAttemptHeartbeat<T>(
       .finally(() => {
         heartbeatRunning = false
       })
-  }, intervalMs)
+  }
+  const interval = setInterval(beat, intervalMs)
+  // Cancellation wake hint: run the heartbeat check immediately instead of
+  // waiting out the interval. The DB read stays authoritative — a spurious
+  // notification just costs one extra heartbeat query.
+  const unsubscribeCancellationWake = input.wakeEvents?.onCancellation(
+    input.claimed.command.runId,
+    beat,
+  )
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined
   const timeoutFailure =
     timeout === undefined
@@ -164,6 +174,7 @@ export async function runWithAttemptHeartbeat<T>(
     return await Promise.race(races)
   } finally {
     clearInterval(interval)
+    unsubscribeCancellationWake?.()
     if (timeoutHandle !== undefined) clearTimeout(timeoutHandle)
     removeShutdownListener?.()
   }

--- a/packages/workflows/src/runtime/worker/loop.ts
+++ b/packages/workflows/src/runtime/worker/loop.ts
@@ -58,6 +58,11 @@ export type WorkerLoopOptions = {
   readonly leaseMs?: number
   readonly maxIdleClaims?: number
   readonly idleDelayMs?: number
+  /**
+   * Push-style wake hint: subscribes a listener that short-circuits the idle
+   * delay when new work may be claimable. Polling stays the fallback.
+   */
+  readonly onWake?: (listener: () => void) => () => void
   readonly retention?: WorkerRetentionOptions
   readonly retentionPruner?: WorkflowRetentionPruner
   readonly scheduling?: WorkerSchedulingOptions
@@ -153,6 +158,35 @@ export async function runWorkerLoop(
       schedulingRunning = false
     }
   }
+  // Wake hints arriving mid-claim must not be lost: latch them and let the
+  // next idle sleep consume the latch instead of waiting out the delay.
+  let wakePending = false
+  const wakeWaiters = new Set<() => void>()
+  const unsubscribeWake = options.onWake?.(() => {
+    wakePending = true
+    for (const waiter of wakeWaiters) waiter()
+  })
+  const idleSleep = async () => {
+    if (wakePending) {
+      wakePending = false
+      return
+    }
+    let waiter: () => void = () => {}
+    const wakeable = new Promise<void>((resolve) => {
+      waiter = resolve
+      wakeWaiters.add(resolve)
+    })
+    try {
+      await Promise.race([
+        sleep(options.idleDelayMs ?? 0, options.signal),
+        wakeable,
+      ])
+    } finally {
+      wakeWaiters.delete(waiter)
+    }
+    wakePending = false
+  }
+
   await Promise.allSettled(
     Array.from({ length: concurrency }, async () => {
       let idleClaims = 0
@@ -174,7 +208,7 @@ export async function runWorkerLoop(
           await runScheduling()
           await runMaintenance()
           if (idleClaims < maxIdleClaims) {
-            await sleep(options.idleDelayMs ?? 0, options.signal)
+            await idleSleep()
           }
         }
       } catch (error) {
@@ -183,6 +217,7 @@ export async function runWorkerLoop(
       }
     }),
   )
+  unsubscribeWake?.()
 
   if (firstError) throw firstError
   return { processed }

--- a/packages/workflows/src/runtime/worker/task-attempt.ts
+++ b/packages/workflows/src/runtime/worker/task-attempt.ts
@@ -5,6 +5,7 @@ import type { AnyTaskDefinition } from '../../types/index.ts'
 import type { ClaimedAttempt } from '../commands.ts'
 import type { AttemptExecutor, RunCoordinationExecutor } from '../executors.ts'
 import type { WorkflowStore } from '../store.ts'
+import type { WorkflowWakeEvents } from '../wake-events.ts'
 import { parseDurationMs } from '../duration.ts'
 import { createWorkflowRuntimeRegistry } from '../registry.ts'
 import { isTerminalRunStatus } from '../status.ts'
@@ -43,6 +44,7 @@ export type RunTaskAttemptInput = {
   readonly claimed: ClaimedAttempt
   readonly leaseMs?: number
   readonly signal?: AbortSignal
+  readonly wakeEvents?: WorkflowWakeEvents
   readonly container: Pick<Container, 'createContext'>
 }
 

--- a/packages/workflows/tests/integration/postgres-wake-events.spec.ts
+++ b/packages/workflows/tests/integration/postgres-wake-events.spec.ts
@@ -1,0 +1,268 @@
+import { t } from '@nmtjs/type'
+import pg from 'pg'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { Pool as PgPool } from 'pg'
+
+import {
+  createPostgresWorkflowConnection,
+  createPostgresWorkflowRuntime,
+  createPostgresWorkflowWakeEvents,
+  type PostgresWorkflowWakeEvents,
+} from '../../src/adapters/postgres.ts'
+import { installPostgresWorkflowSchemaForTesting } from '../../src/adapters/postgres/testing.ts'
+import { defineWorkflow, implementWorkflow } from '../../src/index.ts'
+import {
+  createWorkflowRuntimeClient,
+  runActivityWorker,
+  runWorkflowWorker,
+} from '../../src/runtime/index.ts'
+import {
+  createTestContainer,
+  createTestName,
+  postgresTarget,
+  requireServiceEnv,
+  wait,
+} from './helpers.ts'
+
+requireServiceEnv(postgresTarget)
+
+const { Client, Pool } = pg
+
+// Long enough that any assertion passing below proves the wake path fired
+// instead of the poll/heartbeat fallback.
+const LONG_DELAY_MS = 20_000
+
+describe.skipIf(!postgresTarget.url)(
+  '@nmtjs/workflows Postgres wake events',
+  () => {
+    const pools: PgPool[] = []
+    const wakeEventHubs: PostgresWorkflowWakeEvents[] = []
+
+    afterEach(async () => {
+      await Promise.allSettled(
+        wakeEventHubs.splice(0).map(async (hub) => hub.dispose()),
+      )
+      await Promise.allSettled(pools.splice(0).map((pool) => pool.end()))
+    })
+
+    // Deliberately no table truncation: integration spec files run in
+    // parallel against one database, and this suite only touches runs it
+    // created under unique names.
+    async function createHarness() {
+      const pool = new Pool({ connectionString: postgresTarget.url, max: 16 })
+      pools.push(pool)
+      const connection = createPostgresWorkflowConnection(pool)
+      await installPostgresWorkflowSchemaForTesting(connection)
+      return { runtime: createPostgresWorkflowRuntime({ connection }) }
+    }
+
+    async function createWakeEvents() {
+      const wakeEvents = createPostgresWorkflowWakeEvents({
+        connect: async () => {
+          const client = new Client({ connectionString: postgresTarget.url })
+          await client.connect()
+          return client
+        },
+      })
+      wakeEventHubs.push(wakeEvents)
+      // LISTEN setup is asynchronous; give it a moment before relying on it
+      await wait(300)
+      return wakeEvents
+    }
+
+    it('notifies on command enqueue and cancellation request', async () => {
+      const { runtime } = await createHarness()
+      const wakeEvents = await createWakeEvents()
+
+      const commandWoke = new Promise<void>((resolve) => {
+        wakeEvents.onCommand('continue', resolve)
+      })
+      const run = await runtime.store.createRun({
+        workflowName: createTestName('postgres-wake-notify'),
+        input: {},
+      })
+      await runtime.runCoordinationExecutor.enqueue({
+        kind: 'continueRun',
+        runId: run.id,
+        workflowName: run.workflowName,
+      })
+      await expect(
+        Promise.race([
+          commandWoke.then(() => 'woken'),
+          wait(3_000).then(() => 'timeout'),
+        ]),
+      ).resolves.toBe('woken')
+
+      const cancellationWoke = new Promise<void>((resolve) => {
+        wakeEvents.onCancellation(run.id, resolve)
+      })
+      await runtime.store.requestRunCancellation({ runId: run.id })
+      await expect(
+        Promise.race([
+          cancellationWoke.then(() => 'woken'),
+          wait(3_000).then(() => 'timeout'),
+        ]),
+      ).resolves.toBe('woken')
+    })
+
+    it('dispatches and completes a run while workers idle on long poll intervals', async () => {
+      const harness = await createHarness()
+      const wakeEvents = await createWakeEvents()
+      const runtime = createPostgresWorkflowRuntime({
+        connection: harness.runtime.connection,
+        wakeEvents,
+      })
+      const container = createTestContainer()
+
+      const workflow = defineWorkflow({
+        name: createTestName('postgres-wake-dispatch'),
+        input: t.object({ text: t.string() }),
+        output: t.object({ text: t.string() }),
+      })
+        .activity('echo', {
+          input: t.object({ text: t.string() }),
+          output: t.object({ text: t.string() }),
+        })
+        .build()
+      const implementation = implementWorkflow(workflow)
+        .echo(async (_ctx, input) => input)
+        .finish((_ctx, { echo }) => echo)
+
+      const abort = new AbortController()
+      const workers = Promise.allSettled([
+        runWorkflowWorker({
+          ...runtime,
+          container,
+          workflows: [implementation],
+          workerId: 'wake-coordinator',
+          maxIdleClaims: 1_000,
+          idleDelayMs: LONG_DELAY_MS,
+          reaping: false,
+          runTimeouts: false,
+          signal: abort.signal,
+        }),
+        runActivityWorker({
+          ...runtime,
+          container,
+          workflows: [implementation],
+          workerId: 'wake-activity',
+          maxIdleClaims: 1_000,
+          idleDelayMs: LONG_DELAY_MS,
+          reaping: false,
+          signal: abort.signal,
+        }),
+      ])
+
+      try {
+        // both workers must be inside their idle sleep before the run starts
+        await wait(500)
+        const client = createWorkflowRuntimeClient(runtime)
+        const started = Date.now()
+        const run = await client.start(workflow, { text: 'ping' })
+
+        let status = ''
+        while (Date.now() - started < 10_000) {
+          const snapshot = await client.get(run.id)
+          status = snapshot?.run.status ?? ''
+          if (status === 'completed') break
+          await wait(50)
+        }
+
+        expect(status).toBe('completed')
+        expect(Date.now() - started).toBeLessThan(LONG_DELAY_MS / 2)
+      } finally {
+        abort.abort()
+        await workers
+      }
+    })
+
+    it('aborts a running activity on cancel without waiting for the heartbeat cycle', async () => {
+      const harness = await createHarness()
+      const wakeEvents = await createWakeEvents()
+      const runtime = createPostgresWorkflowRuntime({
+        connection: harness.runtime.connection,
+        wakeEvents,
+      })
+      const container = createTestContainer()
+
+      const workflow = defineWorkflow({
+        name: createTestName('postgres-wake-cancel'),
+        input: t.object({ text: t.string() }),
+        output: t.object({ text: t.string() }),
+      })
+        .activity('hold', {
+          input: t.object({ text: t.string() }),
+          output: t.object({ text: t.string() }),
+        })
+        .build()
+      let activityStarted: () => void = () => {}
+      const activityRunning = new Promise<void>((resolve) => {
+        activityStarted = resolve
+      })
+      const implementation = implementWorkflow(workflow)
+        .hold(async (_ctx, input, lifecycle) => {
+          activityStarted()
+          await new Promise<never>((_resolve, reject) => {
+            lifecycle.signal.addEventListener(
+              'abort',
+              () => reject(new Error('activity aborted')),
+              { once: true },
+            )
+          })
+          return input
+        })
+        .finish((_ctx, { hold }) => hold)
+
+      const abort = new AbortController()
+      const workers = Promise.allSettled([
+        runWorkflowWorker({
+          ...runtime,
+          container,
+          workflows: [implementation],
+          workerId: 'cancel-coordinator',
+          maxIdleClaims: 1_000,
+          idleDelayMs: 25,
+          reaping: false,
+          runTimeouts: false,
+          signal: abort.signal,
+        }),
+        runActivityWorker({
+          ...runtime,
+          container,
+          workflows: [implementation],
+          workerId: 'cancel-activity',
+          // heartbeat interval = leaseMs / 3; far beyond the asserted latency
+          leaseMs: LONG_DELAY_MS * 3,
+          maxIdleClaims: 1_000,
+          idleDelayMs: 25,
+          reaping: false,
+          signal: abort.signal,
+        }),
+      ])
+
+      try {
+        const client = createWorkflowRuntimeClient(runtime)
+        const run = await client.start(workflow, { text: 'hold' })
+        await activityRunning
+
+        const cancelledAt = Date.now()
+        await client.cancel(run.id)
+
+        let status = ''
+        while (Date.now() - cancelledAt < 10_000) {
+          const snapshot = await client.get(run.id)
+          status = snapshot?.run.status ?? ''
+          if (status === 'cancelled') break
+          await wait(50)
+        }
+
+        expect(status).toBe('cancelled')
+        expect(Date.now() - cancelledAt).toBeLessThan(LONG_DELAY_MS / 2)
+      } finally {
+        abort.abort()
+        await workers
+      }
+    })
+  },
+)

--- a/packages/workflows/tests/integration/postgres-wake-events.spec.ts
+++ b/packages/workflows/tests/integration/postgres-wake-events.spec.ts
@@ -203,7 +203,7 @@ describe.skipIf(!postgresTarget.url)(
         .hold(async (_ctx, input, lifecycle) => {
           activityStarted()
           await new Promise<never>((_resolve, reject) => {
-            lifecycle.signal.addEventListener(
+            lifecycle?.signal.addEventListener(
               'abort',
               () => reject(new Error('activity aborted')),
               { once: true },

--- a/packages/workflows/tests/integration/postgres-wake-events.spec.ts
+++ b/packages/workflows/tests/integration/postgres-wake-events.spec.ts
@@ -1,8 +1,7 @@
+import type { Pool as PgPool } from 'pg'
 import { t } from '@nmtjs/type'
 import pg from 'pg'
 import { afterEach, describe, expect, it } from 'vitest'
-
-import type { Pool as PgPool } from 'pg'
 
 import {
   createPostgresWorkflowConnection,

--- a/packages/workflows/tests/runtime-wake-events.spec.ts
+++ b/packages/workflows/tests/runtime-wake-events.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ClaimedAttempt } from '../src/runtime/commands.ts'
+import type { AttemptExecutor } from '../src/runtime/executors.ts'
+import { runWithAttemptHeartbeat } from '../src/runtime/worker/heartbeat.ts'
+import { runWorkerLoop } from '../src/runtime/worker/loop.ts'
+
+const LONG_DELAY_MS = 30_000
+
+describe('workflow wake events', () => {
+  it('short-circuits the worker loop idle delay on wake', async () => {
+    let wake: () => void = () => {}
+    let claims = 0
+    const started = Date.now()
+
+    const result = await runWorkerLoop(
+      {
+        workerId: 'wake-loop',
+        maxIdleClaims: 2,
+        idleDelayMs: LONG_DELAY_MS,
+        onWake: (listener) => {
+          wake = listener
+          return () => {}
+        },
+      },
+      async () => {
+        claims += 1
+        if (claims === 1) setTimeout(() => wake(), 20)
+        return false
+      },
+    )
+
+    expect(result.processed).toBe(0)
+    expect(claims).toBe(2)
+    expect(Date.now() - started).toBeLessThan(LONG_DELAY_MS)
+  })
+
+  it('latches a wake that fires while a claim is in flight', async () => {
+    let wake: () => void = () => {}
+    let claims = 0
+    const started = Date.now()
+
+    await runWorkerLoop(
+      {
+        workerId: 'wake-latch',
+        maxIdleClaims: 2,
+        idleDelayMs: LONG_DELAY_MS,
+        onWake: (listener) => {
+          wake = listener
+          return () => {}
+        },
+      },
+      async () => {
+        claims += 1
+        // fires before the idle sleep starts — must still be observed
+        if (claims === 1) wake()
+        return false
+      },
+    )
+
+    expect(claims).toBe(2)
+    expect(Date.now() - started).toBeLessThan(LONG_DELAY_MS)
+  })
+
+  it('runs the heartbeat check immediately on a cancellation wake', async () => {
+    const claimed = {
+      id: 'command-1',
+      leaseToken: 'lease-1',
+      command: {
+        kind: 'activityAttempt',
+        workflowName: 'wf',
+        activityName: 'act',
+        runId: 'run-1',
+        nodeName: 'node-1',
+        childKey: 'self',
+        attemptId: 'attempt-1',
+        leaseToken: 'lease-1',
+        input: {},
+      },
+    } as unknown as ClaimedAttempt
+
+    let cancelling = false
+    const attemptExecutor = {
+      heartbeat: async () => ({
+        runStatus: cancelling ? 'cancelling' : 'running',
+      }),
+    } as unknown as AttemptExecutor
+
+    let cancellationWake: (() => void) | undefined
+    const work = runWithAttemptHeartbeat(
+      {
+        attemptExecutor,
+        claimed,
+        leaseMs: LONG_DELAY_MS * 3, // heartbeat interval far beyond test timeout
+        wakeEvents: {
+          onCancellation: (runId, listener) => {
+            expect(runId).toBe('run-1')
+            cancellationWake = listener
+            return () => {}
+          },
+        },
+      },
+      () => new Promise<never>(() => {}),
+    )
+
+    expect(cancellationWake).toBeDefined()
+    cancelling = true
+    cancellationWake!()
+    await expect(work).rejects.toThrow('observed cancellation')
+  })
+})

--- a/packages/workflows/tests/runtime-wake-events.spec.ts
+++ b/packages/workflows/tests/runtime-wake-events.spec.ts
@@ -108,4 +108,61 @@ describe('workflow wake events', () => {
     cancellationWake!()
     await expect(work).rejects.toThrow('observed cancellation')
   })
+
+  it('latches a cancellation wake that fires while a heartbeat is in flight', async () => {
+    const claimed = {
+      id: 'command-2',
+      leaseToken: 'lease-2',
+      command: {
+        kind: 'activityAttempt',
+        workflowName: 'wf',
+        activityName: 'act',
+        runId: 'run-2',
+        nodeName: 'node-2',
+        childKey: 'self',
+        attemptId: 'attempt-2',
+        leaseToken: 'lease-2',
+        input: {},
+      },
+    } as unknown as ClaimedAttempt
+
+    const heartbeats: Array<(result: { runStatus: string }) => void> = []
+    const attemptExecutor = {
+      heartbeat: () =>
+        new Promise<{ runStatus: string }>((resolve) => {
+          heartbeats.push(resolve)
+        }),
+    } as unknown as AttemptExecutor
+
+    let cancellationWake: (() => void) | undefined
+    const work = runWithAttemptHeartbeat(
+      {
+        attemptExecutor,
+        claimed,
+        leaseMs: LONG_DELAY_MS * 3,
+        wakeEvents: {
+          onCancellation: (_runId, listener) => {
+            cancellationWake = listener
+            return () => {}
+          },
+        },
+      },
+      () => new Promise<never>(() => {}),
+    )
+
+    // first wake starts a heartbeat whose snapshot predates the cancellation
+    cancellationWake!()
+    expect(heartbeats.length).toBe(1)
+    // cancellation commits and a second wake fires while it is in flight
+    cancellationWake!()
+    expect(heartbeats.length).toBe(1)
+    heartbeats[0]!({ runStatus: 'running' })
+    // the latched wake must trigger a follow-up check without waiting for
+    // the interval
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(heartbeats.length).toBe(2)
+    heartbeats[1]!({ runStatus: 'cancelling' })
+
+    await expect(work).rejects.toThrow('observed cancellation')
+  })
 })


### PR DESCRIPTION
Implements #244.

## What

Layers `LISTEN/NOTIFY` wake-up hints over the existing polling so latency-sensitive workloads no longer need aggressive `pollIntervalMs` / lowered `leaseMs`. Polling stays as the reliability fallback — a missed notification degrades to today's behavior, never to lost work.

### Runtime (adapter-agnostic)

- New optional `WorkflowWakeEvents` port on `WorkflowRuntimeAdapter`: `onCommand(kind, listener)` and `onCancellation(runId, listener)`.
- Worker loop idle sleep races the command wake; a hint arriving while a claim is in flight is latched, not lost.
- Attempt heartbeat subscribes to the cancellation wake and runs the heartbeat check immediately — the DB read stays authoritative, a spurious notification just costs one extra heartbeat query.
- Neem role loop's poll-interval sleep races the wake as well.

### Postgres adapter

- `pg_notify` is embedded in the SQL statements themselves (data-modifying CTEs), so no enqueue path can forget the hint and in-transaction enqueues deliver on commit:
  - continue-command upsert and activity/task dispatch → `workflow_commands` channel, payload = command kind (delayed commands stay poll-only)
  - `requestRunCancellation` status flip → `workflow_run_cancellations` channel, payload = run id
- New `createPostgresWorkflowWakeEvents({ connect })`: one dedicated LISTEN connection per worker process (a connected `pg` `Client` satisfies the interface as-is), best-effort reconnect with backoff, `dispose()` wired through `runtime.dispose()`.
- No schema change, so no manifest/schema version bump.

### Deviation from the issue sketch

Single fixed channels with payload filtering instead of `workflow_commands_<shard>` / `workflow_cancel_<runId>` channels — `LISTEN` is per-connection anyway and a spurious wake costs one cheap claim query, so per-run/per-shard channels add surface without measurable benefit.

## Testing

- 3 new unit tests: loop wake short-circuit, latched mid-claim wake, immediate heartbeat check on cancellation wake.
- 3 new integration tests against real Postgres: NOTIFY fires on enqueue/cancellation; a run dispatches and completes end-to-end while both workers idle on 20s poll intervals; a running activity aborts on cancel with a 60s lease (20s heartbeat cadence) — timings assert the wake path, not the poll fallback.
- Full workflows suite: 370 unit + 15 integration tests pass; repo build, typecheck, and lint clean.