### PR TITLE
workflows: named activity worker pools for capacity isolation

### DIFF
--- a/packages/workflows/src/neem/index.ts
+++ b/packages/workflows/src/neem/index.ts
@@ -1,7 +1,9 @@
 export { createWorkflowsRuntime, defineWorkflowsPlanner } from './planner.ts'
 export { defineWorkflows } from './runtime.ts'
 export type {
+  ResolvedActivityWorkerPool,
   WorkflowsActivityWorkerPoolConfig,
+  WorkflowsNamedActivityWorkerPoolConfig,
   WorkflowsConfig,
   WorkflowsImplementationsFactory,
   WorkflowsRuntimeFactory,

--- a/packages/workflows/src/neem/planner.ts
+++ b/packages/workflows/src/neem/planner.ts
@@ -23,7 +23,15 @@ export function defineWorkflowsPlanner<
           'coordinator',
           config.workers.coordinator,
         ),
-        activity: createWorkerData('activity', config.workers.activity),
+        activity: config.workers.activity.flatMap((pool) =>
+          Array.from(
+            { length: normalizeThreadCount('activity', pool.threads) },
+            (): WorkflowsWorkerData => ({
+              role: 'activity',
+              activityPool: pool.name,
+            }),
+          ),
+        ),
         task:
           config.tasks.length > 0
             ? createWorkerData('task', config.workers.task)

--- a/packages/workflows/src/neem/runtime.ts
+++ b/packages/workflows/src/neem/runtime.ts
@@ -238,11 +238,23 @@ function normalizeActivityWorkerPools(
     }
   }
 
+  // Selectors and implementations resolve from the same config, so an
+  // unknown name is always a typo or a stale entry — with a catch-all it
+  // would silently reroute the real activity there, so fail loudly.
+  const registered = new Set(collectWorkflowActivityNames(workflows))
+  const unknown = [...claimedActivities.keys()].filter(
+    (name) => !registered.has(name),
+  )
+  if (unknown.length > 0) {
+    throw new Error(
+      `Activities [${unknown.join(', ')}] selected by workflows activity worker pools do not exist in the registered workflows`,
+    )
+  }
+
   // Without a catch-all, an activity claimed by no pool would stall its
