### PR TITLE
workflows: inspector foundation — graph serialization, catalog, wire-safe DTOs

### DIFF
--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -13,6 +13,11 @@
       "import": "./dist/runtime/index.js",
       "module-sync": "./dist/runtime/index.js"
     },
+    "./inspector": {
+      "types": "./src/inspector/index.ts",
+      "import": "./dist/inspector/index.js",
+      "module-sync": "./dist/inspector/index.js"
+    },
     "./postgres": {
       "types": "./src/adapters/postgres.ts",
       "import": "./dist/adapters/postgres.js",
@@ -55,6 +60,11 @@
         "types": "./dist/runtime/index.d.ts",
         "import": "./dist/runtime/index.js",
         "module-sync": "./dist/runtime/index.js"
+      },
+      "./inspector": {
+        "types": "./dist/inspector/index.d.ts",
+        "import": "./dist/inspector/index.js",
+        "module-sync": "./dist/inspector/index.js"
       },
       "./postgres": {
         "types": "./dist/adapters/postgres.d.ts",

--- a/packages/workflows/src/inspector/index.ts
+++ b/packages/workflows/src/inspector/index.ts
@@ -138,7 +138,11 @@ export function serializeWorkflowCatalog(input: {
 
 /**
  * Wire-safe counterpart of a stored type: `Date` fields become ISO-8601
- * strings so the value survives JSON transport unchanged.
+ * strings so the value survives JSON transport unchanged. Applies to the
+ * envelope only — payload fields (`input`/`output`/`item`/`error` contents)
+ * are stored JSON values passed through untouched; encoding payload `Date`s
+ * is the schema layer's concern, and persisted payloads have already been
+ * through JSON in any real adapter.
  */
 export type WireSafe<T> = {
   [K in keyof T]: T[K] extends Date
@@ -146,6 +150,25 @@ export type WireSafe<T> = {
     : T[K] extends Date | undefined
       ? string | undefined
       : T[K]
+}
+
+type DateKeys<T> = {
+  [K in keyof T]-?: NonNullable<T[K]> extends Date ? K : never
+}[keyof T]
+
+// Requiring every Date key at the type level makes adding a Date field to a
+// stored type a compile error here instead of a silent Date leaking through
+// a DTO typed as string.
+function convertDates<T extends object>(
+  value: T,
+  dateKeys: Record<DateKeys<T>, true>,
+): WireSafe<T> {
+  const next = { ...value } as Record<string, unknown>
+  for (const key of Object.keys(dateKeys)) {
+    const current = next[key]
+    if (current instanceof Date) next[key] = current.toISOString()
+  }
+  return next as WireSafe<T>
 }
 
 export type RunDto = WireSafe<StoredRun>
@@ -161,36 +184,23 @@ export type RunSnapshotDto = {
 }
 
 export function toRunDto(run: StoredRun): RunDto {
-  return {
-    ...run,
-    createdAt: run.createdAt.toISOString(),
-    updatedAt: run.updatedAt.toISOString(),
-  }
+  return convertDates(run, { createdAt: true, updatedAt: true })
 }
 
 export function toNodeDto(node: StoredNode): NodeDto {
-  return {
-    ...node,
-    createdAt: node.createdAt.toISOString(),
-    updatedAt: node.updatedAt.toISOString(),
-  }
+  return convertDates(node, { createdAt: true, updatedAt: true })
 }
 
 export function toNodeChildDto(child: StoredNodeChild): NodeChildDto {
-  return {
-    ...child,
-    createdAt: child.createdAt.toISOString(),
-    updatedAt: child.updatedAt.toISOString(),
-  }
+  return convertDates(child, { createdAt: true, updatedAt: true })
 }
 
 export function toAttemptDto(attempt: StoredAttempt): AttemptDto {
-  return {
-    ...attempt,
-    dispatchedAt: attempt.dispatchedAt.toISOString(),
-    heartbeatAt: attempt.heartbeatAt?.toISOString(),
-    completedAt: attempt.completedAt?.toISOString(),
-  }
+  return convertDates(attempt, {
+    dispatchedAt: true,
+    heartbeatAt: true,
+    completedAt: true,
+  })
 }
 
 export function toRunSnapshotDto(snapshot: RunSnapshot): RunSnapshotDto {

--- a/packages/workflows/src/inspector/index.ts
+++ b/packages/workflows/src/inspector/index.ts
@@ -1,0 +1,203 @@
+import type {
+  RunSnapshot,
+  StoredAttempt,
+  StoredNode,
+  StoredNodeChild,
+  StoredRun,
+} from '../runtime/state.ts'
+import type {
+  AnyTaskDefinition,
+  AnyWorkflowDefinition,
+  BranchCaseKind,
+  MapRunMode,
+  WorkflowNodeKind,
+} from '../types/index.ts'
+
+/**
+ * Canonical JSON shape of a workflow definition's topology. Stable by
+ * design: it doubles as the per-run definition-snapshot format, so UIs can
+ * render historical runs against the graph they actually executed.
+ */
+export type WorkflowGraph = {
+  readonly name: string
+  readonly nodes: readonly WorkflowGraphNode[]
+}
+
+export type WorkflowGraphNode = {
+  readonly name: string
+  readonly kind: WorkflowNodeKind
+  /** Referenced task/workflow for task, workflow, mapTask and mapWorkflow nodes. */
+  readonly target?: WorkflowGraphTarget
+  /** Branch and parallel members, in definition order. */
+  readonly cases?: readonly WorkflowGraphCase[]
+  /** Fan-out completion mode for mapTask and mapWorkflow nodes. */
+  readonly mode?: MapRunMode
+}
+
+export type WorkflowGraphTarget = {
+  readonly kind: 'task' | 'workflow'
+  readonly name: string
+}
+
+export type WorkflowGraphCase = {
+  readonly key: string
+  readonly kind: BranchCaseKind
+  /** Absent for inline activity cases — they have no named target. */
+  readonly target?: WorkflowGraphTarget
+}
+
+export function serializeWorkflowGraph(
+  definition: AnyWorkflowDefinition,
+): WorkflowGraph {
+  return {
+    name: definition.name,
+    nodes: definition.nodes.map((node): WorkflowGraphNode => {
+      switch (node.kind) {
+        case 'activity':
+          return { name: node.name, kind: node.kind }
+        case 'task':
+          return {
+            name: node.name,
+            kind: node.kind,
+            target: { kind: 'task', name: node.task.name },
+          }
+        case 'workflow':
+          return {
+            name: node.name,
+            kind: node.kind,
+            target: { kind: 'workflow', name: node.workflow.name },
+          }
+        case 'branch':
+        case 'parallel':
+          return {
+            name: node.name,
+            kind: node.kind,
+            cases: Object.entries(node.cases).map(
+              ([key, branchCase]): WorkflowGraphCase =>
+                branchCase.kind === 'activity'
+                  ? { key, kind: branchCase.kind }
+                  : {
+                      key,
+                      kind: branchCase.kind,
+                      target: {
+                        kind: branchCase.kind,
+                        // BranchCaseDefinition's conditional payload doesn't
+                        // narrow on `kind` at the union default, so the cast
+                        // lives here once instead of in every consumer.
+                        name: (
+                          branchCase as unknown as {
+                            target: AnyTaskDefinition | AnyWorkflowDefinition
+                          }
+                        ).target.name,
+                      },
+                    },
+            ),
+          }
+        case 'mapTask':
+          return {
+            name: node.name,
+            kind: node.kind,
+            target: { kind: 'task', name: node.task.name },
+            mode: node.mode,
+          }
+        case 'mapWorkflow':
+          return {
+            name: node.name,
+            kind: node.kind,
+            target: { kind: 'workflow', name: node.workflow.name },
+            mode: node.mode,
+          }
+      }
+    }),
+  }
+}
+
+export type WorkflowCatalog = {
+  readonly workflows: readonly WorkflowGraph[]
+  readonly tasks: readonly WorkflowCatalogTask[]
+}
+
+export type WorkflowCatalogTask = {
+  readonly name: string
+}
+
+/**
+ * "What exists and what does it look like" for a set of definitions. Takes
+ * plain definitions so any holder of them (app code, a runtime registry) can
+ * produce the catalog without coupling to runtime internals.
+ */
+export function serializeWorkflowCatalog(input: {
+  readonly workflows?: Iterable<AnyWorkflowDefinition>
+  readonly tasks?: Iterable<AnyTaskDefinition>
+}): WorkflowCatalog {
+  return {
+    workflows: Array.from(input.workflows ?? [], serializeWorkflowGraph),
+    tasks: Array.from(input.tasks ?? [], (task) => ({ name: task.name })),
+  }
+}
+
+/**
+ * Wire-safe counterpart of a stored type: `Date` fields become ISO-8601
+ * strings so the value survives JSON transport unchanged.
+ */
+export type WireSafe<T> = {
+  [K in keyof T]: T[K] extends Date
+    ? string
+    : T[K] extends Date | undefined
+      ? string | undefined
+      : T[K]
+}
+
+export type RunDto = WireSafe<StoredRun>
+export type NodeDto = WireSafe<StoredNode>
+export type NodeChildDto = WireSafe<StoredNodeChild>
+export type AttemptDto = WireSafe<StoredAttempt>
+
+export type RunSnapshotDto = {
+  readonly run: RunDto
+  readonly nodes: readonly NodeDto[]
+  readonly children: readonly NodeChildDto[]
+  readonly attempts: readonly AttemptDto[]
+}
+
+export function toRunDto(run: StoredRun): RunDto {
+  return {
+    ...run,
+    createdAt: run.createdAt.toISOString(),
+    updatedAt: run.updatedAt.toISOString(),
+  }
+}
+
+export function toNodeDto(node: StoredNode): NodeDto {
+  return {
+    ...node,
+    createdAt: node.createdAt.toISOString(),
+    updatedAt: node.updatedAt.toISOString(),
+  }
+}
+
+export function toNodeChildDto(child: StoredNodeChild): NodeChildDto {
+  return {
+    ...child,
+    createdAt: child.createdAt.toISOString(),
+    updatedAt: child.updatedAt.toISOString(),
+  }
+}
+
+export function toAttemptDto(attempt: StoredAttempt): AttemptDto {
+  return {
+    ...attempt,
+    dispatchedAt: attempt.dispatchedAt.toISOString(),
+    heartbeatAt: attempt.heartbeatAt?.toISOString(),
+    completedAt: attempt.completedAt?.toISOString(),
+  }
+}
+
+export function toRunSnapshotDto(snapshot: RunSnapshot): RunSnapshotDto {
+  return {
+    run: toRunDto(snapshot.run),
+    nodes: snapshot.nodes.map(toNodeDto),
+    children: snapshot.children.map(toNodeChildDto),
+    attempts: snapshot.attempts.map(toAttemptDto),
+  }
+}

--- a/packages/workflows/tests/inspector.spec.ts
+++ b/packages/workflows/tests/inspector.spec.ts
@@ -1,0 +1,235 @@
+import { t } from '@nmtjs/type'
+import { describe, expect, it } from 'vitest'
+
+import type { RunSnapshot, StoredAttempt } from '../src/runtime/state.ts'
+import { defineTask, defineWorkflow } from '../src/index.ts'
+import {
+  serializeWorkflowCatalog,
+  serializeWorkflowGraph,
+  toAttemptDto,
+  toRunSnapshotDto,
+} from '../src/inspector/index.ts'
+
+const scoreTask = defineTask({
+  name: 'score',
+  input: t.object({ text: t.string() }),
+  output: t.object({ score: t.number() }),
+})
+
+const childWorkflow = defineWorkflow({
+  name: 'child',
+  input: t.object({ text: t.string() }),
+  output: t.object({ text: t.string() }),
+}).build()
+
+const workflow = defineWorkflow({
+  name: 'everything',
+  input: t.object({ text: t.string() }),
+  output: t.object({ text: t.string() }),
+})
+  .activity('extract', {
+    input: t.object({ text: t.string() }),
+    output: t.object({ text: t.string() }),
+  })
+  .task('scoring', scoreTask)
+  .workflow('enrich', childWorkflow)
+  .branch('route', {
+    output: t.object({ text: t.string() }),
+    cases: (helpers) => ({
+      inline: helpers.activity({
+        input: t.object({ text: t.string() }),
+        output: t.object({ text: t.string() }),
+      }),
+      delegated: helpers.workflow(childWorkflow),
+    }),
+  })
+  .parallel('fanout', (helpers) => ({
+    scored: helpers.task(scoreTask),
+    enriched: helpers.workflow(childWorkflow),
+  }))
+  .mapTask('scoreAll', scoreTask, {
+    item: t.object({ text: t.string() }),
+    mode: 'wait-all',
+  })
+  .mapWorkflow('enrichAll', childWorkflow, {
+    item: t.object({ text: t.string() }),
+    mode: 'wait-settled',
+  })
+  .build()
+
+describe('serializeWorkflowGraph', () => {
+  it('serializes every node kind to the stable JSON shape', () => {
+    expect(serializeWorkflowGraph(workflow)).toEqual({
+      name: 'everything',
+      nodes: [
+        { name: 'extract', kind: 'activity' },
+        {
+          name: 'scoring',
+          kind: 'task',
+          target: { kind: 'task', name: 'score' },
+        },
+        {
+          name: 'enrich',
+          kind: 'workflow',
+          target: { kind: 'workflow', name: 'child' },
+        },
+        {
+          name: 'route',
+          kind: 'branch',
+          cases: [
+            { key: 'inline', kind: 'activity' },
+            {
+              key: 'delegated',
+              kind: 'workflow',
+              target: { kind: 'workflow', name: 'child' },
+            },
+          ],
+        },
+        {
+          name: 'fanout',
+          kind: 'parallel',
+          cases: [
+            {
+              key: 'scored',
+              kind: 'task',
+              target: { kind: 'task', name: 'score' },
+            },
+            {
+              key: 'enriched',
+              kind: 'workflow',
+              target: { kind: 'workflow', name: 'child' },
+            },
+          ],
+        },
+        {
+          name: 'scoreAll',
+          kind: 'mapTask',
+          target: { kind: 'task', name: 'score' },
+          mode: 'wait-all',
+        },
+        {
+          name: 'enrichAll',
+          kind: 'mapWorkflow',
+          target: { kind: 'workflow', name: 'child' },
+          mode: 'wait-settled',
+        },
+      ],
+    })
+  })
+
+  it('survives JSON transport unchanged', () => {
+    const graph = serializeWorkflowGraph(workflow)
+    expect(JSON.parse(JSON.stringify(graph))).toEqual(graph)
+  })
+})
+
+describe('serializeWorkflowCatalog', () => {
+  it('lists definitions with their graphs', () => {
+    const catalog = serializeWorkflowCatalog({
+      workflows: [workflow, childWorkflow],
+      tasks: [scoreTask],
+    })
+
+    expect(catalog.workflows.map((graph) => graph.name)).toEqual([
+      'everything',
+      'child',
+    ])
+    expect(catalog.workflows[0]).toEqual(serializeWorkflowGraph(workflow))
+    expect(catalog.tasks).toEqual([{ name: 'score' }])
+  })
+
+  it('defaults missing inputs to empty lists', () => {
+    expect(serializeWorkflowCatalog({})).toEqual({ workflows: [], tasks: [] })
+  })
+})
+
+describe('snapshot DTO mappers', () => {
+  const createdAt = new Date('2026-07-08T10:00:00.000Z')
+  const updatedAt = new Date('2026-07-08T10:00:01.000Z')
+
+  const snapshot: RunSnapshot = {
+    run: {
+      id: 'run-1',
+      kind: 'workflow',
+      name: 'everything',
+      workflowName: 'everything',
+      status: 'running',
+      input: { text: 'hi' },
+      rootRunId: 'run-1',
+      tags: { env: 'test' },
+      version: 3,
+      createdAt,
+      updatedAt,
+    },
+    nodes: [
+      {
+        runId: 'run-1',
+        name: 'extract',
+        kind: 'activity',
+        status: 'completed',
+        output: { text: 'hi' },
+        version: 2,
+        createdAt,
+        updatedAt,
+      },
+    ],
+    children: [
+      {
+        runId: 'run-1',
+        nodeName: 'extract',
+        childKey: '$self',
+        kind: 'activity',
+        status: 'completed',
+        ordinal: 0,
+        output: { text: 'hi' },
+        attemptCount: 1,
+        version: 2,
+        createdAt,
+        updatedAt,
+      },
+    ],
+    attempts: [
+      {
+        id: 'attempt-1',
+        runId: 'run-1',
+        nodeName: 'extract',
+        childKey: '$self',
+        status: 'completed',
+        attemptNumber: 1,
+        input: { text: 'hi' },
+        output: { text: 'hi' },
+        dispatchedAt: createdAt,
+        completedAt: updatedAt,
+      },
+    ],
+  }
+
+  it('converts every Date to an ISO string and round-trips through JSON', () => {
+    const dto = toRunSnapshotDto(snapshot)
+
+    expect(dto.run.createdAt).toBe('2026-07-08T10:00:00.000Z')
+    expect(dto.nodes[0].updatedAt).toBe('2026-07-08T10:00:01.000Z')
+    expect(dto.children[0].createdAt).toBe('2026-07-08T10:00:00.000Z')
+    expect(dto.attempts[0].dispatchedAt).toBe('2026-07-08T10:00:00.000Z')
+    expect(dto.attempts[0].completedAt).toBe('2026-07-08T10:00:01.000Z')
+    expect(JSON.parse(JSON.stringify(dto))).toEqual(dto)
+  })
+
+  it('keeps optional attempt timestamps optional', () => {
+    const attempt: StoredAttempt = {
+      id: 'attempt-2',
+      runId: 'run-1',
+      nodeName: 'extract',
+      childKey: '$self',
+      status: 'started',
+      attemptNumber: 1,
+      input: { text: 'hi' },
+      dispatchedAt: createdAt,
+      heartbeatAt: updatedAt,
+    }
+
+    const dto = toAttemptDto(attempt)
+    expect(dto.heartbeatAt).toBe('2026-07-08T10:00:01.000Z')
+    expect(dto.completedAt).toBeUndefined()
+  })
+})

--- a/packages/workflows/tests/inspector.spec.ts
+++ b/packages/workflows/tests/inspector.spec.ts
@@ -232,4 +232,28 @@ describe('snapshot DTO mappers', () => {
     expect(dto.heartbeatAt).toBe('2026-07-08T10:00:01.000Z')
     expect(dto.completedAt).toBeUndefined()
   })
+
+  it('passes stored errors through untouched', () => {
+    const attempt: StoredAttempt = {
+      id: 'attempt-3',
+      runId: 'run-1',
+      nodeName: 'extract',
+      childKey: '$self',
+      status: 'failed',
+      attemptNumber: 2,
+      input: { text: 'hi' },
+      error: {
+        name: 'Error',
+        message: 'boom',
+        stack: 'Error: boom',
+        cause: { message: 'root cause' },
+      },
+      dispatchedAt: createdAt,
+      completedAt: updatedAt,
+    }
+
+    const dto = toAttemptDto(attempt)
+    expect(dto.error).toEqual(attempt.error)
+    expect(JSON.parse(JSON.stringify(dto))).toEqual(dto)
+  })
 })


### PR DESCRIPTION
Closes #248. First step of #242.

New `@nmtjs/workflows/inspector` export — pure, additive, no store or adapter changes.

## What's in

- **`serializeWorkflowGraph(definition)`** — canonical, stable JSON shape of a workflow's topology (`WorkflowGraph`). Covers all seven node kinds: plain nodes carry a `target` ref where one exists, branch/parallel carry `cases` in definition order, map nodes carry `target` + `mode`. The `BranchCaseDefinition` payload doesn't narrow on `kind` at the union default, so the one required cast lives inside the serializer instead of in every consumer.
- **`serializeWorkflowCatalog({workflows, tasks})`** — "what exists and what does it look like" over plain definitions. Takes iterables of definitions rather than the runtime registry, so any holder of definitions (app code, a registry) can produce it without coupling to runtime internals.
- **Wire-safe DTOs** — `RunDto` / `NodeDto` / `NodeChildDto` / `AttemptDto` / `RunSnapshotDto` via a published `WireSafe<T>` mapped type (every `Date` → ISO-8601 string), with `toRunDto` / `toNodeDto` / `toNodeChildDto` / `toAttemptDto` / `toRunSnapshotDto` mappers. These are the return-type contract for the read-model methods in #249.

## Deliberately not in

- Runtime registry exposure — the catalog takes definitions directly; exposing the registry can wait until an inspector factory composes with the store (#249/#250).
- Node options (retry/timeout/concurrency) in the graph shape — topology only, keeps the shape stable.

## Tests

`tests/inspector.spec.ts`: graph serialization across all node kinds with exact-shape assertion, JSON round-trip stability for graph and snapshot DTOs, catalog composition, optional attempt timestamp handling. 381 package tests pass; `pnpm check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new workflow inspection export for accessing workflow graphs, catalogs, and run snapshots.
  * Workflow run and node data can now be converted into JSON-safe output for easier viewing and transport.
  * Serialized workflow information is now stable and deterministic, improving consistency when inspecting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->