### PR TITLE
workflows: management actions — deleteRun, retry, per-run dead-command filter

### DIFF
--- a/packages/workflows/src/adapters/postgres/store-runs.ts
+++ b/packages/workflows/src/adapters/postgres/store-runs.ts
@@ -1,9 +1,11 @@
 import type { RunSnapshot, StoredRun } from '../../runtime/state.ts'
 import type {
   CreateRunInput,
+  DeleteRunResult,
   ListRunsFilter,
   PruneTerminalRunsParams,
   PruneTerminalRunsResult,
+  TerminalRunStatus,
   WorkflowStore,
 } from '../../runtime/store.ts'
 import type { WorkflowPostgresConnection } from './connection.ts'
@@ -46,6 +48,7 @@ type PostgresWorkflowRunStore = Pick<
   | 'listRuns'
   | 'listRunSummaries'
   | 'pruneTerminalRuns'
+  | 'deleteRun'
   | 'listDeadCommands'
   | 'listUnreapedDeadCommands'
   | 'markDeadCommandReaped'
@@ -204,6 +207,56 @@ export const pruneTerminalRunsInTransaction = async (
   )
 
   return { deleted }
+}
+
+export const deleteRunInTransaction = async (
+  connection: WorkflowPostgresConnection,
+  runId: string,
+): Promise<DeleteRunResult> => {
+  if (!isUuid(runId)) return { deleted: false }
+
+  const target = await one(
+    connection,
+    'SELECT * FROM workflow_runs WHERE id = $1 FOR UPDATE',
+    [runId],
+  )
+  if (!target) return { deleted: false }
+  if (target.parent_run_id !== null && target.parent_run_id !== undefined) {
+    throw new Error(`Run [${runId}] is not a root run`)
+  }
+
+  const family = await many<{ id: string; status: string }>(
+    connection,
+    `
+      SELECT id, status
+      FROM workflow_runs
+      WHERE root_run_id = $1
+      ORDER BY created_at, id
+      FOR UPDATE
+    `,
+    [runId],
+  )
+  if (
+    family.some(
+      (run) =>
+        !DEFAULT_PRUNE_STATUSES.includes(run.status as TerminalRunStatus),
+    )
+  ) {
+    throw new Error(`Run [${runId}] has non-terminal runs`)
+  }
+
+  const familyRunIds = family.map((run) => run.id)
+  await connection.query(
+    'DELETE FROM workflow_commands WHERE run_id = ANY($1::uuid[])',
+    [familyRunIds],
+  )
+  const deleted = await many<{ id: string }>(
+    connection,
+    'DELETE FROM workflow_runs WHERE id = $1 RETURNING id',
+    [runId],
+  )
+
+  return { deleted: deleted.length > 0 }
 }
 
 type RunListQueryParts = {
@@ -390,16 +443,23 @@ export const createPostgresWorkflowRunStore = (
       await ready
       return db.transaction((tx) => pruneTerminalRunsInTransaction(tx, params))
     },
-    async listDeadCommands() {
+    async deleteRun(runId) {
       await ready
+      return db.transaction((tx) => deleteRunInTransaction(tx, runId))
+    },
+    async listDeadCommands(params) {
+      await ready
+      if (params?.runId !== undefined && !isUuid(params.runId)) return []
       const rows = await many(
         db,
         `
         SELECT *
         FROM workflow_commands
         WHERE dead_at IS NOT NULL
+        ${params?.runId === undefined ? '' : 'AND run_id = $1'}
         ORDER BY dead_at DESC, created_at DESC, id ASC
       `,
+        params?.runId === undefined ? [] : [params.runId],
       )
       return rows
         .map((row) => withDateColumns(row, ['dead_at', 'created_at', 'run_at']))

--- a/packages/workflows/src/adapters/postgres/store-runs.ts
+++ b/packages/workflows/src/adapters/postgres/store-runs.ts
@@ -225,16 +225,36 @@ export const deleteRunInTransaction = async (
     throw new Error(`Run [${runId}] is not a root run`)
   }
 
+  const descendants = await many<{ id: string; status: string }>(
+    connection,
+    `
+      WITH RECURSIVE descendants AS (
+        SELECT id, status
+        FROM workflow_runs
+        WHERE id = $1
+        UNION
+        SELECT r.id, r.status
+        FROM workflow_runs r
+        JOIN descendants d
+          ON (r.parent_run_id = d.id OR r.root_run_id = d.id)
+         AND r.id <> d.id
+      )
+      SELECT id, status
+      FROM descendants
+    `,
+    [runId],
+  )
+  const familyRunIds = descendants.map((run) => run.id)
   const family = await many<{ id: string; status: string }>(
     connection,
     `
       SELECT id, status
       FROM workflow_runs
-      WHERE root_run_id = $1
+      WHERE id = ANY($1::uuid[])
       ORDER BY created_at, id
       FOR UPDATE
     `,
-    [runId],
+    [familyRunIds],
   )
   if (
     family.some(
@@ -245,7 +265,7 @@ export const deleteRunInTransaction = async (
     throw new Error(`Run [${runId}] has non-terminal runs`)
   }
 
-  const familyRunIds = family.map((run) => run.id)
+  // Guards against schema drift if workflow_commands_run_fk stops cascading.
   await connection.query(
     'DELETE FROM workflow_commands WHERE run_id = ANY($1::uuid[])',
     [familyRunIds],

--- a/packages/workflows/src/runtime/client.ts
+++ b/packages/workflows/src/runtime/client.ts
@@ -226,9 +226,11 @@ async function retryRun(
 
   switch (run.kind) {
     case 'workflow': {
-      const implementation = registry.getWorkflow(run.name)
+      const implementation = registry.getWorkflow(run.workflowName)
       if (!implementation) {
-        throw new Error(`No registered workflow implementation [${run.name}]`)
+        throw new Error(
+          `No registered workflow implementation [${run.workflowName}]`,
+        )
       }
       return (await start(implementation.workflow, run.input as never, {
         tags: run.tags,

--- a/packages/workflows/src/runtime/client.ts
+++ b/packages/workflows/src/runtime/client.ts
@@ -16,6 +16,7 @@ import type { WorkflowScheduler } from './scheduler.ts'
 import type { RunSnapshot, StoredRun } from './state.ts'
 import type {
   DeadWorkflowCommand,
+  DeleteRunResult,
   ListRunsFilter,
   ListRunSummariesResult,
   ListRunsResult,
@@ -79,6 +80,11 @@ export type WorkflowRuntimeClient = {
     ): Promise<TaskRun<Task>>
   }
   readonly cancel: (runId: string) => Promise<StoredRun | undefined>
+  readonly deleteRun: (runId: string) => Promise<DeleteRunResult>
+  readonly retry: (
+    runId: string,
+    options?: WorkflowRuntimeStartOptions,
+  ) => Promise<StoredRun>
   readonly get: (runId: string) => Promise<RunSnapshot | undefined>
   readonly list: (filter?: ListRunsFilter) => Promise<ListRunsResult>
   readonly listSummaries: (
@@ -93,7 +99,9 @@ export type WorkflowRuntimeClient = {
   readonly pruneRuns: (
     params: PruneTerminalRunsParams,
   ) => Promise<PruneTerminalRunsResult>
-  readonly listDeadCommands: () => Promise<readonly DeadWorkflowCommand[]>
+  readonly listDeadCommands: (params?: {
+    readonly runId?: string
+  }) => Promise<readonly DeadWorkflowCommand[]>
   readonly requeueDeadCommand: (id: string) => Promise<void>
   readonly schedules: {
     readonly list: WorkflowScheduler['list']
@@ -152,6 +160,9 @@ export function createWorkflowRuntimeClient(
 
   return Object.freeze({
     start,
+    deleteRun: (runId) => input.store.deleteRun(runId),
+    retry: (runId, options) =>
+      retryRun(input.store, registry, start, runId, options),
     cancel: async (runId) => {
       const run = await input.store.requestRunCancellation({ runId })
       if (!run) return undefined
@@ -171,7 +182,7 @@ export function createWorkflowRuntimeClient(
       input.store.loadNodeSnapshot({ runId, nodeName }),
     getFamily: (runId) => input.store.listRunFamily(runId),
     pruneRuns: (params) => pruneRuns(input.store, params),
-    listDeadCommands: () => input.store.listDeadCommands(),
+    listDeadCommands: (params) => input.store.listDeadCommands(params),
     requeueDeadCommand: (id) => input.store.requeueDeadCommand(id),
     schedules: {
       list: async () => requireScheduler().list(),
@@ -194,6 +205,47 @@ async function pruneRuns(
     const result = await store.pruneTerminalRuns({ ...params, batchSize })
     deleted += result.deleted
     if (result.deleted < batchSize) return { deleted }
+  }
+}
+
+async function retryRun(
+  store: WorkflowStore,
+  registry: WorkflowRuntimeRegistry,
+  start: WorkflowRuntimeClient['start'],
+  runId: string,
+  options?: WorkflowRuntimeStartOptions,
+): Promise<StoredRun> {
+  const [run] = await store.loadRuns([runId])
+  if (!run) throw new Error(`Run [${runId}] not found`)
+  if (!isTerminalRunStatus(run.status)) {
+    throw new Error(`Run [${runId}] is not terminal`)
+  }
+  if (run.parentRunId !== undefined) {
+    throw new Error(`Run [${runId}] is not a root run`)
+  }
+
+  switch (run.kind) {
+    case 'workflow': {
+      const implementation = registry.getWorkflow(run.name)
+      if (!implementation) {
+        throw new Error(`No registered workflow implementation [${run.name}]`)
+      }
+      return (await start(implementation.workflow, run.input as never, {
+        tags: run.tags,
+        ...options,
+      })) as StoredRun
+    }
+    case 'task': {
+      const taskName = run.taskName ?? run.name
+      const implementation = registry.getTask(taskName)
+      if (!implementation) {
+        throw new Error(`No registered task implementation [${taskName}]`)
+      }
+      return (await start(implementation.task, run.input as never, {
+        tags: run.tags,
+        ...options,
+      })) as StoredRun
+    }
   }
 }
 

--- a/packages/workflows/src/runtime/in-memory.ts
+++ b/packages/workflows/src/runtime/in-memory.ts
@@ -409,7 +409,33 @@ export function createInMemoryWorkflowRuntime(
       sweepDeadCommands(deadBefore)
       return { deleted: roots.length }
     },
-    async listDeadCommands() {
+    async deleteRun(runId) {
+      const run = runs.get(runId)
+      if (!run) return { deleted: false }
+      if (run.parentRunId !== undefined) {
+        throw new Error(`Run [${runId}] is not a root run`)
+      }
+
+      const familyRunIds = new Set(
+        [...runs.values()]
+          .filter((familyRun) => familyRun.rootRunId === runId)
+          .map((familyRun) => familyRun.id),
+      )
+      if (
+        [...familyRunIds].some((familyRunId) => {
+          const familyRun = runs.get(familyRunId)
+          return (
+            familyRun === undefined || !isTerminalRunStatus(familyRun.status)
+          )
+        })
+      ) {
+        throw new Error(`Run [${runId}] has non-terminal runs`)
+      }
+
+      deleteRunTrees(familyRunIds)
+      return { deleted: true }
+    },
+    async listDeadCommands(params) {
       return [
         ...continueRunCommands.flatMap((item) => {
           const dead = mapDeadCommand(item, 'continue')
@@ -423,11 +449,16 @@ export function createInMemoryWorkflowRuntime(
           const dead = mapDeadCommand(item, 'task')
           return dead === undefined ? [] : [dead]
         }),
-      ].sort((left, right) => {
-        const byDeadAt = right.deadAt.getTime() - left.deadAt.getTime()
-        if (byDeadAt !== 0) return byDeadAt
-        return right.createdAt.getTime() - left.createdAt.getTime()
-      })
+      ]
+        .filter(
+          (command) =>
+            params?.runId === undefined || command.runId === params.runId,
+        )
+        .sort((left, right) => {
+          const byDeadAt = right.deadAt.getTime() - left.deadAt.getTime()
+          if (byDeadAt !== 0) return byDeadAt
+          return right.createdAt.getTime() - left.createdAt.getTime()
+        })
     },
     async listUnreapedDeadCommands(params) {
       const limit = params?.limit ?? Number.POSITIVE_INFINITY

--- a/packages/workflows/src/runtime/in-memory.ts
+++ b/packages/workflows/src/runtime/in-memory.ts
@@ -416,11 +416,7 @@ export function createInMemoryWorkflowRuntime(
         throw new Error(`Run [${runId}] is not a root run`)
       }
 
-      const familyRunIds = new Set(
-        [...runs.values()]
-          .filter((familyRun) => familyRun.rootRunId === runId)
-          .map((familyRun) => familyRun.id),
-      )
+      const familyRunIds = collectRunDescendantIds(runId)
       if (
         [...familyRunIds].some((familyRunId) => {
           const familyRun = runs.get(familyRunId)
@@ -457,7 +453,10 @@ export function createInMemoryWorkflowRuntime(
         .sort((left, right) => {
           const byDeadAt = right.deadAt.getTime() - left.deadAt.getTime()
           if (byDeadAt !== 0) return byDeadAt
-          return right.createdAt.getTime() - left.createdAt.getTime()
+          const byCreatedAt =
+            right.createdAt.getTime() - left.createdAt.getTime()
+          if (byCreatedAt !== 0) return byCreatedAt
+          return left.id.localeCompare(right.id)
         })
     },
     async listUnreapedDeadCommands(params) {
@@ -1235,6 +1234,23 @@ export function createInMemoryWorkflowRuntime(
       }
     }
     return treeIds
+  }
+  const collectRunDescendantIds = (rootId: string) => {
+    const descendantIds = new Set([rootId])
+    let checkedSize = -1
+    while (checkedSize !== descendantIds.size) {
+      checkedSize = descendantIds.size
+      for (const run of runs.values()) {
+        if (
+          (run.parentRunId !== undefined &&
+            descendantIds.has(run.parentRunId)) ||
+          descendantIds.has(run.rootRunId)
+        ) {
+          descendantIds.add(run.id)
+        }
+      }
+    }
+    return descendantIds
   }
   const deleteRunTrees = (treeIds: ReadonlySet<string>) => {
     if (treeIds.size === 0) return

--- a/packages/workflows/src/runtime/index.ts
+++ b/packages/workflows/src/runtime/index.ts
@@ -85,6 +85,7 @@ export type {
   CreateNodeInput,
   CreateRunInput,
   DeadWorkflowCommand,
+  DeleteRunResult,
   EnsureChildAttemptParams,
   EnsureChildAttemptResult,
   EnsureChildRunParams,

--- a/packages/workflows/src/runtime/store.ts
+++ b/packages/workflows/src/runtime/store.ts
@@ -104,6 +104,8 @@ export type PruneTerminalRunsResult = {
   readonly deleted: number
 }
 
+export type DeleteRunResult = { readonly deleted: boolean }
+
 export type WorkflowRetentionPruner = {
   pruneTerminalRuns(
     params: PruneTerminalRunsParams,
@@ -236,7 +238,13 @@ export type WorkflowStore = {
   pruneTerminalRuns(
     params: PruneTerminalRunsParams,
   ): Promise<PruneTerminalRunsResult>
-  listDeadCommands(): Promise<readonly DeadWorkflowCommand[]>
+  /**
+   * Cascade-deletes one root run and its whole terminal family.
+   */
+  deleteRun(runId: string): Promise<DeleteRunResult>
+  listDeadCommands(params?: {
+    readonly runId?: string
+  }): Promise<readonly DeadWorkflowCommand[]>
   /**
    * Dead commands the reaper has not settled yet, oldest first. The reaper
    * marks each one reaped only AFTER producing its recovery outcome, so a

--- a/packages/workflows/tests/runtime-adapter-contract.spec.ts
+++ b/packages/workflows/tests/runtime-adapter-contract.spec.ts
@@ -979,6 +979,261 @@ function workflowRuntimeAdapterContract(
       expect(runs).toHaveLength(5)
     })
 
+    it('returns not deleted when deleting an unknown run', async () => {
+      const runtime = await createRuntime()
+
+      await expect(
+        runtime.store.deleteRun('missing-run-id'),
+      ).resolves.toStrictEqual({ deleted: false })
+      await expect(
+        runtime.store.deleteRun('00000000-0000-4000-8000-000000000000'),
+      ).resolves.toStrictEqual({ deleted: false })
+    })
+
+    it('refuses to delete child runs directly', async () => {
+      const runtime = await createRuntime()
+      const root = await runtime.store.createRun({
+        workflowName: 'delete-child-root',
+        input: {},
+      })
+      await runtime.store.createNode({
+        runId: root.id,
+        name: 'child',
+        kind: 'workflow',
+      })
+      await runtime.store.ensureNodeChildren({
+        runId: root.id,
+        nodeName: 'child',
+        children: [{ childKey: '$self', kind: 'workflow' }],
+      })
+      const { childRun } = await runtime.store.ensureChildRun({
+        runId: root.id,
+        nodeName: 'child',
+        childKey: '$self',
+        childKind: 'workflow',
+        childName: 'delete-child-member',
+        input: {},
+        rootRunId: root.id,
+      })
+
+      await expect(runtime.store.deleteRun(childRun.id)).rejects.toThrow(
+        `Run [${childRun.id}] is not a root run`,
+      )
+    })
+
+    it('refuses to delete run families with non-terminal members', async () => {
+      const runtime = await createRuntime()
+      const root = await runtime.store.createRun({
+        workflowName: 'delete-live-family-root',
+        input: {},
+      })
+      await runtime.store.createNode({
+        runId: root.id,
+        name: 'child',
+        kind: 'workflow',
+      })
+      await runtime.store.ensureNodeChildren({
+        runId: root.id,
+        nodeName: 'child',
+        children: [{ childKey: '$self', kind: 'workflow' }],
+      })
+      const { childRun } = await runtime.store.ensureChildRun({
+        runId: root.id,
+        nodeName: 'child',
+        childKey: '$self',
+        childKind: 'workflow',
+        childName: 'delete-live-family-child',
+        input: {},
+        rootRunId: root.id,
+      })
+      await runtime.store.completeRun({ runId: root.id, output: { ok: true } })
+
+      await expect(runtime.store.deleteRun(root.id)).rejects.toThrow(
+        `Run [${root.id}] has non-terminal runs`,
+      )
+      await expect(
+        runtime.store.loadRunSnapshot(root.id),
+      ).resolves.toBeDefined()
+      await expect(
+        runtime.store.loadRunSnapshot(childRun.id),
+      ).resolves.toBeDefined()
+    })
+
+    it('deletes terminal root run families and associated commands', async () => {
+      const runtime = await createRuntime({ maxDeliveries: 1 })
+      const root = await runtime.store.createRun({
+        workflowName: 'deleted-root-workflow',
+        input: {},
+      })
+      await runtime.store.createNode({
+        runId: root.id,
+        name: 'child',
+        kind: 'workflow',
+      })
+      await runtime.store.createNode({
+        runId: root.id,
+        name: 'content',
+        kind: 'activity',
+      })
+      await runtime.store.ensureNodeChildren({
+        runId: root.id,
+        nodeName: 'child',
+        children: [{ childKey: '$self', kind: 'workflow' }],
+      })
+      const { childRun } = await runtime.store.ensureChildRun({
+        runId: root.id,
+        nodeName: 'child',
+        childKey: '$self',
+        childKind: 'workflow',
+        childName: 'deleted-child-workflow',
+        input: {},
+        rootRunId: root.id,
+      })
+      await runtime.store.ensureNodeChildren({
+        runId: root.id,
+        nodeName: 'content',
+        children: [{ childKey: '$self', kind: 'activity' }],
+      })
+      const attempt = await runtime.store.createAttempt({
+        runId: root.id,
+        nodeName: 'content',
+        childKey: '$self',
+        input: {},
+      })
+      const lease = await runtime.store.acquireRunLease({
+        runId: root.id,
+        leaseMs: 30_000,
+      })
+      await runtime.runCoordinationExecutor.enqueue({
+        kind: 'continueRun',
+        runId: root.id,
+        workflowName: root.workflowName,
+      })
+      await runtime.runCoordinationExecutor.enqueue({
+        kind: 'continueRun',
+        runId: childRun.id,
+        workflowName: childRun.workflowName,
+      })
+      await runtime.attemptExecutor.dispatchActivity({
+        kind: 'activityAttempt',
+        workflowName: root.workflowName,
+        activityName: 'content',
+        runId: root.id,
+        nodeName: 'content',
+        childKey: '$self',
+        attemptId: attempt.id,
+        leaseToken: attempt.leaseToken!,
+        input: {},
+      })
+      const claimed = await runtime.runCoordinationExecutor.claim({
+        workerId: 'delete-dead-letterer',
+        workflowNames: [root.workflowName],
+        leaseMs: 30_000,
+      })
+      await runtime.runCoordinationExecutor.release(claimed!, {
+        error: new Error('delete dead command'),
+      })
+      await runtime.store.completeRun({
+        runId: childRun.id,
+        output: { ok: true },
+      })
+      await runtime.store.completeRun({ runId: root.id, output: { ok: true } })
+
+      await expect(
+        runtime.store.listDeadCommands({ runId: root.id }),
+      ).resolves.toHaveLength(1)
+      await expect(runtime.store.deleteRun(root.id)).resolves.toStrictEqual({
+        deleted: true,
+      })
+      await expect(
+        runtime.store.loadRunSnapshot(root.id),
+      ).resolves.toBeUndefined()
+      await expect(
+        runtime.store.loadRunSnapshot(childRun.id),
+      ).resolves.toBeUndefined()
+      await expect(
+        runtime.store.listDeadCommands({ runId: root.id }),
+      ).resolves.toStrictEqual([])
+      await expect(
+        runtime.runCoordinationExecutor.claim({
+          workerId: 'delete-root-checker',
+          workflowNames: [childRun.workflowName],
+          leaseMs: 30_000,
+        }),
+      ).resolves.toBeNull()
+      await expect(
+        runtime.attemptExecutor.claimActivity({
+          workerId: 'delete-attempt-checker',
+          workflowNames: [root.workflowName],
+          activityNames: ['content'],
+          leaseMs: 30_000,
+        }),
+      ).resolves.toBeNull()
+      await expect(
+        runtime.store.renewRunLease(lease!, 30_000),
+      ).resolves.toBeUndefined()
+    })
+
+    it('filters dead commands by run id', async () => {
+      const runtime = await createRuntime({ maxDeliveries: 1 })
+      const client = createWorkflowRuntimeClient(runtime)
+      const first = await runtime.store.createRun({
+        workflowName: 'filtered-dead-command-workflow-first',
+        input: { index: 1 },
+      })
+      const second = await runtime.store.createRun({
+        workflowName: 'filtered-dead-command-workflow-second',
+        input: { index: 2 },
+      })
+      await runtime.runCoordinationExecutor.enqueue({
+        kind: 'continueRun',
+        runId: first.id,
+        workflowName: first.workflowName,
+      })
+      await runtime.runCoordinationExecutor.enqueue({
+        kind: 'continueRun',
+        runId: second.id,
+        workflowName: second.workflowName,
+      })
+
+      const firstClaim = await runtime.runCoordinationExecutor.claim({
+        workerId: 'dead-filter-worker-1',
+        workflowNames: [first.workflowName],
+        leaseMs: 30_000,
+      })
+      await runtime.runCoordinationExecutor.release(firstClaim!, {
+        error: new Error('first dead command'),
+      })
+      const secondClaim = await runtime.runCoordinationExecutor.claim({
+        workerId: 'dead-filter-worker-2',
+        workflowNames: [second.workflowName],
+        leaseMs: 30_000,
+      })
+      await runtime.runCoordinationExecutor.release(secondClaim!, {
+        error: new Error('second dead command'),
+      })
+
+      await expect(runtime.store.listDeadCommands()).resolves.toHaveLength(2)
+      await expect(
+        runtime.store.listDeadCommands({ runId: first.id }),
+      ).resolves.toMatchObject([
+        {
+          kind: 'continue',
+          runId: first.id,
+          lastError: { message: 'first dead command' },
+        },
+      ])
+      await expect(
+        client.listDeadCommands({ runId: second.id }),
+      ).resolves.toMatchObject([
+        {
+          kind: 'continue',
+          runId: second.id,
+          lastError: { message: 'second dead command' },
+        },
+      ])
+    })
+
     it('threads worker continuation errors into dead-letter metadata', async () => {
       const workflow = defineWorkflow({
         name: 'poison-worker-workflow',

--- a/packages/workflows/tests/runtime-adapter-contract.spec.ts
+++ b/packages/workflows/tests/runtime-adapter-contract.spec.ts
@@ -1059,6 +1059,40 @@ function workflowRuntimeAdapterContract(
       ).resolves.toBeDefined()
     })
 
+    it('refuses to delete parent-linked descendants missing the root id', async () => {
+      const runtime = await createRuntime()
+      const root = await runtime.store.createRun({
+        workflowName: 'delete-parent-link-root',
+        input: {},
+      })
+      const child = await runtime.store.createRun({
+        workflowName: 'delete-parent-link-child',
+        input: {},
+        parentRunId: root.id,
+      })
+      await runtime.store.markRunRunning({ runId: child.id })
+      await runtime.store.completeRun({ runId: root.id, output: { ok: true } })
+
+      await expect(runtime.store.deleteRun(root.id)).rejects.toThrow(
+        `Run [${root.id}] has non-terminal runs`,
+      )
+      await expect(
+        runtime.store.loadRunSnapshot(child.id),
+      ).resolves.toBeDefined()
+
+      await runtime.store.completeRun({ runId: child.id, output: { ok: true } })
+
+      await expect(runtime.store.deleteRun(root.id)).resolves.toStrictEqual({
+        deleted: true,
+      })
+      await expect(
+        runtime.store.loadRunSnapshot(root.id),
+      ).resolves.toBeUndefined()
+      await expect(
+        runtime.store.loadRunSnapshot(child.id),
+      ).resolves.toBeUndefined()
+    })
+
     it('deletes terminal root run families and associated commands', async () => {
       const runtime = await createRuntime({ maxDeliveries: 1 })
       const root = await runtime.store.createRun({
@@ -1133,6 +1167,14 @@ function workflowRuntimeAdapterContract(
       await runtime.runCoordinationExecutor.release(claimed!, {
         error: new Error('delete dead command'),
       })
+      const childClaimed = await runtime.runCoordinationExecutor.claim({
+        workerId: 'delete-child-dead-letterer',
+        workflowNames: [childRun.workflowName],
+        leaseMs: 30_000,
+      })
+      await runtime.runCoordinationExecutor.release(childClaimed!, {
+        error: new Error('delete child dead command'),
+      })
       await runtime.store.completeRun({
         runId: childRun.id,
         output: { ok: true },
@@ -1141,6 +1183,9 @@ function workflowRuntimeAdapterContract(
 
       await expect(
         runtime.store.listDeadCommands({ runId: root.id }),
+      ).resolves.toHaveLength(1)
+      await expect(
+        runtime.store.listDeadCommands({ runId: childRun.id }),
       ).resolves.toHaveLength(1)
       await expect(runtime.store.deleteRun(root.id)).resolves.toStrictEqual({
         deleted: true,
@@ -1153,6 +1198,9 @@ function workflowRuntimeAdapterContract(
       ).resolves.toBeUndefined()
       await expect(
         runtime.store.listDeadCommands({ runId: root.id }),
+      ).resolves.toStrictEqual([])
+      await expect(
+        runtime.store.listDeadCommands({ runId: childRun.id }),
       ).resolves.toStrictEqual([])
       await expect(
         runtime.runCoordinationExecutor.claim({

--- a/packages/workflows/tests/runtime-client.spec.ts
+++ b/packages/workflows/tests/runtime-client.spec.ts
@@ -317,6 +317,187 @@ describe('workflow runtime client', () => {
     })
   })
 
+  it('deletes terminal root runs through the client', async () => {
+    const workflow = defineWorkflow({
+      name: 'client-delete-workflow',
+      input: t.object({ scenario: t.string() }),
+      output: t.object({ caseId: t.string() }),
+    }).build()
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient(runtime)
+    const run = await client.start(workflow, { scenario: 'alpha' })
+    await runtime.store.completeRun({
+      runId: run.id,
+      output: { caseId: 'alpha' },
+    })
+
+    await expect(client.deleteRun(run.id)).resolves.toStrictEqual({
+      deleted: true,
+    })
+    await expect(client.get(run.id)).resolves.toBeUndefined()
+  })
+
+  it('retries terminal workflow runs with original input and tags', async () => {
+    const workflow = defineWorkflow({
+      name: 'client-retry-workflow',
+      input: t.object({ scenario: t.string() }),
+      output: t.object({ caseId: t.string() }),
+    }).build()
+    const implementation = implementWorkflow(workflow).finish(
+      (_ctx, _outputs, input) => ({ caseId: input.scenario }),
+    )
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient({
+      ...runtime,
+      workflows: [implementation],
+    })
+    const run = await client.start(
+      workflow,
+      { scenario: 'alpha' },
+      {
+        tags: { tenantId: 'tenant-1' },
+        idempotencyKey: ['workflow', 'alpha'],
+      },
+    )
+    await runtime.store.completeRun({
+      runId: run.id,
+      output: { caseId: 'alpha' },
+    })
+
+    const retried = await client.retry(run.id)
+
+    expect(retried).toMatchObject({
+      kind: 'workflow',
+      name: workflow.name,
+      workflowName: workflow.name,
+      status: 'queued',
+      input: { scenario: 'alpha' },
+      tags: { tenantId: 'tenant-1' },
+    })
+    expect(retried.id).not.toBe(run.id)
+    expect(retried.idempotencyKey).toBeUndefined()
+    expect(runtime.inspect().continueRunCommands).toMatchObject([
+      { payload: { runId: run.id } },
+      { payload: { runId: retried.id } },
+    ])
+  })
+
+  it('retries terminal task runs with original input and tags', async () => {
+    const task = defineTask({
+      name: 'client-retry-task',
+      input: t.object({ text: t.string() }),
+      output: t.object({ id: t.string() }),
+    })
+    const implementation = implementTask(task, {
+      handler: async (_ctx, input) => ({ id: input.text }),
+    })
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient({
+      ...runtime,
+      tasks: [implementation],
+    })
+    const run = await client.start(
+      task,
+      { text: 'alpha' },
+      {
+        tags: { tenantId: 'tenant-1' },
+        idempotencyKey: ['task', 'alpha'],
+      },
+    )
+    await runtime.store.completeRun({
+      runId: run.id,
+      output: { id: 'alpha' },
+    })
+
+    const retried = await client.retry(run.id)
+
+    expect(retried).toMatchObject({
+      kind: 'task',
+      name: task.name,
+      workflowName: task.name,
+      taskName: task.name,
+      status: 'queued',
+      input: { text: 'alpha' },
+      tags: { tenantId: 'tenant-1' },
+    })
+    expect(retried.id).not.toBe(run.id)
+    expect(retried.idempotencyKey).toBeUndefined()
+    expect(runtime.inspect().taskCommands).toMatchObject([
+      { payload: { runId: run.id } },
+      { payload: { runId: retried.id } },
+    ])
+  })
+
+  it('refuses to retry non-terminal runs', async () => {
+    const workflow = defineWorkflow({
+      name: 'client-retry-live-workflow',
+      input: t.object({ scenario: t.string() }),
+      output: t.object({ caseId: t.string() }),
+    }).build()
+    const implementation = implementWorkflow(workflow).finish(
+      (_ctx, _outputs, input) => ({ caseId: input.scenario }),
+    )
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient({
+      ...runtime,
+      workflows: [implementation],
+    })
+    const run = await client.start(workflow, { scenario: 'alpha' })
+
+    await expect(client.retry(run.id)).rejects.toThrow(
+      `Run [${run.id}] is not terminal`,
+    )
+  })
+
+  it('refuses to retry unknown runs', async () => {
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient(runtime)
+
+    await expect(client.retry('missing-run-id')).rejects.toThrow(
+      'Run [missing-run-id] not found',
+    )
+  })
+
+  it('refuses to retry child runs', async () => {
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient(runtime)
+    const parent = await runtime.store.createRun({
+      workflowName: 'client-retry-parent',
+      input: {},
+    })
+    const child = await runtime.store.createRun({
+      workflowName: 'client-retry-child',
+      input: {},
+      parentRunId: parent.id,
+      parentNodeName: 'child',
+      rootRunId: parent.id,
+    })
+    await runtime.store.completeRun({ runId: child.id, output: { ok: true } })
+
+    await expect(client.retry(child.id)).rejects.toThrow(
+      `Run [${child.id}] is not a root run`,
+    )
+  })
+
+  it('refuses to retry runs without a registered implementation', async () => {
+    const workflow = defineWorkflow({
+      name: 'client-retry-unregistered-workflow',
+      input: t.object({ scenario: t.string() }),
+      output: t.object({ caseId: t.string() }),
+    }).build()
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient(runtime)
+    const run = await client.start(workflow, { scenario: 'alpha' })
+    await runtime.store.completeRun({
+      runId: run.id,
+      output: { caseId: 'alpha' },
+    })
+
+    await expect(client.retry(run.id)).rejects.toThrow(
+      `No registered workflow implementation [${workflow.name}]`,
+    )
+  })
+
   it('manages schedules through the adapter scheduler', async () => {
     const workflow = defineWorkflow({
       name: 'client-scheduled-workflow',

--- a/packages/workflows/tests/runtime-client.spec.ts
+++ b/packages/workflows/tests/runtime-client.spec.ts
@@ -382,6 +382,102 @@ describe('workflow runtime client', () => {
     ])
   })
 
+  it('retries workflow runs using the canonical workflow name', async () => {
+    const workflow = defineWorkflow({
+      name: 'client-retry-canonical-workflow',
+      input: t.object({ scenario: t.string() }),
+      output: t.object({ caseId: t.string() }),
+    }).build()
+    const implementation = implementWorkflow(workflow).finish(
+      (_ctx, _outputs, input) => ({ caseId: input.scenario }),
+    )
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient({
+      ...runtime,
+      workflows: [implementation],
+    })
+    const run = await runtime.store.createRun({
+      name: 'custom display name',
+      workflowName: workflow.name,
+      input: { scenario: 'alpha' },
+    })
+    await runtime.store.completeRun({
+      runId: run.id,
+      output: { caseId: 'alpha' },
+    })
+
+    const retried = await client.retry(run.id)
+
+    expect(retried).toMatchObject({
+      kind: 'workflow',
+      name: workflow.name,
+      workflowName: workflow.name,
+      input: { scenario: 'alpha' },
+    })
+  })
+
+  it('lets retry options override copied workflow tags', async () => {
+    const workflow = defineWorkflow({
+      name: 'client-retry-workflow-tag-override',
+      input: t.object({ scenario: t.string() }),
+      output: t.object({ caseId: t.string() }),
+    }).build()
+    const implementation = implementWorkflow(workflow).finish(
+      (_ctx, _outputs, input) => ({ caseId: input.scenario }),
+    )
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient({
+      ...runtime,
+      workflows: [implementation],
+    })
+    const run = await client.start(
+      workflow,
+      { scenario: 'alpha' },
+      { tags: { tenantId: 'tenant-1', source: 'original' } },
+    )
+    await runtime.store.completeRun({
+      runId: run.id,
+      output: { caseId: 'alpha' },
+    })
+
+    const retried = await client.retry(run.id, {
+      tags: { tenantId: 'tenant-2' },
+    })
+
+    expect(retried.tags).toStrictEqual({ tenantId: 'tenant-2' })
+  })
+
+  it('lets retry options set a workflow idempotency key', async () => {
+    const workflow = defineWorkflow({
+      name: 'client-retry-workflow-idempotency-override',
+      input: t.object({ scenario: t.string() }),
+      output: t.object({ caseId: t.string() }),
+    }).build()
+    const implementation = implementWorkflow(workflow).finish(
+      (_ctx, _outputs, input) => ({ caseId: input.scenario }),
+    )
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient({
+      ...runtime,
+      workflows: [implementation],
+    })
+    const run = await client.start(
+      workflow,
+      { scenario: 'alpha' },
+      { idempotencyKey: ['workflow', 'alpha'] },
+    )
+    await runtime.store.completeRun({
+      runId: run.id,
+      output: { caseId: 'alpha' },
+    })
+
+    const retried = await client.retry(run.id, {
+      idempotencyKey: ['retry', 'alpha'],
+    })
+
+    expect(retried.idempotencyKey).toStrictEqual(['retry', 'alpha'])
+  })
+
   it('retries terminal task runs with original input and tags', async () => {
     const task = defineTask({
       name: 'client-retry-task',


### PR DESCRIPTION
Closes #250. Third step of #242.

Management actions for ops UIs: `cancel` existed; `deleteRun` and `retry` didn't, and dead commands weren't queryable per run.

## Client

- **`deleteRun(runId)`** — guarded cascade delete of a whole run family. Refuses non-root runs and families with any non-terminal member (same guard shape as `pruneTerminalRuns`, scoped to one root). Postgres runs it in a transaction with `FOR UPDATE` on the family rows so an in-flight coordinator can't race the delete; descendant runs and their nodes/children/attempts/leases go via the existing FK cascades (`workflow_runs_root_run_fk`), family `workflow_commands` are removed explicitly.
- **`retry(runId, options?)`** — canonicalizes "retry = new run with the original input". Client-level composition over `start()`: refuses unknown, non-terminal, and non-root sources; resolves the registered definition by name (unregistered names throw instead of silently starting an unroutable run); copies `tags` but deliberately NOT `idempotencyKey` (copying it would dedupe the retry against the original run); `options` can override.
- **`listDeadCommands({runId?})`** — the per-run diagnostic filter, so "what got reaped for this run" no longer requires scanning the global dead-letter list.

## Semantics notes

- `deleteRun` on an unknown id returns `{deleted: false}` rather than throwing — deletion is idempotent from the caller's perspective; the guards throw only when the run exists but is not deletable.
- Dead-command surfacing in run detail is intentionally composition (`listDeadCommands({runId})` next to `getDetail(runId)`) rather than a new snapshot field — the reaper (on by default since #243) already folds dead commands into run state, so this is diagnostics, not recovery.

## Tests

Adapter conformance (in-memory + PGlite): refusal of child runs and families with running members, full cascade verification (runs, nodes, children, attempts, commands all gone), unknown-id idempotency, dead-command run filter. Client spec: retry happy path (fresh id, same input/tags, no idempotency key), all refusal paths including unregistered definitions. 408 package tests pass; `pnpm check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now delete completed *root* workflow runs, with the result indicating whether a run was actually removed.
  * Added run retry support for completed workflow and task root runs, creating a new queued run with the original input/tags (and updated idempotency as needed).
  * Dead-command listings can be filtered by `runId`.

* **Bug Fixes**
  * Deletion is now safer: it validates run IDs, rejects non-root and non-terminal families to prevent partial cleanup, and ensures only fully-terminal families are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->