-  // workflows silently forever — fail loudly at startup instead. A selector
-  // naming an unknown activity stays allowed (deploy skew is harmless).
+  // workflows silently forever — fail loudly at startup instead.
   if (catchAll === undefined) {
-    const uncovered = collectWorkflowActivityNames(workflows).filter(
+    const uncovered = [...registered].filter(
       (name) => !claimedActivities.has(name),
     )
     if (uncovered.length > 0) {

--- a/packages/workflows/src/neem/runtime.ts
+++ b/packages/workflows/src/neem/runtime.ts
@@ -43,9 +43,21 @@ export type WorkflowsActivityWorkerPoolConfig = WorkflowsWorkerPoolConfig & {
   readonly activityNames?: readonly string[]
 }
 
+export type WorkflowsNamedActivityWorkerPoolConfig =
+  WorkflowsActivityWorkerPoolConfig & {
+    readonly name: string
+  }
+
 export type WorkflowsWorkersConfig = {
   readonly coordinator?: WorkflowsWorkerPoolConfig
-  readonly activity?: WorkflowsActivityWorkerPoolConfig
+  /**
+   * Either one shared pool (default) or multiple isolated named pools. With
+   * named pools, each claims only its `activityNames`; at most one pool may
+   * omit `activityNames` to act as the catch-all for unmatched activities.
+   */
+  readonly activity?:
+    | WorkflowsActivityWorkerPoolConfig
+    | readonly WorkflowsNamedActivityWorkerPoolConfig[]
   readonly task?: WorkflowsWorkerPoolConfig
 }
 
@@ -72,16 +84,25 @@ export type ResolvedWorkflowsConfig<
   readonly workflows: readonly TWorkflowImplementation[]
   readonly tasks: readonly TTaskImplementation[]
   readonly schedules: readonly TScheduleDefinition[]
-  readonly workers: Required<{
+  readonly workers: {
     readonly coordinator: Required<WorkflowsWorkerPoolConfig>
-    readonly activity: Required<WorkflowsActivityWorkerPoolConfig>
+    readonly activity: readonly ResolvedActivityWorkerPool[]
     readonly task: Required<WorkflowsWorkerPoolConfig>
-  }>
+  }
+}
+
+export type ResolvedActivityWorkerPool = Required<WorkflowsWorkerPoolConfig> & {
+  readonly name: string
+  readonly activityNames?: readonly string[]
 }
 
 export type WorkflowsWorkerData = {
   readonly role: WorkflowWorkerRole
+  /** Which resolved activity pool this worker serves; activity role only. */
+  readonly activityPool?: string
 }
+
+export const DEFAULT_ACTIVITY_POOL_NAME = 'activity'
 
 const defaultWorkerConfig = {
   threads: 1,
@@ -137,7 +158,7 @@ export async function resolveWorkflowsConfig<
     schedules: (await config.schedules?.()) ?? [],
     workers: {
       coordinator: normalizeWorkerPool(config.workers?.coordinator),
-      activity: normalizeWorkerPool(config.workers?.activity),
+      activity: normalizeActivityWorkerPools(config.workers?.activity),
       task: normalizeWorkerPool(config.workers?.task),
     },
   }
@@ -150,4 +171,72 @@ function normalizeWorkerPool<TConfig extends WorkflowsWorkerPoolConfig>(
     ...defaultWorkerConfig,
     ...config,
   }) as Required<TConfig & WorkflowsWorkerPoolConfig>
+}
+
+function normalizeActivityWorkerPools(
+  config:
+    | WorkflowsActivityWorkerPoolConfig
+    | readonly WorkflowsNamedActivityWorkerPoolConfig[]
+    | undefined,
+): readonly ResolvedActivityWorkerPool[] {
+  if (config === undefined || !Array.isArray(config)) {
+    return [
+      {
+        name: DEFAULT_ACTIVITY_POOL_NAME,
+        ...normalizeWorkerPool(
+          config as WorkflowsActivityWorkerPoolConfig | undefined,
+        ),
+      },
+    ]
+  }
+
+  const pools = config as readonly WorkflowsNamedActivityWorkerPoolConfig[]
+  if (pools.length === 0) {
+    throw new Error('Workflows activity worker pool list must not be empty')
+  }
+
+  const names = new Set<string>()
+  const claimedActivities = new Map<string, string>()
+  let catchAll: string | undefined
+  for (const pool of pools) {
+    if (!pool.name) {
+      throw new Error('Workflows activity worker pool requires a name')
+    }
+    if (names.has(pool.name)) {
+      throw new Error(
+        `Duplicate workflows activity worker pool name [${pool.name}]`,
+      )
+    }
+    names.add(pool.name)
+
+    if (pool.activityNames === undefined) {
+      // two catch-alls would race for the same unmatched activities with
+      // conflicting cadence/lease settings
+      if (catchAll !== undefined) {
+        throw new Error(
+          `Workflows activity worker pools [${catchAll}] and [${pool.name}] both omit activityNames; only one catch-all pool is allowed`,
+        )
+      }
+      catchAll = pool.name
+      continue
+    }
+
+    for (const activityName of pool.activityNames) {
+      const owner = claimedActivities.get(activityName)
+      if (owner !== undefined) {
+        throw new Error(
+          `Activity [${activityName}] is claimed by both workflows worker pools [${owner}] and [${pool.name}]`,
+        )
+      }
+      claimedActivities.set(activityName, pool.name)
+    }
+  }
+
+  return pools.map((pool) => ({
+    ...normalizeWorkerPool(pool),
+    name: pool.name,
+    ...(pool.activityNames === undefined
+      ? {}
+      : { activityNames: pool.activityNames }),
+  }))
 }

--- a/packages/workflows/src/neem/runtime.ts
+++ b/packages/workflows/src/neem/runtime.ts
@@ -4,6 +4,7 @@ import type {
 } from '../implement/index.ts'
 import type { WorkflowRuntimeAdapter } from '../runtime/client.ts'
 import type { AnyScheduleDefinition, MaybePromise } from '../types/index.ts'
+import { collectWorkflowActivityNames } from '../runtime/worker.ts'
 
 export type AnyWorkflowImplementation = Omit<
   WorkflowImplementation,
@@ -151,14 +152,18 @@ export async function resolveWorkflowsConfig<
     TScheduleDefinition
   >
 > {
+  const workflows = await config.workflows()
   return {
     runtime: config.runtime,
-    workflows: await config.workflows(),
+    workflows,
     tasks: (await config.tasks?.()) ?? [],
     schedules: (await config.schedules?.()) ?? [],
     workers: {
       coordinator: normalizeWorkerPool(config.workers?.coordinator),
-      activity: normalizeActivityWorkerPools(config.workers?.activity),
+      activity: normalizeActivityWorkerPools(
+        config.workers?.activity,
+        workflows,
+      ),
       task: normalizeWorkerPool(config.workers?.task),
     },
   }
@@ -178,6 +183,7 @@ function normalizeActivityWorkerPools(
     | WorkflowsActivityWorkerPoolConfig
     | readonly WorkflowsNamedActivityWorkerPoolConfig[]
     | undefined,
+  workflows: readonly AnyWorkflowImplementation[],
 ): readonly ResolvedActivityWorkerPool[] {
   if (config === undefined || !Array.isArray(config)) {
     return [
@@ -229,6 +235,20 @@ function normalizeActivityWorkerPools(
         )
       }
       claimedActivities.set(activityName, pool.name)
+    }
+  }
+
+  // Without a catch-all, an activity claimed by no pool would stall its
+  // workflows silently forever — fail loudly at startup instead. A selector
+  // naming an unknown activity stays allowed (deploy skew is harmless).
+  if (catchAll === undefined) {
+    const uncovered = collectWorkflowActivityNames(workflows).filter(
+      (name) => !claimedActivities.has(name),
+    )
+    if (uncovered.length > 0) {
+      throw new Error(
+        `Activities [${uncovered.join(', ')}] are not claimed by any workflows activity worker pool; add them to a pool or configure a catch-all pool without activityNames`,
+      )
     }
   }
 

--- a/packages/workflows/src/neem/worker-entry.ts
+++ b/packages/workflows/src/neem/worker-entry.ts
@@ -5,11 +5,13 @@ import type { WorkflowRuntimeAdapter } from '../runtime/client.ts'
 import type {
   AnyTaskImplementation,
   AnyWorkflowImplementation,
+  ResolvedActivityWorkerPool,
   ResolvedWorkflowsConfig,
   WorkflowsConfig,
   WorkflowsWorkerData,
 } from './runtime.ts'
 import {
+  collectWorkflowActivityNames,
   runActivityWorker,
   runTaskWorker,
   runWorkflowWorker,
@@ -52,7 +54,7 @@ export function defineWorkflowsWorker<
           }
           workerLoopError = undefined
           workerLoop = runRoleLoop({
-            role: ctx.data.role,
+            data: ctx.data,
             runtime,
             config,
             container,
@@ -92,13 +94,26 @@ const ROLE_WAKE_KIND = {
 } as const
 
 async function runRoleLoop(input: {
-  readonly role: WorkflowsWorkerData['role']
+  readonly data: WorkflowsWorkerData
   readonly runtime: WorkflowRuntimeAdapter
   readonly config: ResolvedWorkflowsConfig
   readonly container: Container
   readonly workerId: string
   readonly signal: AbortSignal
 }): Promise<void> {
+  const role = input.data.role
+  const activityPool =
+    role === 'activity'
+      ? resolveActivityWorkerPool(input.config, input.data)
+      : undefined
+  const activityNames =
+    activityPool === undefined
+      ? undefined
+      : resolveActivityPoolClaimNames(
+          activityPool,
+          input.config.workers.activity,
+          input.config.workflows,
+        )
   // Between loop iterations the poll-interval sleep races the adapter's wake
   // hint (if any), so a fresh command interrupts idle waiting immediately.
   const idleSleep = async (ms: number) => {
@@ -106,7 +121,7 @@ async function runRoleLoop(input: {
     if (!wakeEvents) return sleep(ms, input.signal)
     let unsubscribe = () => {}
     const woken = new Promise<void>((resolve) => {
-      unsubscribe = wakeEvents.onCommand(ROLE_WAKE_KIND[input.role], resolve)
+      unsubscribe = wakeEvents.onCommand(ROLE_WAKE_KIND[role], resolve)
     })
     try {
       await Promise.race([sleep(ms, input.signal), woken])
@@ -116,7 +131,7 @@ async function runRoleLoop(input: {
   }
 
   while (!input.signal.aborted) {
-    switch (input.role) {
+    switch (role) {
       case 'coordinator':
         await runWorkflowWorker({
           ...input.runtime,
@@ -139,15 +154,15 @@ async function runRoleLoop(input: {
           ...input.runtime,
           container: input.container,
           workflows: input.config.workflows,
-          activityNames: input.config.workers.activity.activityNames,
+          activityNames,
           workerId: input.workerId,
-          concurrency: input.config.workers.activity.concurrency,
-          leaseMs: input.config.workers.activity.leaseMs,
-          maxIdleClaims: input.config.workers.activity.maxIdleClaims,
-          idleDelayMs: input.config.workers.activity.pollIntervalMs,
+          concurrency: activityPool!.concurrency,
+          leaseMs: activityPool!.leaseMs,
+          maxIdleClaims: activityPool!.maxIdleClaims,
+          idleDelayMs: activityPool!.pollIntervalMs,
           signal: input.signal,
         })
-        await idleSleep(input.config.workers.activity.pollIntervalMs)
+        await idleSleep(activityPool!.pollIntervalMs)
         continue
 
       case 'task':
@@ -166,6 +181,47 @@ async function runRoleLoop(input: {
         continue
     }
   }
+}
+
+function resolveActivityWorkerPool(
+  config: ResolvedWorkflowsConfig,
+  data: WorkflowsWorkerData,
+): ResolvedActivityWorkerPool {
+  const pools = config.workers.activity
+  if (data.activityPool !== undefined) {
+    const pool = pools.find((candidate) => candidate.name === data.activityPool)
+    if (!pool) {
+      throw new Error(
+        `Unknown workflows activity worker pool [${data.activityPool}]`,
+      )
+    }
+    return pool
+  }
+  // worker data without a pool name (hand-written neem config) is only
+  // unambiguous when a single pool exists
+  if (pools.length === 1) return pools[0]!
+  throw new Error(
+    'Workflows activity worker data must name a pool when multiple activity pools are configured',
+  )
+}
+
+// A catch-all pool must not claim activities selected by sibling pools, or
+// capacity isolation silently breaks; explicit pools claim their list as-is.
+export function resolveActivityPoolClaimNames(
+  pool: ResolvedActivityWorkerPool,
+  pools: readonly ResolvedActivityWorkerPool[],
+  workflows: ResolvedWorkflowsConfig['workflows'],
+): readonly string[] | undefined {
+  if (pool.activityNames !== undefined) return pool.activityNames
+  const claimedElsewhere = new Set(
+    pools.flatMap((sibling) =>
+      sibling.name === pool.name ? [] : (sibling.activityNames ?? []),
+    ),
+  )
+  if (claimedElsewhere.size === 0) return undefined
+  return collectWorkflowActivityNames(workflows).filter(
+    (name) => !claimedElsewhere.has(name),
+  )
 }
 
 async function sleep(ms: number, signal: AbortSignal): Promise<void> {

--- a/packages/workflows/src/runtime/worker.ts
+++ b/packages/workflows/src/runtime/worker.ts
@@ -3,6 +3,7 @@ export {
   type RunActivityAttemptInput,
 } from './worker/activity-attempt.ts'
 export {
+  collectWorkflowActivityNames,
   runActivityWorker,
   runTaskWorker,
   runWorkflowWorker,

--- a/packages/workflows/src/runtime/worker/entry.ts
+++ b/packages/workflows/src/runtime/worker/entry.ts
@@ -293,8 +293,8 @@ export async function runTaskWorker(
   )
 }
 
-function collectWorkflowActivityNames(
-  workflows: readonly AnyWorkflowImplementation[],
+export function collectWorkflowActivityNames(
+  workflows: readonly Pick<AnyWorkflowImplementation, 'nodes'>[],
 ): readonly string[] {
   const names = new Set<string>()
   for (const workflow of workflows) {

--- a/packages/workflows/tests/neem-integration.spec.ts
+++ b/packages/workflows/tests/neem-integration.spec.ts
@@ -165,6 +165,58 @@ describe('workflows Neem integration', () => {
     )
   })
 
+  it('rejects named pools that leave a registered activity uncovered', async () => {
+    const workflowWithActivities = defineWorkflow({
+      name: 'neem.integration.pool-coverage',
+      input: t.object({}),
+      output: t.object({}),
+    })
+      .activity('fast', { input: t.object({}), output: t.object({}) })
+      .activity('slow', { input: t.object({}), output: t.object({}) })
+      .build()
+    const impl = implementWorkflow(workflowWithActivities)
+      .fast(async () => ({}))
+      .slow(async () => ({}))
+      .finish(() => ({}))
+
+    const uncovered = defineWorkflows({
+      runtime: () => createInMemoryWorkflowRuntime(),
+      workflows: () => [impl],
+      workers: {
+        activity: [{ name: 'interactive', activityNames: ['fast'] }],
+      },
+    })
+    await expect(resolveWorkflowsConfig(uncovered)).rejects.toThrow(
+      'Activities [slow] are not claimed by any workflows activity worker pool',
+    )
+
+    // a catch-all pool absorbs the rest — same pools plus catch-all resolves
+    const covered = defineWorkflows({
+      runtime: () => createInMemoryWorkflowRuntime(),
+      workflows: () => [impl],
+      workers: {
+        activity: [
+          { name: 'interactive', activityNames: ['fast'] },
+          { name: 'batch' },
+        ],
+      },
+    })
+    await expect(resolveWorkflowsConfig(covered)).resolves.toBeDefined()
+
+    // full explicit coverage needs no catch-all
+    const explicit = defineWorkflows({
+      runtime: () => createInMemoryWorkflowRuntime(),
+      workflows: () => [impl],
+      workers: {
+        activity: [
+          { name: 'interactive', activityNames: ['fast'] },
+          { name: 'heavy', activityNames: ['slow', 'not-registered'] },
+        ],
+      },
+    })
+    await expect(resolveWorkflowsConfig(explicit)).resolves.toBeDefined()
+  })
+
   it('computes catch-all pool claim names as the complement of named pools', async () => {
     const config = defineWorkflows({
       runtime: () => createInMemoryWorkflowRuntime(),

--- a/packages/workflows/tests/neem-integration.spec.ts
+++ b/packages/workflows/tests/neem-integration.spec.ts
@@ -22,7 +22,10 @@ import {
   defineWorkflows,
   defineWorkflowsPlanner,
   defineWorkflowsWorker,
+  type WorkflowsNamedActivityWorkerPoolConfig,
 } from '../src/neem/index.ts'
+import { resolveWorkflowsConfig } from '../src/neem/runtime.ts'
+import { resolveActivityPoolClaimNames } from '../src/neem/worker-entry.ts'
 import {
   createInMemoryWorkflowRuntime,
   createWorkflowRuntimeClient,
@@ -73,9 +76,150 @@ describe('workflows Neem integration', () => {
     expect(plan.options).toBeDefined()
     expect(plan.workers).toStrictEqual({
       coordinator: [{ role: 'coordinator' }, { role: 'coordinator' }],
-      activity: [{ role: 'activity' }],
+      activity: [{ role: 'activity', activityPool: 'activity' }],
       task: [],
     })
+  })
+
+  it('plans one worker group per named activity pool', async () => {
+    const config = defineWorkflows({
+      runtime: () => createInMemoryWorkflowRuntime(),
+      workflows: () => [workflowImpl],
+      workers: {
+        activity: [
+          {
+            name: 'interactive',
+            activityNames: ['handle-user-request'],
+            threads: 2,
+            concurrency: 20,
+            pollIntervalMs: 25,
+            leaseMs: 6_000,
+          },
+          { name: 'batch', threads: 1, concurrency: 50 },
+        ],
+      },
+    })
+    const planner = defineWorkflowsPlanner(() => config)
+    const plan = await planner({
+      mode: 'development',
+      name: 'workflows',
+      logger,
+    })
+
+    expect(plan.workers).toStrictEqual({
+      coordinator: [{ role: 'coordinator' }],
+      activity: [
+        { role: 'activity', activityPool: 'interactive' },
+        { role: 'activity', activityPool: 'interactive' },
+        { role: 'activity', activityPool: 'batch' },
+      ],
+      task: [],
+    })
+
+    const resolved = await resolveWorkflowsConfig(config)
+    expect(resolved.workers.activity).toMatchObject([
+      {
+        name: 'interactive',
+        activityNames: ['handle-user-request'],
+        concurrency: 20,
+        pollIntervalMs: 25,
+        leaseMs: 6_000,
+      },
+      { name: 'batch', concurrency: 50, pollIntervalMs: 250 },
+    ])
+    expect(resolved.workers.activity[1]!.activityNames).toBeUndefined()
+  })
+
+  it('rejects invalid activity pool lists', async () => {
+    const reject = async (
+      activity: readonly WorkflowsNamedActivityWorkerPoolConfig[],
+      message: string,
+    ) => {
+      const config = defineWorkflows({
+        runtime: () => createInMemoryWorkflowRuntime(),
+        workflows: () => [workflowImpl],
+        workers: { activity },
+      })
+      await expect(resolveWorkflowsConfig(config)).rejects.toThrow(message)
+    }
+
+    await reject([], 'must not be empty')
+    await reject([{ name: '', activityNames: ['a'] }], 'requires a name')
+    await reject(
+      [
+        { name: 'one', activityNames: ['a'] },
+        { name: 'one', activityNames: ['b'] },
+      ],
+      'Duplicate workflows activity worker pool name [one]',
+    )
+    await reject(
+      [{ name: 'one' }, { name: 'two' }],
+      'only one catch-all pool is allowed',
+    )
+    await reject(
+      [
+        { name: 'one', activityNames: ['a'] },
+        { name: 'two', activityNames: ['a'] },
+      ],
+      'Activity [a] is claimed by both workflows worker pools [one] and [two]',
+    )
+  })
+
+  it('computes catch-all pool claim names as the complement of named pools', async () => {
+    const config = defineWorkflows({
+      runtime: () => createInMemoryWorkflowRuntime(),
+      workflows: () => [],
+      workers: {
+        activity: [
+          { name: 'interactive', activityNames: ['fast'] },
+          { name: 'batch' },
+        ],
+      },
+    })
+    const resolved = await resolveWorkflowsConfig(config)
+    const [interactive, batch] = resolved.workers.activity
+    const workflows = [
+      { nodes: [] },
+    ] as unknown as (typeof resolved)['workflows']
+    const collected = [
+      {
+        nodes: [
+          { kind: 'activity', activity: { name: 'fast' } },
+          { kind: 'activity', activity: { name: 'slow' } },
+          { kind: 'activity', activity: { name: 'bulk' } },
+        ],
+      },
+    ] as unknown as (typeof resolved)['workflows']
+
+    expect(
+      resolveActivityPoolClaimNames(
+        interactive!,
+        resolved.workers.activity,
+        collected,
+      ),
+    ).toStrictEqual(['fast'])
+    expect(
+      resolveActivityPoolClaimNames(
+        batch!,
+        resolved.workers.activity,
+        collected,
+      ),
+    ).toStrictEqual(['slow', 'bulk'])
+
+    // a single catch-all pool claims everything (undefined = no filter)
+    const soloConfig = defineWorkflows({
+      runtime: () => createInMemoryWorkflowRuntime(),
+      workflows: () => [],
+      workers: { activity: [{ name: 'only' }] },
+    })
+    const solo = await resolveWorkflowsConfig(soloConfig)
+    expect(
+      resolveActivityPoolClaimNames(
+        solo.workers.activity[0]!,
+        solo.workers.activity,
+        workflows,
+      ),
+    ).toBeUndefined()
   })
 
   it('accepts task implementations with typed dependencies', async () => {

--- a/packages/workflows/tests/neem-integration.spec.ts
+++ b/packages/workflows/tests/neem-integration.spec.ts
@@ -82,14 +82,27 @@ describe('workflows Neem integration', () => {
   })
 
   it('plans one worker group per named activity pool', async () => {
+    const pooledWorkflow = defineWorkflow({
+      name: 'neem.integration.pooled',
+      input: t.object({}),
+      output: t.object({}),
+    })
+      .activity('handleUserRequest', {
+        input: t.object({}),
+        output: t.object({}),
+      })
+      .build()
+    const pooledImpl = implementWorkflow(pooledWorkflow)
+      .handleUserRequest(async () => ({}))
+      .finish(() => ({}))
     const config = defineWorkflows({
       runtime: () => createInMemoryWorkflowRuntime(),
-      workflows: () => [workflowImpl],
+      workflows: () => [pooledImpl],
       workers: {
         activity: [
           {
             name: 'interactive',
-            activityNames: ['handle-user-request'],
+            activityNames: ['handleUserRequest'],
             threads: 2,
             concurrency: 20,
             pollIntervalMs: 25,
@@ -120,7 +133,7 @@ describe('workflows Neem integration', () => {
     expect(resolved.workers.activity).toMatchObject([
       {
         name: 'interactive',
-        activityNames: ['handle-user-request'],
+        activityNames: ['handleUserRequest'],
         concurrency: 20,
         pollIntervalMs: 25,
         leaseMs: 6_000,
@@ -210,17 +223,48 @@ describe('workflows Neem integration', () => {
       workers: {
         activity: [
           { name: 'interactive', activityNames: ['fast'] },
-          { name: 'heavy', activityNames: ['slow', 'not-registered'] },
+          { name: 'heavy', activityNames: ['slow'] },
         ],
       },
     })
     await expect(resolveWorkflowsConfig(explicit)).resolves.toBeDefined()
+
+    // a selector naming an unknown activity is always a config bug: with a
+    // catch-all it would silently reroute the real activity there
+    const typo = defineWorkflows({
+      runtime: () => createInMemoryWorkflowRuntime(),
+      workflows: () => [impl],
+      workers: {
+        activity: [
+          { name: 'interactive', activityNames: ['fastt'] },
+          { name: 'batch' },
+        ],
+      },
+    })
+    await expect(resolveWorkflowsConfig(typo)).rejects.toThrow(
+      'Activities [fastt] selected by workflows activity worker pools do not exist in the registered workflows',
+    )
   })
 
   it('computes catch-all pool claim names as the complement of named pools', async () => {
+    const workflowWithActivities = defineWorkflow({
+      name: 'neem.integration.pool-complement',
+      input: t.object({}),
+      output: t.object({}),
+    })
+      .activity('fast', { input: t.object({}), output: t.object({}) })
+      .activity('slow', { input: t.object({}), output: t.object({}) })
+      .activity('bulk', { input: t.object({}), output: t.object({}) })
+      .build()
+    const impl = implementWorkflow(workflowWithActivities)
+      .fast(async () => ({}))
+      .slow(async () => ({}))
+      .bulk(async () => ({}))
+      .finish(() => ({}))
+
     const config = defineWorkflows({
       runtime: () => createInMemoryWorkflowRuntime(),
-      workflows: () => [],
+      workflows: () => [impl],
       workers: {
         activity: [
           { name: 'interactive', activityNames: ['fast'] },
@@ -230,38 +274,26 @@ describe('workflows Neem integration', () => {
     })
     const resolved = await resolveWorkflowsConfig(config)
     const [interactive, batch] = resolved.workers.activity
-    const workflows = [
-      { nodes: [] },
-    ] as unknown as (typeof resolved)['workflows']
-    const collected = [
-      {
-        nodes: [
-          { kind: 'activity', activity: { name: 'fast' } },
-          { kind: 'activity', activity: { name: 'slow' } },
-          { kind: 'activity', activity: { name: 'bulk' } },
-        ],
-      },
-    ] as unknown as (typeof resolved)['workflows']
 
     expect(
       resolveActivityPoolClaimNames(
         interactive!,
         resolved.workers.activity,
-        collected,
+        resolved.workflows,
       ),
     ).toStrictEqual(['fast'])
     expect(
       resolveActivityPoolClaimNames(
         batch!,
         resolved.workers.activity,
-        collected,
+        resolved.workflows,
       ),
     ).toStrictEqual(['slow', 'bulk'])
 
     // a single catch-all pool claims everything (undefined = no filter)
     const soloConfig = defineWorkflows({
       runtime: () => createInMemoryWorkflowRuntime(),
-      workflows: () => [],
+      workflows: () => [impl],
       workers: { activity: [{ name: 'only' }] },
     })
     const solo = await resolveWorkflowsConfig(soloConfig)
@@ -269,7 +301,7 @@ describe('workflows Neem integration', () => {
       resolveActivityPoolClaimNames(
         solo.workers.activity[0]!,
         solo.workers.activity,
-        workflows,
+        solo.workflows,
       ),
     ).toBeUndefined()
   })

--- a/skills/use-neemata/references/workflows.md
+++ b/skills/use-neemata/references/workflows.md
@@ -233,7 +233,10 @@ workers: {
 ```
 
 Pool names must be unique, an activity name may be claimed by at most one
-pool, and only one catch-all (no `activityNames`) pool is allowed. Without a
-catch-all, every activity of the registered workflows must be covered by some
-pool's `activityNames` — an uncovered activity fails config resolution instead
-of silently never being claimed.
+pool, and only one catch-all (no `activityNames`) pool is allowed. Selection
+is validated against the registered workflows at config resolution: an
+`activityNames` entry that matches no registered activity fails resolution
+(it is always a typo or stale entry, and with a catch-all it would silently
+reroute the real activity there), and without a catch-all every registered
+activity must be covered by some pool's `activityNames` — an uncovered
+activity fails resolution instead of silently never being claimed.

--- a/skills/use-neemata/references/workflows.md
+++ b/skills/use-neemata/references/workflows.md
@@ -233,4 +233,7 @@ workers: {
 ```
 
 Pool names must be unique, an activity name may be claimed by at most one
-pool, and only one catch-all (no `activityNames`) pool is allowed.
+pool, and only one catch-all (no `activityNames`) pool is allowed. Without a
+catch-all, every activity of the registered workflows must be covered by some
+pool's `activityNames` — an uncovered activity fails config resolution instead
+of silently never being claimed.

--- a/skills/use-neemata/references/workflows.md
+++ b/skills/use-neemata/references/workflows.md
@@ -209,3 +209,28 @@ Worker pool options: `threads`, `concurrency`, `leaseMs`, `pollIntervalMs`,
 pin a pool to specific activities. The task pool only spawns when task
 implementations exist. Worker shutdown aborts in-flight handlers with reason
 `shutdown` and releases their commands for redelivery.
+
+`activity` also accepts an array of named pools for capacity isolation —
+latency-sensitive activities get their own claim loop, cadence, and lease
+instead of queueing behind long-running batch attempts:
+
+```ts
+workers: {
+  activity: [
+    {
+      name: 'interactive',
+      activityNames: ['handle-user-request'],
+      threads: 1,
+      concurrency: 20,
+      pollIntervalMs: 25,
+      leaseMs: 6_000,
+    },
+    // at most one pool may omit activityNames: it claims every activity
+    // not selected by a named pool
+    { name: 'batch', threads: 1, concurrency: 50 },
+  ],
+}
+```
+
+Pool names must be unique, an activity name may be claimed by at most one
+pool, and only one catch-all (no `activityNames`) pool is allowed.


### PR DESCRIPTION
Implements #245.

## What

`workers.activity` in the neem workflows config now accepts either the existing single pool (unchanged) or an array of named pools:

```ts
workers: {
  coordinator: { threads: 1, concurrency: 10 },
  activity: [
    {
      name: 'interactive',
      activityNames: ['handle-user-request'],
      threads: 1,
      concurrency: 20,
      pollIntervalMs: 25,
      leaseMs: 6_000,
    },
    // catch-all: claims every activity not selected by a named pool
    { name: 'batch', threads: 1, concurrency: 50 },
  ],
  task: { threads: 1, concurrency: 50 },
}
```

### Behavior

- **Capacity isolation**: the planner emits one worker group per pool (`threads` each, carrying `activityPool` in the worker data), so each pool runs its own claim loop — a saturated batch pool cannot delay interactive claims.
- **Per-pool cadence**: `pollIntervalMs`, `leaseMs`, `concurrency`, `maxIdleClaims` apply per pool; fast polling and short leases are paid only where latency matters.
- **Claim-side filtering**: explicit pools claim their `activityNames` as-is (existing `runActivityWorker` filter, no schema changes). The catch-all pool claims the complement — all activity names collected from the registered workflow implementations minus every sibling pool's selection — so isolation can't silently break by double-claiming.
- **Validation at resolve time**: non-empty pool list, unique non-empty names, an activity name claimed by at most one pool, and at most one catch-all pool.
- An activity name in a selector that matches nothing is not an error (tolerates deploy skew); an activity not matched by any selector is served by the catch-all.

### Backward compatibility

The single-pool shape (including its `activityNames` option) resolves to one pool named `activity`; hand-written worker data without a pool name keeps working when exactly one pool is configured, and errors clearly when several are.

## Testing

- New unit tests: planner emits per-pool worker groups; resolution normalizes and validates pool lists (empty list, missing/duplicate names, overlapping selectors, multiple catch-alls); catch-all claim names computed as the complement of sibling selections.
- Existing suite: 374 unit + 15 integration tests pass; repo build, typecheck, format, and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring activity workers as multiple named pools, including a catch-all option.
  * Activity workers can now be routed to a specific pool, with separate polling and lease settings per pool.
  * Expanded public workflow worker utilities and type exports for activity name collection and pool configuration.

* **Bug Fixes**
  * Added validation to reject invalid pool setups, duplicate names, overlapping activity claims, and uncovered activities.
  * Improved worker assignment so activity groups now reflect their configured pool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->