### PR TITLE
workflows: run event history and watch() — truthful status change feed

### DIFF
--- a/packages/workflows/src/adapters/postgres/drizzle.ts
+++ b/packages/workflows/src/adapters/postgres/drizzle.ts
@@ -25,6 +25,7 @@ type TableKey =
   | 'attempts'
   | 'nodeChildren'
   | 'runLeases'
+  | 'runEvents'
   | 'commands'
 
 type EnumKey =
@@ -82,6 +83,7 @@ const tableNames = {
   attempts: 'workflow_attempts',
   nodeChildren: 'workflow_node_children',
   runLeases: 'workflow_run_leases',
+  runEvents: 'workflow_run_events',
   commands: 'workflow_commands',
 } as const satisfies Record<TableKey, string>
 
@@ -332,6 +334,33 @@ export function createSchema() {
       }).onDelete('cascade'),
     ],
   )
+  const runEvents = createTable(
+    tableNames.runEvents,
+    {
+      id: bigint('id', { mode: 'bigint' })
+        .primaryKey()
+        .generatedAlwaysAsIdentity(),
+      runId: uuid('run_id').notNull(),
+      rootRunId: uuid('root_run_id').notNull(),
+      kind: text('kind').notNull(),
+      status: text('status').notNull(),
+      nodeName: text('node_name'),
+      childKey: text('child_key'),
+      attemptId: uuid('attempt_id'),
+      attemptNumber: integer('attempt_number'),
+      error: jsonb('error'),
+      createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    },
+    (t) => [
+      index('workflow_run_events_run_idx').on(t.runId, t.id),
+      index('workflow_run_events_root_idx').on(t.rootRunId, t.id),
+      foreignKey({
+        name: 'workflow_run_events_run_fk',
+        columns: [t.runId],
+        foreignColumns: [runs.id],
+      }).onDelete('cascade'),
+    ],
+  )
   const commands = createTable(
     tableNames.commands,
     {
@@ -386,6 +415,7 @@ export function createSchema() {
       attempts,
       nodeChildren,
       runLeases,
+      runEvents,
       commands,
     },
     enums,

--- a/packages/workflows/src/adapters/postgres/manifest.ts
+++ b/packages/workflows/src/adapters/postgres/manifest.ts
@@ -57,6 +57,7 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
     'workflow_attempts',
     'workflow_node_children',
     'workflow_run_leases',
+    'workflow_run_events',
     'workflow_commands',
   ],
   constraints: [
@@ -71,6 +72,7 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
     'workflow_attempts_child_attempt_key',
     'workflow_node_children_pkey',
     'workflow_run_leases_pkey',
+    'workflow_run_events_pkey',
     'workflow_commands_pkey',
     'workflow_runs_parent_run_fk',
     'workflow_runs_root_run_fk',
@@ -82,6 +84,7 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
     'workflow_node_children_child_run_fk',
     'workflow_node_children_current_attempt_fk',
     'workflow_run_leases_run_fk',
+    'workflow_run_events_run_fk',
     'workflow_commands_run_fk',
   ],
   indexes: [
@@ -94,6 +97,8 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
     'workflow_attempts_node_idx',
     'workflow_node_children_node_idx',
     'workflow_node_children_child_run_idx',
+    'workflow_run_events_run_idx',
+    'workflow_run_events_root_idx',
     'workflow_commands_run_idx',
     'workflow_commands_claim_idx',
     'workflow_commands_continue_dedup_idx',
@@ -106,6 +111,11 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
     },
     workflow_commands_run_fk: {
       table: 'workflow_commands',
+      type: 'f',
+      columns: ['run_id'],
+    },
+    workflow_run_events_run_fk: {
+      table: 'workflow_run_events',
       type: 'f',
       columns: ['run_id'],
     },
@@ -180,6 +190,16 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
       table: 'workflow_node_children',
       unique: false,
       columns: ['child_run_id'],
+    },
+    workflow_run_events_run_idx: {
+      table: 'workflow_run_events',
+      unique: false,
+      columns: ['run_id', 'id'],
+    },
+    workflow_run_events_root_idx: {
+      table: 'workflow_run_events',
+      unique: false,
+      columns: ['root_run_id', 'id'],
     },
   },
   columns: {
@@ -276,6 +296,19 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
       lease_token: { type: 'text', nullable: false },
       version: { type: 'int4', nullable: false },
       expires_at: { type: 'timestamptz', nullable: false },
+    },
+    workflow_run_events: {
+      id: { type: 'int8', nullable: false },
+      run_id: { type: 'uuid', nullable: false },
+      root_run_id: { type: 'uuid', nullable: false },
+      kind: { type: 'text', nullable: false },
+      status: { type: 'text', nullable: false },
+      node_name: { type: 'text', nullable: true },
+      child_key: { type: 'text', nullable: true },
+      attempt_id: { type: 'uuid', nullable: true },
+      attempt_number: { type: 'int4', nullable: true },
+      error: { type: 'jsonb', nullable: true },
+      created_at: { type: 'timestamptz', nullable: false },
     },
     workflow_commands: {
       id: { type: 'uuid', nullable: false },

--- a/packages/workflows/src/adapters/postgres/sql.ts
+++ b/packages/workflows/src/adapters/postgres/sql.ts
@@ -341,8 +341,17 @@ export const notifyRunStatusEventSql = (cteName: string) => `
   )
 `
 
-export const notifyRunStatusEventCountSql = (...cteNames: readonly string[]) =>
-  cteNames.map((name) => `(SELECT count(*) FROM ${name}_notified)`).join(', ')
+// Postgres prunes plain SELECT CTEs that are not referenced from projected
+// output, so pg_notify counts must be output columns for notifications to fire.
+export const notifyRunStatusEventColumnsSql = (
+  ...cteNames: readonly string[]
+) =>
+  cteNames
+    .map(
+      (name) =>
+        `,\n    (SELECT count(*) FROM ${name}_notified) AS ${name}_notified`,
+    )
+    .join('')
 
 export const emitRunStatusEventSql = (sourceAlias: string, cteName: string) => `
   ${cteName}_events AS (

--- a/packages/workflows/src/adapters/postgres/sql.ts
+++ b/packages/workflows/src/adapters/postgres/sql.ts
@@ -6,6 +6,7 @@ import type {
   StoredNodeChild,
   StoredError,
   StoredRun,
+  StoredRunEvent,
 } from '../../runtime/state.ts'
 import type {
   RuntimeNodeStatus,
@@ -46,6 +47,7 @@ export const TASK_RUN_NODE_NAME = '$task'
 // run id respectively. Delivery is best-effort — polling remains the fallback.
 export const WORKFLOW_COMMANDS_CHANNEL = 'workflow_commands'
 export const WORKFLOW_CANCELLATIONS_CHANNEL = 'workflow_run_cancellations'
+export const WORKFLOW_RUN_EVENTS_CHANNEL = 'workflow_run_events'
 export const id = () => randomUUID()
 export const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -317,6 +319,97 @@ export const mapDeadCommand = (row: JsonRecord): DeadWorkflowCommand => ({
   deadAt: row.dead_at as Date,
   createdAt: row.created_at as Date,
 })
+
+export const mapRunEvent = (row: JsonRecord): StoredRunEvent => ({
+  id: String(row.id),
+  runId: row.run_id as string,
+  rootRunId: row.root_run_id as string,
+  kind: row.kind as StoredRunEvent['kind'],
+  status: row.status as string,
+  ...optional('nodeName', row.node_name as string | undefined),
+  ...optional('childKey', row.child_key as string | undefined),
+  ...optional('attemptId', row.attempt_id as string | undefined),
+  ...optional('attemptNumber', row.attempt_number as number | undefined),
+  ...optional('error', fromOptional(row.error) as StoredError | undefined),
+  createdAt: row.created_at as Date,
+})
+
+export const notifyRunStatusEventSql = (cteName: string) => `
+  ${cteName}_notified AS (
+    SELECT pg_notify('${WORKFLOW_RUN_EVENTS_CHANNEL}', root_run_id::text)
+    FROM ${cteName}_events
+  )
+`
+
+export const notifyRunStatusEventCountSql = (...cteNames: readonly string[]) =>
+  cteNames.map((name) => `(SELECT count(*) FROM ${name}_notified)`).join(', ')
+
+export const emitRunStatusEventSql = (sourceAlias: string, cteName: string) => `
+  ${cteName}_events AS (
+    INSERT INTO workflow_run_events (
+      run_id, root_run_id, kind, status, error, created_at
+    )
+    SELECT
+      id, root_run_id, 'run', status::text, error, now()
+    FROM ${sourceAlias}
+    WHERE old_status IS DISTINCT FROM status::text
+    RETURNING root_run_id
+  ),
+  ${notifyRunStatusEventSql(cteName)}
+`
+
+export const emitNodeStatusEventSql = (
+  sourceAlias: string,
+  cteName: string,
+) => `
+  ${cteName}_events AS (
+    INSERT INTO workflow_run_events (
+      run_id, root_run_id, kind, status, node_name, error, created_at
+    )
+    SELECT
+      run_id, root_run_id, 'node', status::text, name, error, now()
+    FROM ${sourceAlias}
+    WHERE old_status IS DISTINCT FROM status::text
+    RETURNING root_run_id
+  ),
+  ${notifyRunStatusEventSql(cteName)}
+`
+
+export const emitChildStatusEventSql = (
+  sourceAlias: string,
+  cteName: string,
+) => `
+  ${cteName}_events AS (
+    INSERT INTO workflow_run_events (
+      run_id, root_run_id, kind, status, node_name, child_key, error, created_at
+    )
+    SELECT
+      run_id, root_run_id, 'child', status::text, node_name, child_key, error, now()
+    FROM ${sourceAlias}
+    WHERE old_status IS DISTINCT FROM status::text
+    RETURNING root_run_id
+  ),
+  ${notifyRunStatusEventSql(cteName)}
+`
+
+export const emitAttemptStatusEventSql = (
+  sourceAlias: string,
+  cteName: string,
+) => `
+  ${cteName}_events AS (
+    INSERT INTO workflow_run_events (
+      run_id, root_run_id, kind, status, node_name, child_key,
+      attempt_id, attempt_number, error, created_at
+    )
+    SELECT
+      run_id, root_run_id, 'attempt', status::text, node_name, child_key,
+      id, attempt_number, error, now()
+    FROM ${sourceAlias}
+    WHERE old_status IS DISTINCT FROM status::text
+    RETURNING root_run_id
+  ),
+  ${notifyRunStatusEventSql(cteName)}
+`
 
 export const parseJsonColumn = (value: unknown): unknown =>
   typeof value === 'string' ? JSON.parse(value) : value

--- a/packages/workflows/src/adapters/postgres/store-children.ts
+++ b/packages/workflows/src/adapters/postgres/store-children.ts
@@ -20,7 +20,7 @@ import {
   mapNodeChild,
   mapRun,
   nodeStatusSourcesSql,
-  notifyRunStatusEventCountSql,
+  notifyRunStatusEventColumnsSql,
   one,
   sameOptionalValue,
   sameValue,
@@ -270,11 +270,8 @@ export const createPostgresWorkflowChildStore = (
             RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
             ),
             ${emitChildStatusEventSql('updated', 'child_run_linked')}
-            SELECT updated.*
+            SELECT updated.*${notifyRunStatusEventColumnsSql('child_run_linked')}
             FROM updated
-            CROSS JOIN (
-              SELECT ${notifyRunStatusEventCountSql('child_run_linked')}
-            ) emitted
           `,
             [runId, nodeName, childKey, childRun.id],
           )
@@ -347,11 +344,8 @@ export const createPostgresWorkflowChildStore = (
               JOIN workflow_runs r ON r.id = inserted.run_id
             ),
             ${emitAttemptStatusEventSql('event_source', 'attempt_started')}
-            SELECT inserted.*
+            SELECT inserted.*${notifyRunStatusEventColumnsSql('attempt_started')}
             FROM inserted
-            CROSS JOIN (
-              SELECT ${notifyRunStatusEventCountSql('attempt_started')}
-            ) emitted
           `,
             [
               attemptId,
@@ -388,11 +382,8 @@ export const createPostgresWorkflowChildStore = (
             RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
             ),
             ${emitChildStatusEventSql('updated', 'child_running')}
-            SELECT updated.*
+            SELECT updated.*${notifyRunStatusEventColumnsSql('child_running')}
             FROM updated
-            CROSS JOIN (
-              SELECT ${notifyRunStatusEventCountSql('child_running')}
-            ) emitted
           `,
             [runId, nodeName, childKey, attemptId],
           )
@@ -421,7 +412,7 @@ export const createPostgresWorkflowChildStore = (
             RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
             ),
             ${emitNodeStatusEventSql('updated', 'node_running')}
-            SELECT count(*), ${notifyRunStatusEventCountSql('node_running')}
+            SELECT count(*)${notifyRunStatusEventColumnsSql('node_running')}
             FROM updated
           `,
             [runId, nodeName],
@@ -512,11 +503,8 @@ export const createPostgresWorkflowChildStore = (
         RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
         ),
         ${emitChildStatusEventSql('updated', 'child_completed')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('child_completed')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('child_completed')}
-        ) emitted
       `,
         [runId, nodeName, childKey, json(output)],
       )
@@ -555,11 +543,8 @@ export const createPostgresWorkflowChildStore = (
         RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
         ),
         ${emitChildStatusEventSql('updated', 'child_failed')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('child_failed')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('child_failed')}
-        ) emitted
       `,
         [runId, nodeName, childKey, json(toStoredError(error))],
       )
@@ -600,11 +585,8 @@ export const createPostgresWorkflowChildStore = (
         RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
         ),
         ${emitNodeStatusEventSql('updated', 'node_waiting')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('node_waiting')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('node_waiting')}
-        ) emitted
       `,
         [runId, nodeName],
       )

--- a/packages/workflows/src/adapters/postgres/store-children.ts
+++ b/packages/workflows/src/adapters/postgres/store-children.ts
@@ -8,6 +8,9 @@ import type { WorkflowPostgresConnection } from './connection.ts'
 import { toStoredError } from '../../runtime/errors.ts'
 import { isTerminalNodeStatus } from '../../runtime/status.ts'
 import {
+  emitAttemptStatusEventSql,
+  emitChildStatusEventSql,
+  emitNodeStatusEventSql,
   id,
   isUniqueViolation,
   json,
@@ -17,6 +20,7 @@ import {
   mapNodeChild,
   mapRun,
   nodeStatusSourcesSql,
+  notifyRunStatusEventCountSql,
   one,
   sameOptionalValue,
   sameValue,
@@ -244,15 +248,33 @@ export const createPostgresWorkflowChildStore = (
           const updated = await one(
             tx,
             `
+            WITH candidate AS (
+              SELECT c.run_id, c.node_name, c.child_key,
+                c.status::text AS old_status, r.root_run_id
+              FROM workflow_node_children c
+              JOIN workflow_runs r ON r.id = c.run_id
+              WHERE c.run_id = $1 AND c.node_name = $2 AND c.child_key = $3
+            ),
+            updated AS (
             UPDATE workflow_node_children
             SET child_run_id = $4,
                 status = 'running',
                 version = version + 1,
                 updated_at = now()
-            WHERE run_id = $1 AND node_name = $2 AND child_key = $3
-              AND child_run_id IS NULL
-              AND status IN (${nodeStatusSourcesSql('running', { self: true })})
-            RETURNING *
+            FROM candidate
+            WHERE workflow_node_children.run_id = candidate.run_id
+              AND workflow_node_children.node_name = candidate.node_name
+              AND workflow_node_children.child_key = candidate.child_key
+              AND workflow_node_children.child_run_id IS NULL
+              AND workflow_node_children.status IN (${nodeStatusSourcesSql('running', { self: true })})
+            RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
+            ),
+            ${emitChildStatusEventSql('updated', 'child_run_linked')}
+            SELECT updated.*
+            FROM updated
+            CROSS JOIN (
+              SELECT ${notifyRunStatusEventCountSql('child_run_linked')}
+            ) emitted
           `,
             [runId, nodeName, childKey, childRun.id],
           )
@@ -311,12 +333,25 @@ export const createPostgresWorkflowChildStore = (
           const attempt = await one(
             tx,
             `
+            WITH inserted AS (
             INSERT INTO workflow_attempts (
               id, run_id, node_name, child_key, status,
               lease_token, attempt_number, input, idempotency_key, dispatched_at
             )
             VALUES ($1, $2, $3, $4, 'started', $5, 1, $6::jsonb, $7::jsonb, now())
-            RETURNING *
+            RETURNING *, NULL::text AS old_status
+            ),
+            event_source AS (
+              SELECT inserted.*, r.root_run_id
+              FROM inserted
+              JOIN workflow_runs r ON r.id = inserted.run_id
+            ),
+            ${emitAttemptStatusEventSql('event_source', 'attempt_started')}
+            SELECT inserted.*
+            FROM inserted
+            CROSS JOIN (
+              SELECT ${notifyRunStatusEventCountSql('attempt_started')}
+            ) emitted
           `,
             [
               attemptId,
@@ -331,15 +366,33 @@ export const createPostgresWorkflowChildStore = (
           const updatedChild = await one(
             tx,
             `
+            WITH candidate AS (
+              SELECT c.run_id, c.node_name, c.child_key,
+                c.status::text AS old_status, r.root_run_id
+              FROM workflow_node_children c
+              JOIN workflow_runs r ON r.id = c.run_id
+              WHERE c.run_id = $1 AND c.node_name = $2 AND c.child_key = $3
+            ),
+            updated AS (
             UPDATE workflow_node_children
             SET current_attempt_id = $4,
                 attempt_count = 1,
                 status = 'running',
                 version = version + 1,
                 updated_at = now()
-            WHERE run_id = $1 AND node_name = $2 AND child_key = $3
-              AND status IN (${nodeStatusSourcesSql('running', { self: true })})
-            RETURNING *
+            FROM candidate
+            WHERE workflow_node_children.run_id = candidate.run_id
+              AND workflow_node_children.node_name = candidate.node_name
+              AND workflow_node_children.child_key = candidate.child_key
+              AND workflow_node_children.status IN (${nodeStatusSourcesSql('running', { self: true })})
+            RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
+            ),
+            ${emitChildStatusEventSql('updated', 'child_running')}
+            SELECT updated.*
+            FROM updated
+            CROSS JOIN (
+              SELECT ${notifyRunStatusEventCountSql('child_running')}
+            ) emitted
           `,
             [runId, nodeName, childKey, attemptId],
           )
@@ -352,10 +405,24 @@ export const createPostgresWorkflowChildStore = (
           // node parked in another state must not fail the attempt creation.
           await tx.query(
             `
+            WITH candidate AS (
+              SELECT n.run_id, n.name, n.status::text AS old_status, r.root_run_id
+              FROM workflow_nodes n
+              JOIN workflow_runs r ON r.id = n.run_id
+              WHERE n.run_id = $1 AND n.name = $2
+            ),
+            updated AS (
             UPDATE workflow_nodes
             SET status = 'running', version = version + 1, updated_at = now()
-            WHERE run_id = $1 AND name = $2
-              AND status IN (${nodeStatusSourcesSql('running', { self: true })})
+            FROM candidate
+            WHERE workflow_nodes.run_id = candidate.run_id
+              AND workflow_nodes.name = candidate.name
+              AND workflow_nodes.status IN (${nodeStatusSourcesSql('running', { self: true })})
+            RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
+            ),
+            ${emitNodeStatusEventSql('updated', 'node_running')}
+            SELECT count(*), ${notifyRunStatusEventCountSql('node_running')}
+            FROM updated
           `,
             [runId, nodeName],
           )
@@ -424,14 +491,32 @@ export const createPostgresWorkflowChildStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT c.run_id, c.node_name, c.child_key,
+            c.status::text AS old_status, r.root_run_id
+          FROM workflow_node_children c
+          JOIN workflow_runs r ON r.id = c.run_id
+          WHERE c.run_id = $1 AND c.node_name = $2 AND c.child_key = $3
+        ),
+        updated AS (
         UPDATE workflow_node_children
         SET status = 'completed',
             output = $4::jsonb,
             version = version + 1,
             updated_at = now()
-        WHERE run_id = $1 AND node_name = $2 AND child_key = $3
-          AND status IN (${nodeStatusSourcesSql('completed')})
-        RETURNING *
+        FROM candidate
+        WHERE workflow_node_children.run_id = candidate.run_id
+          AND workflow_node_children.node_name = candidate.node_name
+          AND workflow_node_children.child_key = candidate.child_key
+          AND workflow_node_children.status IN (${nodeStatusSourcesSql('completed')})
+        RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
+        ),
+        ${emitChildStatusEventSql('updated', 'child_completed')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('child_completed')}
+        ) emitted
       `,
         [runId, nodeName, childKey, json(output)],
       )
@@ -449,14 +534,32 @@ export const createPostgresWorkflowChildStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT c.run_id, c.node_name, c.child_key,
+            c.status::text AS old_status, r.root_run_id
+          FROM workflow_node_children c
+          JOIN workflow_runs r ON r.id = c.run_id
+          WHERE c.run_id = $1 AND c.node_name = $2 AND c.child_key = $3
+        ),
+        updated AS (
         UPDATE workflow_node_children
         SET status = 'failed',
             error = $4::jsonb,
             version = version + 1,
             updated_at = now()
-        WHERE run_id = $1 AND node_name = $2 AND child_key = $3
-          AND status IN (${nodeStatusSourcesSql('failed')})
-        RETURNING *
+        FROM candidate
+        WHERE workflow_node_children.run_id = candidate.run_id
+          AND workflow_node_children.node_name = candidate.node_name
+          AND workflow_node_children.child_key = candidate.child_key
+          AND workflow_node_children.status IN (${nodeStatusSourcesSql('failed')})
+        RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
+        ),
+        ${emitChildStatusEventSql('updated', 'child_failed')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('child_failed')}
+        ) emitted
       `,
         [runId, nodeName, childKey, json(toStoredError(error))],
       )
@@ -481,11 +584,27 @@ export const createPostgresWorkflowChildStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT n.run_id, n.name, n.status::text AS old_status, r.root_run_id
+          FROM workflow_nodes n
+          JOIN workflow_runs r ON r.id = n.run_id
+          WHERE n.run_id = $1 AND n.name = $2
+        ),
+        updated AS (
         UPDATE workflow_nodes
         SET status = 'waiting', version = version + 1, updated_at = now()
-        WHERE run_id = $1 AND name = $2
-          AND status IN (${nodeStatusSourcesSql('waiting', { self: true })})
-        RETURNING *
+        FROM candidate
+        WHERE workflow_nodes.run_id = candidate.run_id
+          AND workflow_nodes.name = candidate.name
+          AND workflow_nodes.status IN (${nodeStatusSourcesSql('waiting', { self: true })})
+        RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
+        ),
+        ${emitNodeStatusEventSql('updated', 'node_waiting')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('node_waiting')}
+        ) emitted
       `,
         [runId, nodeName],
       )

--- a/packages/workflows/src/adapters/postgres/store-nodes.ts
+++ b/packages/workflows/src/adapters/postgres/store-nodes.ts
@@ -13,6 +13,10 @@ import {
 } from '../../runtime/status.ts'
 import {
   WORKFLOW_CANCELLATIONS_CHANNEL,
+  emitAttemptStatusEventSql,
+  emitChildStatusEventSql,
+  emitNodeStatusEventSql,
+  emitRunStatusEventSql,
   id,
   isUuid,
   jsonRecordArrayColumn,
@@ -24,6 +28,7 @@ import {
   mapNodeChild,
   mapRun,
   nodeStatusSourcesSql,
+  notifyRunStatusEventCountSql,
   one,
   runStatusSourcesSql,
   withDateColumns,
@@ -128,11 +133,11 @@ export const createPostgresWorkflowNodeStore = (
         `
         UPDATE workflow_nodes
         SET input = $3::jsonb,
-            status = 'running',
             version = version + 1,
             updated_at = now()
-        WHERE run_id = $1 AND name = $2
-          AND status IN (${nodeStatusSourcesSql('running', { self: true })})
+        WHERE run_id = $1
+          AND name = $2
+          AND status NOT IN ('completed', 'failed', 'cancelled')
         RETURNING *
       `,
         [runId, nodeName, json(input)],
@@ -230,6 +235,7 @@ export const createPostgresWorkflowNodeStore = (
         const attempt = await one(
           tx,
           `
+          WITH inserted AS (
           INSERT INTO workflow_attempts (
             id, run_id, node_name, child_key, status, lease_token,
             attempt_number, input, idempotency_key, dispatched_at
@@ -237,7 +243,19 @@ export const createPostgresWorkflowNodeStore = (
           VALUES (
             $1, $2, $3, $4, 'started', $5, $6, $7::jsonb, $8::jsonb, now()
           )
-          RETURNING *
+          RETURNING *, NULL::text AS old_status
+          ),
+          event_source AS (
+            SELECT inserted.*, r.root_run_id
+            FROM inserted
+            JOIN workflow_runs r ON r.id = inserted.run_id
+          ),
+          ${emitAttemptStatusEventSql('event_source', 'attempt_started')}
+          SELECT inserted.*
+          FROM inserted
+          CROSS JOIN (
+            SELECT ${notifyRunStatusEventCountSql('attempt_started')}
+          ) emitted
         `,
           [
             attemptId,
@@ -253,15 +271,33 @@ export const createPostgresWorkflowNodeStore = (
         const updatedChild = await one(
           tx,
           `
+          WITH candidate AS (
+            SELECT c.run_id, c.node_name, c.child_key,
+              c.status::text AS old_status, r.root_run_id
+            FROM workflow_node_children c
+            JOIN workflow_runs r ON r.id = c.run_id
+            WHERE c.run_id = $1 AND c.node_name = $2 AND c.child_key = $3
+          ),
+          updated AS (
           UPDATE workflow_node_children
           SET current_attempt_id = $4,
               attempt_count = attempt_count + 1,
               status = 'running',
               version = version + 1,
               updated_at = now()
-          WHERE run_id = $1 AND node_name = $2 AND child_key = $3
-            AND status IN (${nodeStatusSourcesSql('running', { self: true })})
-          RETURNING *
+          FROM candidate
+          WHERE workflow_node_children.run_id = candidate.run_id
+            AND workflow_node_children.node_name = candidate.node_name
+            AND workflow_node_children.child_key = candidate.child_key
+            AND workflow_node_children.status IN (${nodeStatusSourcesSql('running', { self: true })})
+          RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
+          ),
+          ${emitChildStatusEventSql('updated', 'child_running')}
+          SELECT updated.*
+          FROM updated
+          CROSS JOIN (
+            SELECT ${notifyRunStatusEventCountSql('child_running')}
+          ) emitted
         `,
           [input.runId, input.nodeName, input.childKey, attemptId],
         )
@@ -274,10 +310,24 @@ export const createPostgresWorkflowNodeStore = (
         // again, but never fail the retry when the node cannot move.
         await tx.query(
           `
+          WITH candidate AS (
+            SELECT n.run_id, n.name, n.status::text AS old_status, r.root_run_id
+            FROM workflow_nodes n
+            JOIN workflow_runs r ON r.id = n.run_id
+            WHERE n.run_id = $1 AND n.name = $2
+          ),
+          updated AS (
           UPDATE workflow_nodes
           SET status = 'running', version = version + 1, updated_at = now()
-          WHERE run_id = $1 AND name = $2
-            AND status IN (${nodeStatusSourcesSql('running', { self: true })})
+          FROM candidate
+          WHERE workflow_nodes.run_id = candidate.run_id
+            AND workflow_nodes.name = candidate.name
+            AND workflow_nodes.status IN (${nodeStatusSourcesSql('running', { self: true })})
+          RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
+          ),
+          ${emitNodeStatusEventSql('updated', 'node_running')}
+          SELECT count(*), ${notifyRunStatusEventCountSql('node_running')}
+          FROM updated
         `,
           [input.runId, input.nodeName],
         )
@@ -299,10 +349,25 @@ export const createPostgresWorkflowNodeStore = (
           const row = await one(
             tx,
             `
+            WITH candidate AS (
+              SELECT a.id, a.status::text AS old_status, r.root_run_id
+              FROM workflow_attempts a
+              JOIN workflow_runs r ON r.id = a.run_id
+              WHERE a.id = $1 AND a.lease_token = $2 AND a.status = 'started'
+            ),
+            updated AS (
             UPDATE workflow_attempts
             SET status = 'completed', output = $3::jsonb, completed_at = now()
-            WHERE id = $1 AND lease_token = $2 AND status = 'started'
-            RETURNING *
+            FROM candidate
+            WHERE workflow_attempts.id = candidate.id
+            RETURNING workflow_attempts.*, candidate.old_status, candidate.root_run_id
+            ),
+            ${emitAttemptStatusEventSql('updated', 'attempt_completed')}
+            SELECT updated.*
+            FROM updated
+            CROSS JOIN (
+              SELECT ${notifyRunStatusEventCountSql('attempt_completed')}
+            ) emitted
           `,
             [attemptId, leaseToken, json(output)],
           )
@@ -310,15 +375,33 @@ export const createPostgresWorkflowNodeStore = (
           const child = await one(
             tx,
             `
+            WITH candidate AS (
+              SELECT c.run_id, c.node_name, c.child_key,
+                c.status::text AS old_status, r.root_run_id
+              FROM workflow_node_children c
+              JOIN workflow_runs r ON r.id = c.run_id
+              WHERE c.run_id = $1 AND c.node_name = $2 AND c.child_key = $3
+                AND c.current_attempt_id = $4
+            ),
+            updated AS (
             UPDATE workflow_node_children
             SET status = 'completed',
                 output = $5::jsonb,
                 version = version + 1,
                 updated_at = now()
-            WHERE run_id = $1 AND node_name = $2 AND child_key = $3
-              AND current_attempt_id = $4
-              AND status IN (${nodeStatusSourcesSql('completed')})
-            RETURNING *
+            FROM candidate
+            WHERE workflow_node_children.run_id = candidate.run_id
+              AND workflow_node_children.node_name = candidate.node_name
+              AND workflow_node_children.child_key = candidate.child_key
+              AND workflow_node_children.status IN (${nodeStatusSourcesSql('completed')})
+            RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
+            ),
+            ${emitChildStatusEventSql('updated', 'child_completed')}
+            SELECT updated.*
+            FROM updated
+            CROSS JOIN (
+              SELECT ${notifyRunStatusEventCountSql('child_completed')}
+            ) emitted
           `,
             [run_id, node_name, child_key, attemptId, json(output)],
           )
@@ -338,10 +421,25 @@ export const createPostgresWorkflowNodeStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT a.id, a.status::text AS old_status, r.root_run_id
+          FROM workflow_attempts a
+          JOIN workflow_runs r ON r.id = a.run_id
+          WHERE a.id = $1 AND a.lease_token = $2 AND a.status = 'started'
+        ),
+        updated AS (
         UPDATE workflow_attempts
         SET status = 'failed', error = $3::jsonb, completed_at = now()
-        WHERE id = $1 AND lease_token = $2 AND status = 'started'
-        RETURNING *
+        FROM candidate
+        WHERE workflow_attempts.id = candidate.id
+        RETURNING workflow_attempts.*, candidate.old_status, candidate.root_run_id
+        ),
+        ${emitAttemptStatusEventSql('updated', 'attempt_failed')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('attempt_failed')}
+        ) emitted
       `,
         [attemptId, leaseToken, json(toStoredError(error))],
       )
@@ -355,10 +453,25 @@ export const createPostgresWorkflowNodeStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT a.id, a.status::text AS old_status, r.root_run_id
+          FROM workflow_attempts a
+          JOIN workflow_runs r ON r.id = a.run_id
+          WHERE a.id = $1 AND a.lease_token = $2 AND a.status = 'started'
+        ),
+        updated AS (
         UPDATE workflow_attempts
         SET status = 'timedOut', error = $3::jsonb, completed_at = now()
-        WHERE id = $1 AND lease_token = $2 AND status = 'started'
-        RETURNING *
+        FROM candidate
+        WHERE workflow_attempts.id = candidate.id
+        RETURNING workflow_attempts.*, candidate.old_status, candidate.root_run_id
+        ),
+        ${emitAttemptStatusEventSql('updated', 'attempt_timed_out')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('attempt_timed_out')}
+        ) emitted
       `,
         [attemptId, leaseToken, json(toStoredError(error))],
       )
@@ -378,14 +491,30 @@ export const createPostgresWorkflowNodeStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT n.run_id, n.name, n.status::text AS old_status, r.root_run_id
+          FROM workflow_nodes n
+          JOIN workflow_runs r ON r.id = n.run_id
+          WHERE n.run_id = $1 AND n.name = $2
+        ),
+        updated AS (
         UPDATE workflow_nodes
         SET status = 'completed',
             output = $3::jsonb,
             version = version + 1,
             updated_at = now()
-        WHERE run_id = $1 AND name = $2
-          AND status IN (${nodeStatusSourcesSql('completed')})
-        RETURNING *
+        FROM candidate
+        WHERE workflow_nodes.run_id = candidate.run_id
+          AND workflow_nodes.name = candidate.name
+          AND workflow_nodes.status IN (${nodeStatusSourcesSql('completed')})
+        RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
+        ),
+        ${emitNodeStatusEventSql('updated', 'node_completed')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('node_completed')}
+        ) emitted
       `,
         [runId, nodeName, json(output)],
       )
@@ -411,14 +540,30 @@ export const createPostgresWorkflowNodeStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT n.run_id, n.name, n.status::text AS old_status, r.root_run_id
+          FROM workflow_nodes n
+          JOIN workflow_runs r ON r.id = n.run_id
+          WHERE n.run_id = $1 AND n.name = $2
+        ),
+        updated AS (
         UPDATE workflow_nodes
         SET status = 'failed',
             error = $3::jsonb,
             version = version + 1,
             updated_at = now()
-        WHERE run_id = $1 AND name = $2
-          AND status IN (${nodeStatusSourcesSql('failed')})
-        RETURNING *
+        FROM candidate
+        WHERE workflow_nodes.run_id = candidate.run_id
+          AND workflow_nodes.name = candidate.name
+          AND workflow_nodes.status IN (${nodeStatusSourcesSql('failed')})
+        RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
+        ),
+        ${emitNodeStatusEventSql('updated', 'node_failed')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('node_failed')}
+        ) emitted
       `,
         [runId, nodeName, json(toStoredError(error))],
       )
@@ -435,13 +580,27 @@ export const createPostgresWorkflowNodeStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT id, status::text AS old_status
+          FROM workflow_runs
+          WHERE id = $1
+        ),
+        updated AS (
         UPDATE workflow_runs
         SET status = 'running',
             version = version + 1,
             updated_at = now()
-        WHERE id = $1
-          AND status IN (${runStatusSourcesSql('running')})
-        RETURNING *
+        FROM candidate
+        WHERE workflow_runs.id = candidate.id
+          AND workflow_runs.status IN (${runStatusSourcesSql('running')})
+        RETURNING workflow_runs.*, candidate.old_status
+        ),
+        ${emitRunStatusEventSql('updated', 'run_running')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('run_running')}
+        ) emitted
       `,
         [runId],
       )
@@ -458,13 +617,27 @@ export const createPostgresWorkflowNodeStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT id, status::text AS old_status
+          FROM workflow_runs
+          WHERE id = $1
+        ),
+        updated AS (
         UPDATE workflow_runs
         SET status = 'waiting',
             version = version + 1,
             updated_at = now()
-        WHERE id = $1
-          AND status IN (${runStatusSourcesSql('waiting')})
-        RETURNING *
+        FROM candidate
+        WHERE workflow_runs.id = candidate.id
+          AND workflow_runs.status IN (${runStatusSourcesSql('waiting')})
+        RETURNING workflow_runs.*, candidate.old_status
+        ),
+        ${emitRunStatusEventSql('updated', 'run_waiting')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('run_waiting')}
+        ) emitted
       `,
         [runId],
       )
@@ -488,14 +661,28 @@ export const createPostgresWorkflowNodeStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT id, status::text AS old_status
+          FROM workflow_runs
+          WHERE id = $1
+        ),
+        updated AS (
         UPDATE workflow_runs
         SET status = 'completed',
             output = $2::jsonb,
             version = version + 1,
             updated_at = now()
-        WHERE id = $1
-          AND status IN (${runStatusSourcesSql('completed')})
-        RETURNING *
+        FROM candidate
+        WHERE workflow_runs.id = candidate.id
+          AND workflow_runs.status IN (${runStatusSourcesSql('completed')})
+        RETURNING workflow_runs.*, candidate.old_status
+        ),
+        ${emitRunStatusEventSql('updated', 'run_completed')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('run_completed')}
+        ) emitted
       `,
         [runId, json(output)],
       )
@@ -519,14 +706,28 @@ export const createPostgresWorkflowNodeStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT id, status::text AS old_status
+          FROM workflow_runs
+          WHERE id = $1
+        ),
+        updated AS (
         UPDATE workflow_runs
         SET status = 'failed',
             error = $2::jsonb,
             version = version + 1,
             updated_at = now()
-        WHERE id = $1
-          AND status IN (${runStatusSourcesSql('failed')})
-        RETURNING *
+        FROM candidate
+        WHERE workflow_runs.id = candidate.id
+          AND workflow_runs.status IN (${runStatusSourcesSql('failed')})
+        RETURNING workflow_runs.*, candidate.old_status
+        ),
+        ${emitRunStatusEventSql('updated', 'run_failed')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('run_failed')}
+        ) emitted
       `,
         [runId, json(toStoredError(error))],
       )
@@ -556,17 +757,31 @@ export const createPostgresWorkflowNodeStore = (
         db,
         `
         WITH updated AS (
+          WITH candidate AS (
+            SELECT id, status::text AS old_status
+            FROM workflow_runs
+            WHERE id = $1
+          )
           UPDATE workflow_runs
           SET status = 'cancelling',
               version = version + 1,
               updated_at = now()
-          WHERE id = $1
-            AND status IN (${runStatusSourcesSql('cancelling')})
-          RETURNING *
+          FROM candidate
+          WHERE workflow_runs.id = candidate.id
+            AND workflow_runs.status IN (${runStatusSourcesSql('cancelling')})
+          RETURNING workflow_runs.*, candidate.old_status
+        ),
+        ${emitRunStatusEventSql('updated', 'run_cancelling')},
+        cancellation_notified AS (
+          SELECT pg_notify('${WORKFLOW_CANCELLATIONS_CHANNEL}', id::text)
+          FROM updated
         )
-        SELECT updated.*,
-          pg_notify('${WORKFLOW_CANCELLATIONS_CHANNEL}', updated.id::text)
+        SELECT updated.*
         FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('run_cancelling')},
+            (SELECT count(*) FROM cancellation_notified)
+        ) emitted
       `,
         [runId],
       )
@@ -590,13 +805,27 @@ export const createPostgresWorkflowNodeStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT id, status::text AS old_status
+          FROM workflow_runs
+          WHERE id = $1
+        ),
+        updated AS (
         UPDATE workflow_runs
         SET status = 'cancelled',
             version = version + 1,
             updated_at = now()
-        WHERE id = $1
-          AND status IN (${runStatusSourcesSql('cancelled')})
-        RETURNING *
+        FROM candidate
+        WHERE workflow_runs.id = candidate.id
+          AND workflow_runs.status IN (${runStatusSourcesSql('cancelled')})
+        RETURNING workflow_runs.*, candidate.old_status
+        ),
+        ${emitRunStatusEventSql('updated', 'run_cancelled')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('run_cancelled')}
+        ) emitted
       `,
         [runId],
       )
@@ -622,13 +851,29 @@ export const createPostgresWorkflowNodeStore = (
       const row = await one(
         db,
         `
+        WITH candidate AS (
+          SELECT n.run_id, n.name, n.status::text AS old_status, r.root_run_id
+          FROM workflow_nodes n
+          JOIN workflow_runs r ON r.id = n.run_id
+          WHERE n.run_id = $1 AND n.name = $2
+        ),
+        updated AS (
         UPDATE workflow_nodes
         SET status = 'cancelled',
             version = version + 1,
             updated_at = now()
-        WHERE run_id = $1 AND name = $2
-          AND status IN (${nodeStatusSourcesSql('cancelled')})
-        RETURNING *
+        FROM candidate
+        WHERE workflow_nodes.run_id = candidate.run_id
+          AND workflow_nodes.name = candidate.name
+          AND workflow_nodes.status IN (${nodeStatusSourcesSql('cancelled')})
+        RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
+        ),
+        ${emitNodeStatusEventSql('updated', 'node_cancelled')}
+        SELECT updated.*
+        FROM updated
+        CROSS JOIN (
+          SELECT ${notifyRunStatusEventCountSql('node_cancelled')}
+        ) emitted
       `,
         [runId, nodeName],
       )
@@ -646,24 +891,56 @@ export const createPostgresWorkflowNodeStore = (
         const rows = await many(
           tx,
           `
+          WITH candidate AS (
+            SELECT n.run_id, n.name, n.status::text AS old_status, r.root_run_id
+            FROM workflow_nodes n
+            JOIN workflow_runs r ON r.id = n.run_id
+            WHERE n.run_id = $1
+          ),
+          updated AS (
           UPDATE workflow_nodes
           SET status = 'cancelled',
               version = version + 1,
               updated_at = now()
-          WHERE run_id = $1
-            AND status IN (${nodeStatusSourcesSql('cancelled')})
-          RETURNING *
+          FROM candidate
+          WHERE workflow_nodes.run_id = candidate.run_id
+            AND workflow_nodes.name = candidate.name
+            AND workflow_nodes.status IN (${nodeStatusSourcesSql('cancelled')})
+          RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
+          ),
+          ${emitNodeStatusEventSql('updated', 'nodes_cancelled')}
+          SELECT updated.*
+          FROM updated
+          CROSS JOIN (
+            SELECT ${notifyRunStatusEventCountSql('nodes_cancelled')}
+          ) emitted
         `,
           [runId],
         )
         await tx.query(
           `
+          WITH candidate AS (
+            SELECT c.run_id, c.node_name, c.child_key,
+              c.status::text AS old_status, r.root_run_id
+            FROM workflow_node_children c
+            JOIN workflow_runs r ON r.id = c.run_id
+            WHERE c.run_id = $1
+          ),
+          updated AS (
           UPDATE workflow_node_children
           SET status = 'cancelled',
               version = version + 1,
               updated_at = now()
-          WHERE run_id = $1
-            AND status IN (${nodeStatusSourcesSql('cancelled')})
+          FROM candidate
+          WHERE workflow_node_children.run_id = candidate.run_id
+            AND workflow_node_children.node_name = candidate.node_name
+            AND workflow_node_children.child_key = candidate.child_key
+            AND workflow_node_children.status IN (${nodeStatusSourcesSql('cancelled')})
+          RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
+          ),
+          ${emitChildStatusEventSql('updated', 'children_cancelled')}
+          SELECT count(*), ${notifyRunStatusEventCountSql('children_cancelled')}
+          FROM updated
         `,
           [runId],
         )

--- a/packages/workflows/src/adapters/postgres/store-nodes.ts
+++ b/packages/workflows/src/adapters/postgres/store-nodes.ts
@@ -28,7 +28,7 @@ import {
   mapNodeChild,
   mapRun,
   nodeStatusSourcesSql,
-  notifyRunStatusEventCountSql,
+  notifyRunStatusEventColumnsSql,
   one,
   runStatusSourcesSql,
   withDateColumns,
@@ -251,11 +251,8 @@ export const createPostgresWorkflowNodeStore = (
             JOIN workflow_runs r ON r.id = inserted.run_id
           ),
           ${emitAttemptStatusEventSql('event_source', 'attempt_started')}
-          SELECT inserted.*
+          SELECT inserted.*${notifyRunStatusEventColumnsSql('attempt_started')}
           FROM inserted
-          CROSS JOIN (
-            SELECT ${notifyRunStatusEventCountSql('attempt_started')}
-          ) emitted
         `,
           [
             attemptId,
@@ -293,11 +290,8 @@ export const createPostgresWorkflowNodeStore = (
           RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
           ),
           ${emitChildStatusEventSql('updated', 'child_running')}
-          SELECT updated.*
+          SELECT updated.*${notifyRunStatusEventColumnsSql('child_running')}
           FROM updated
-          CROSS JOIN (
-            SELECT ${notifyRunStatusEventCountSql('child_running')}
-          ) emitted
         `,
           [input.runId, input.nodeName, input.childKey, attemptId],
         )
@@ -326,7 +320,7 @@ export const createPostgresWorkflowNodeStore = (
           RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
           ),
           ${emitNodeStatusEventSql('updated', 'node_running')}
-          SELECT count(*), ${notifyRunStatusEventCountSql('node_running')}
+          SELECT count(*)${notifyRunStatusEventColumnsSql('node_running')}
           FROM updated
         `,
           [input.runId, input.nodeName],
@@ -363,11 +357,8 @@ export const createPostgresWorkflowNodeStore = (
             RETURNING workflow_attempts.*, candidate.old_status, candidate.root_run_id
             ),
             ${emitAttemptStatusEventSql('updated', 'attempt_completed')}
-            SELECT updated.*
+            SELECT updated.*${notifyRunStatusEventColumnsSql('attempt_completed')}
             FROM updated
-            CROSS JOIN (
-              SELECT ${notifyRunStatusEventCountSql('attempt_completed')}
-            ) emitted
           `,
             [attemptId, leaseToken, json(output)],
           )
@@ -397,11 +388,8 @@ export const createPostgresWorkflowNodeStore = (
             RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
             ),
             ${emitChildStatusEventSql('updated', 'child_completed')}
-            SELECT updated.*
+            SELECT updated.*${notifyRunStatusEventColumnsSql('child_completed')}
             FROM updated
-            CROSS JOIN (
-              SELECT ${notifyRunStatusEventCountSql('child_completed')}
-            ) emitted
           `,
             [run_id, node_name, child_key, attemptId, json(output)],
           )
@@ -435,11 +423,8 @@ export const createPostgresWorkflowNodeStore = (
         RETURNING workflow_attempts.*, candidate.old_status, candidate.root_run_id
         ),
         ${emitAttemptStatusEventSql('updated', 'attempt_failed')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('attempt_failed')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('attempt_failed')}
-        ) emitted
       `,
         [attemptId, leaseToken, json(toStoredError(error))],
       )
@@ -467,11 +452,8 @@ export const createPostgresWorkflowNodeStore = (
         RETURNING workflow_attempts.*, candidate.old_status, candidate.root_run_id
         ),
         ${emitAttemptStatusEventSql('updated', 'attempt_timed_out')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('attempt_timed_out')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('attempt_timed_out')}
-        ) emitted
       `,
         [attemptId, leaseToken, json(toStoredError(error))],
       )
@@ -510,11 +492,8 @@ export const createPostgresWorkflowNodeStore = (
         RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
         ),
         ${emitNodeStatusEventSql('updated', 'node_completed')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('node_completed')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('node_completed')}
-        ) emitted
       `,
         [runId, nodeName, json(output)],
       )
@@ -559,11 +538,8 @@ export const createPostgresWorkflowNodeStore = (
         RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
         ),
         ${emitNodeStatusEventSql('updated', 'node_failed')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('node_failed')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('node_failed')}
-        ) emitted
       `,
         [runId, nodeName, json(toStoredError(error))],
       )
@@ -596,11 +572,8 @@ export const createPostgresWorkflowNodeStore = (
         RETURNING workflow_runs.*, candidate.old_status
         ),
         ${emitRunStatusEventSql('updated', 'run_running')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('run_running')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('run_running')}
-        ) emitted
       `,
         [runId],
       )
@@ -633,11 +606,8 @@ export const createPostgresWorkflowNodeStore = (
         RETURNING workflow_runs.*, candidate.old_status
         ),
         ${emitRunStatusEventSql('updated', 'run_waiting')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('run_waiting')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('run_waiting')}
-        ) emitted
       `,
         [runId],
       )
@@ -678,11 +648,8 @@ export const createPostgresWorkflowNodeStore = (
         RETURNING workflow_runs.*, candidate.old_status
         ),
         ${emitRunStatusEventSql('updated', 'run_completed')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('run_completed')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('run_completed')}
-        ) emitted
       `,
         [runId, json(output)],
       )
@@ -723,11 +690,8 @@ export const createPostgresWorkflowNodeStore = (
         RETURNING workflow_runs.*, candidate.old_status
         ),
         ${emitRunStatusEventSql('updated', 'run_failed')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('run_failed')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('run_failed')}
-        ) emitted
       `,
         [runId, json(toStoredError(error))],
       )
@@ -776,12 +740,9 @@ export const createPostgresWorkflowNodeStore = (
           SELECT pg_notify('${WORKFLOW_CANCELLATIONS_CHANNEL}', id::text)
           FROM updated
         )
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('run_cancelling')},
+          (SELECT count(*) FROM cancellation_notified) AS cancellation_notified
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('run_cancelling')},
-            (SELECT count(*) FROM cancellation_notified)
-        ) emitted
       `,
         [runId],
       )
@@ -821,11 +782,8 @@ export const createPostgresWorkflowNodeStore = (
         RETURNING workflow_runs.*, candidate.old_status
         ),
         ${emitRunStatusEventSql('updated', 'run_cancelled')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('run_cancelled')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('run_cancelled')}
-        ) emitted
       `,
         [runId],
       )
@@ -869,11 +827,8 @@ export const createPostgresWorkflowNodeStore = (
         RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
         ),
         ${emitNodeStatusEventSql('updated', 'node_cancelled')}
-        SELECT updated.*
+        SELECT updated.*${notifyRunStatusEventColumnsSql('node_cancelled')}
         FROM updated
-        CROSS JOIN (
-          SELECT ${notifyRunStatusEventCountSql('node_cancelled')}
-        ) emitted
       `,
         [runId, nodeName],
       )
@@ -909,11 +864,8 @@ export const createPostgresWorkflowNodeStore = (
           RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
           ),
           ${emitNodeStatusEventSql('updated', 'nodes_cancelled')}
-          SELECT updated.*
+          SELECT updated.*${notifyRunStatusEventColumnsSql('nodes_cancelled')}
           FROM updated
-          CROSS JOIN (
-            SELECT ${notifyRunStatusEventCountSql('nodes_cancelled')}
-          ) emitted
         `,
           [runId],
         )
@@ -939,7 +891,7 @@ export const createPostgresWorkflowNodeStore = (
           RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
           ),
           ${emitChildStatusEventSql('updated', 'children_cancelled')}
-          SELECT count(*), ${notifyRunStatusEventCountSql('children_cancelled')}
+          SELECT count(*)${notifyRunStatusEventColumnsSql('children_cancelled')}
           FROM updated
         `,
           [runId],

--- a/packages/workflows/src/adapters/postgres/store-runs.ts
+++ b/packages/workflows/src/adapters/postgres/store-runs.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../runtime/store.ts'
 import type { WorkflowPostgresConnection } from './connection.ts'
 import type { JsonRecord } from './sql.ts'
+import { assertValidRunEventsCursor } from '../../runtime/store.ts'
 import {
   id,
   isUniqueViolation,
@@ -32,7 +33,7 @@ import {
   emitRunStatusEventSql,
   normalizePruneBatchSize,
   normalizePruneStatuses,
-  notifyRunStatusEventCountSql,
+  notifyRunStatusEventColumnsSql,
   now,
   one,
   runnableName,
@@ -119,11 +120,8 @@ export const createStoredRunWithState = async (
         RETURNING *, NULL::text AS old_status
       ),
       ${emitRunStatusEventSql('inserted', 'run_created')}
-      SELECT inserted.*
+      SELECT inserted.*${notifyRunStatusEventColumnsSql('run_created')}
       FROM inserted
-      CROSS JOIN (
-        SELECT ${notifyRunStatusEventCountSql('run_created')}
-      ) emitted
       `,
       [
         runId,
@@ -453,12 +451,7 @@ export const createPostgresWorkflowRunStore = (
       if (normalizedLimit !== undefined && normalizedLimit < 1) {
         return { events: [] }
       }
-      if (
-        afterEventId !== undefined &&
-        (!/^\d+$/.test(afterEventId) || BigInt(afterEventId) < 0n)
-      ) {
-        throw new Error(`Invalid run event cursor [${afterEventId}]`)
-      }
+      assertValidRunEventsCursor(afterEventId)
 
       const params: unknown[] = [runId, afterEventId ?? '0']
       const limitSql =

--- a/packages/workflows/src/adapters/postgres/store-runs.ts
+++ b/packages/workflows/src/adapters/postgres/store-runs.ts
@@ -26,10 +26,13 @@ import {
   mapNodeChildSummary,
   mapNodeSummary,
   mapRun,
+  mapRunEvent,
   mapRunSummary,
   DEFAULT_PRUNE_STATUSES,
+  emitRunStatusEventSql,
   normalizePruneBatchSize,
   normalizePruneStatuses,
+  notifyRunStatusEventCountSql,
   now,
   one,
   runnableName,
@@ -46,6 +49,7 @@ type PostgresWorkflowRunStore = Pick<
   WorkflowStore,
   | 'createRun'
   | 'listRuns'
+  | 'listRunEvents'
   | 'listRunSummaries'
   | 'pruneTerminalRuns'
   | 'deleteRun'
@@ -102,6 +106,7 @@ export const createStoredRunWithState = async (
     const row = await one(
       connection,
       `
+      WITH inserted AS (
         INSERT INTO workflow_runs (
           id, kind, name, workflow_name, task_name, status, input,
           parent_run_id, parent_node_name, root_run_id, tags,
@@ -111,7 +116,14 @@ export const createStoredRunWithState = async (
           $1, $2, $3, $4, $5, 'queued', $6::jsonb,
           $7, $8, $9, $10::jsonb, $11::jsonb, 1, $12, $12
         )
-        RETURNING *
+        RETURNING *, NULL::text AS old_status
+      ),
+      ${emitRunStatusEventSql('inserted', 'run_created')}
+      SELECT inserted.*
+      FROM inserted
+      CROSS JOIN (
+        SELECT ${notifyRunStatusEventCountSql('run_created')}
+      ) emitted
       `,
       [
         runId,
@@ -431,6 +443,54 @@ export const createPostgresWorkflowRunStore = (
         runs: page.map(mapRun),
         ...(query.limit !== null && rows.length > query.limit
           ? { nextCursor: String(query.offset + query.limit) }
+          : {}),
+      }
+    },
+    async listRunEvents({ runId, family = false, afterEventId, limit }) {
+      await ready
+      if (!isUuid(runId)) return { events: [] }
+      const normalizedLimit = normalizeEventLimit(limit)
+      if (normalizedLimit !== undefined && normalizedLimit < 1) {
+        return { events: [] }
+      }
+      if (
+        afterEventId !== undefined &&
+        (!/^\d+$/.test(afterEventId) || BigInt(afterEventId) < 0n)
+      ) {
+        throw new Error(`Invalid run event cursor [${afterEventId}]`)
+      }
+
+      const params: unknown[] = [runId, afterEventId ?? '0']
+      const limitSql =
+        normalizedLimit === undefined
+          ? ''
+          : `LIMIT $${params.push(normalizedLimit + 1)}`
+      const rows = await many(
+        db,
+        `
+        SELECT e.*
+        FROM workflow_run_events e
+        JOIN workflow_runs target
+          ON target.id = $1
+        WHERE e.id > $2::bigint
+          AND ${
+            family
+              ? 'e.root_run_id = target.root_run_id'
+              : 'e.run_id = target.id'
+          }
+        ORDER BY e.id ASC
+        ${limitSql}
+      `,
+        params,
+      )
+      const page =
+        normalizedLimit === undefined ? rows : rows.slice(0, normalizedLimit)
+      return {
+        events: page
+          .map((row) => withDateColumns(row, ['created_at']))
+          .map(mapRunEvent),
+        ...(normalizedLimit !== undefined && rows.length > normalizedLimit
+          ? { nextCursor: String(page.at(-1)?.id) }
           : {}),
       }
     },
@@ -814,4 +874,9 @@ export const createPostgresWorkflowRunStore = (
       }))
     },
   }
+}
+
+function normalizeEventLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) return undefined
+  return Number.isInteger(limit) && limit > 0 ? limit : 0
 }

--- a/packages/workflows/src/adapters/postgres/testing.ts
+++ b/packages/workflows/src/adapters/postgres/testing.ts
@@ -219,6 +219,21 @@ export async function installPostgresWorkflowSchemaForTesting(
     )
   `)
   await db.query(`
+    CREATE TABLE IF NOT EXISTS workflow_run_events (
+      id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      run_id uuid NOT NULL,
+      root_run_id uuid NOT NULL,
+      kind text NOT NULL,
+      status text NOT NULL,
+      node_name text,
+      child_key text,
+      attempt_id uuid,
+      attempt_number integer,
+      error jsonb,
+      created_at timestamptz NOT NULL
+    )
+  `)
+  await db.query(`
     CREATE TABLE IF NOT EXISTS workflow_commands (
       id uuid PRIMARY KEY,
       kind workflow_command_kind NOT NULL,
@@ -278,6 +293,14 @@ export async function installPostgresWorkflowSchemaForTesting(
   await db.query(`
     CREATE INDEX IF NOT EXISTS workflow_node_children_child_run_idx
     ON workflow_node_children (child_run_id)
+  `)
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS workflow_run_events_run_idx
+    ON workflow_run_events (run_id, id)
+  `)
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS workflow_run_events_root_idx
+    ON workflow_run_events (root_run_id, id)
   `)
   await db.query(`
     DO $$
@@ -363,6 +386,14 @@ export async function installPostgresWorkflowSchemaForTesting(
       IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'workflow_run_leases_run_fk') THEN
         ALTER TABLE workflow_run_leases
         ADD CONSTRAINT workflow_run_leases_run_fk
+        FOREIGN KEY (run_id)
+        REFERENCES workflow_runs(id)
+        ON DELETE CASCADE;
+      END IF;
+
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'workflow_run_events_run_fk') THEN
+        ALTER TABLE workflow_run_events
+        ADD CONSTRAINT workflow_run_events_run_fk
         FOREIGN KEY (run_id)
         REFERENCES workflow_runs(id)
         ON DELETE CASCADE;

--- a/packages/workflows/src/adapters/postgres/wake-events.ts
+++ b/packages/workflows/src/adapters/postgres/wake-events.ts
@@ -5,6 +5,7 @@ import type {
 import {
   WORKFLOW_CANCELLATIONS_CHANNEL,
   WORKFLOW_COMMANDS_CHANNEL,
+  WORKFLOW_RUN_EVENTS_CHANNEL,
 } from './sql.ts'
 
 const DEFAULT_RECONNECT_DELAY_MS = 1_000
@@ -52,6 +53,7 @@ export function createPostgresWorkflowWakeEvents(
   const reconnectDelayMs = params.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS
   const commandListeners = new Map<WorkflowCommandWakeKind, Set<() => void>>()
   const cancellationListeners = new Map<string, Set<() => void>>()
+  const runEventListeners = new Map<string, Set<() => void>>()
 
   let disposed = false
   let client: WorkflowPostgresListenerClient | undefined
@@ -83,6 +85,10 @@ export function createPostgresWorkflowWakeEvents(
     }
     if (message.channel === WORKFLOW_CANCELLATIONS_CHANNEL) {
       if (message.payload) fire(cancellationListeners.get(message.payload))
+      return
+    }
+    if (message.channel === WORKFLOW_RUN_EVENTS_CHANNEL) {
+      if (message.payload) fire(runEventListeners.get(message.payload))
     }
   }
 
@@ -119,7 +125,7 @@ export function createPostgresWorkflowWakeEvents(
       connected.on('error', onLost)
       connected.on('end', () => onLost())
       await connected.query(
-        `LISTEN "${WORKFLOW_COMMANDS_CHANNEL}"; LISTEN "${WORKFLOW_CANCELLATIONS_CHANNEL}"`,
+        `LISTEN "${WORKFLOW_COMMANDS_CHANNEL}"; LISTEN "${WORKFLOW_CANCELLATIONS_CHANNEL}"; LISTEN "${WORKFLOW_RUN_EVENTS_CHANNEL}"`,
       )
     } catch (error) {
       reportError(error)
@@ -147,11 +153,14 @@ export function createPostgresWorkflowWakeEvents(
     onCommand: (kind, listener) => subscribe(commandListeners, kind, listener),
     onCancellation: (runId, listener) =>
       subscribe(cancellationListeners, runId, listener),
+    onRunEvent: (rootRunId, listener) =>
+      subscribe(runEventListeners, rootRunId, listener),
     async dispose() {
       disposed = true
       if (reconnectTimer) clearTimeout(reconnectTimer)
       commandListeners.clear()
       cancellationListeners.clear()
+      runEventListeners.clear()
       const current = client
       client = undefined
       try {

--- a/packages/workflows/src/inspector/index.ts
+++ b/packages/workflows/src/inspector/index.ts
@@ -4,6 +4,7 @@ import type {
   StoredNode,
   StoredNodeChild,
   StoredRun,
+  StoredRunEvent,
 } from '../runtime/state.ts'
 import type {
   AttemptSummary,
@@ -185,6 +186,7 @@ export type RunDto = WireSafe<StoredRun>
 export type NodeDto = WireSafe<StoredNode>
 export type NodeChildDto = WireSafe<StoredNodeChild>
 export type AttemptDto = WireSafe<StoredAttempt>
+export type RunEventDto = WireSafe<StoredRunEvent>
 
 export type RunSnapshotDto = {
   readonly run: RunDto
@@ -251,6 +253,10 @@ export function toAttemptDto(attempt: StoredAttempt): AttemptDto {
     heartbeatAt: true,
     completedAt: true,
   })
+}
+
+export function toRunEventDto(event: StoredRunEvent): RunEventDto {
+  return convertDates(event, { createdAt: true })
 }
 
 export function toRunSnapshotDto(snapshot: RunSnapshot): RunSnapshotDto {

--- a/packages/workflows/src/runtime/client.ts
+++ b/packages/workflows/src/runtime/client.ts
@@ -224,12 +224,50 @@ async function* watchRun(params: {
   const pollIntervalMs = normalizePollInterval(params.options?.pollIntervalMs)
   let afterEventId = params.options?.afterEventId
   let cleanupWait: (() => void) | undefined
+  let resolveWait: (() => void) | undefined
+  let wakePending = false
+  const removeWake = params.wakeEvents?.onRunEvent?.(rootRunId, () => {
+    wakePending = true
+    resolveWait?.()
+  })
 
   const cleanup = () => {
     cleanupWait?.()
     cleanupWait = undefined
+    resolveWait = undefined
   }
 
+  const waitForChange = async () => {
+    if (wakePending) {
+      wakePending = false
+      return
+    }
+    await new Promise<void>((resolve) => {
+      let settled = false
+      const finish = () => {
+        if (settled) return
+        settled = true
+        cleanup()
+        resolve()
+      }
+      const timer = setTimeout(finish, pollIntervalMs)
+      const removeAbort =
+        params.options?.signal === undefined
+          ? undefined
+          : () => params.options?.signal?.removeEventListener('abort', finish)
+      params.options?.signal?.addEventListener('abort', finish, {
+        once: true,
+      })
+      resolveWait = finish
+      cleanupWait = () => {
+        clearTimeout(timer)
+        removeAbort?.()
+      }
+    })
+    wakePending = false
+  }
+
+  let checkedBeforeFirstWait = false
   try {
     while (!params.options?.signal?.aborted) {
       const result = await params.store.listRunEvents({
@@ -251,32 +289,33 @@ async function* watchRun(params: {
         if (params.options?.signal?.aborted) return
       }
 
-      await new Promise<void>((resolve) => {
-        let settled = false
-        const finish = () => {
-          if (settled) return
-          settled = true
-          cleanup()
-          resolve()
+      if (params.options?.signal?.aborted) return
+
+      if (result.events.length === 0 || !checkedBeforeFirstWait) {
+        checkedBeforeFirstWait = true
+        const [latestRun] = await params.store.loadRuns([params.runId])
+        if (latestRun && isTerminalRunStatus(latestRun.status)) {
+          // Event ids are allocated before commit, so concurrent commits can
+          // hide the terminal event behind the cursor; stored status is truth.
+          const finalResult = await params.store.listRunEvents({
+            runId: params.runId,
+            family: params.options?.family,
+            afterEventId,
+          })
+          for (const event of finalResult.events) {
+            afterEventId = event.id
+            yield event
+            if (params.options?.signal?.aborted) return
+          }
+          return
         }
-        const timer = setTimeout(finish, pollIntervalMs)
-        const removeWake = params.wakeEvents?.onRunEvent?.(rootRunId, finish)
-        const removeAbort =
-          params.options?.signal === undefined
-            ? undefined
-            : () => params.options?.signal?.removeEventListener('abort', finish)
-        params.options?.signal?.addEventListener('abort', finish, {
-          once: true,
-        })
-        cleanupWait = () => {
-          clearTimeout(timer)
-          removeWake?.()
-          removeAbort?.()
-        }
-      })
+      }
+
+      await waitForChange()
     }
   } finally {
     cleanup()
+    removeWake?.()
   }
 }
 

--- a/packages/workflows/src/runtime/client.ts
+++ b/packages/workflows/src/runtime/client.ts
@@ -13,7 +13,7 @@ import type {
 import type { WorkflowRuntimeAtomicStart } from './coordinator.ts'
 import type { AttemptExecutor, RunCoordinationExecutor } from './executors.ts'
 import type { WorkflowScheduler } from './scheduler.ts'
-import type { RunSnapshot, StoredRun } from './state.ts'
+import type { RunSnapshot, StoredRun, StoredRunEvent } from './state.ts'
 import type {
   DeadWorkflowCommand,
   DeleteRunResult,
@@ -46,6 +46,13 @@ export type WorkflowRuntimeStartOptions = {
   readonly tags?: Readonly<Record<string, string>>
   readonly idempotencyKey?: readonly unknown[]
   readonly startAt?: Date
+}
+
+export type WatchRunOptions = {
+  readonly family?: boolean
+  readonly afterEventId?: string
+  readonly signal?: AbortSignal
+  readonly pollIntervalMs?: number
 }
 
 export type WorkflowRuntimeAdapter = {
@@ -96,6 +103,10 @@ export type WorkflowRuntimeClient = {
     nodeName: string,
   ) => Promise<NodeSnapshot | undefined>
   readonly getFamily: (runId: string) => Promise<readonly RunFamilyEntry[]>
+  readonly watch: (
+    runId: string,
+    options?: WatchRunOptions,
+  ) => AsyncIterable<StoredRunEvent>
   readonly pruneRuns: (
     params: PruneTerminalRunsParams,
   ) => Promise<PruneTerminalRunsResult>
@@ -181,6 +192,13 @@ export function createWorkflowRuntimeClient(
     getNode: (runId, nodeName) =>
       input.store.loadNodeSnapshot({ runId, nodeName }),
     getFamily: (runId) => input.store.listRunFamily(runId),
+    watch: (runId, options) =>
+      watchRun({
+        store: input.store,
+        wakeEvents: input.wakeEvents,
+        runId,
+        options,
+      }),
     pruneRuns: (params) => pruneRuns(input.store, params),
     listDeadCommands: (params) => input.store.listDeadCommands(params),
     requeueDeadCommand: (id) => input.store.requeueDeadCommand(id),
@@ -191,6 +209,75 @@ export function createWorkflowRuntimeClient(
         requireScheduler().setEnabled(name, enabled),
     },
   })
+}
+
+async function* watchRun(params: {
+  readonly store: WorkflowStore
+  readonly wakeEvents?: WorkflowWakeEvents
+  readonly runId: string
+  readonly options?: WatchRunOptions
+}): AsyncIterable<StoredRunEvent> {
+  const [run] = await params.store.loadRuns([params.runId])
+  if (!run) return
+
+  const rootRunId = run.rootRunId
+  const pollIntervalMs = normalizePollInterval(params.options?.pollIntervalMs)
+  let afterEventId = params.options?.afterEventId
+  let cleanupWait: (() => void) | undefined
+
+  const cleanup = () => {
+    cleanupWait?.()
+    cleanupWait = undefined
+  }
+
+  try {
+    while (!params.options?.signal?.aborted) {
+      const result = await params.store.listRunEvents({
+        runId: params.runId,
+        family: params.options?.family,
+        afterEventId,
+      })
+
+      for (const event of result.events) {
+        afterEventId = event.id
+        yield event
+        if (
+          event.kind === 'run' &&
+          event.runId === params.runId &&
+          isTerminalRunStatus(event.status as StoredRun['status'])
+        ) {
+          return
+        }
+        if (params.options?.signal?.aborted) return
+      }
+
+      await new Promise<void>((resolve) => {
+        let settled = false
+        const finish = () => {
+          if (settled) return
+          settled = true
+          cleanup()
+          resolve()
+        }
+        const timer = setTimeout(finish, pollIntervalMs)
+        const removeWake = params.wakeEvents?.onRunEvent?.(rootRunId, finish)
+        const removeAbort =
+          params.options?.signal === undefined
+            ? undefined
+            : () => params.options?.signal?.removeEventListener('abort', finish)
+        params.options?.signal?.addEventListener('abort', finish, {
+          once: true,
+        })
+        cleanupWait = () => {
+          clearTimeout(timer)
+          removeWake?.()
+          removeAbort?.()
+        }
+      })
+    }
+  } finally {
+    cleanup()
+  }
 }
 
 async function pruneRuns(
@@ -255,6 +342,11 @@ function normalizePruneBatchSize(batchSize: number | undefined): number {
   if (batchSize === undefined) return 100
   if (!Number.isInteger(batchSize) || batchSize < 1) return 0
   return batchSize
+}
+
+function normalizePollInterval(intervalMs: number | undefined): number {
+  if (intervalMs === undefined) return 1_000
+  return Number.isFinite(intervalMs) && intervalMs > 0 ? intervalMs : 1_000
 }
 
 function getWorkflowImplementation<WorkflowDef extends AnyWorkflowDefinition>(

--- a/packages/workflows/src/runtime/in-memory.ts
+++ b/packages/workflows/src/runtime/in-memory.ts
@@ -52,6 +52,7 @@ import {
   startStoredScheduleRun,
 } from './scheduler.ts'
 import { isTerminalNodeStatus, isTerminalRunStatus } from './status.ts'
+import { assertValidRunEventsCursor } from './store.ts'
 import {
   NODE_TRANSITIONS,
   RUN_TRANSITIONS,
@@ -450,6 +451,7 @@ export function createInMemoryWorkflowRuntime(
       if (normalizedLimit !== undefined && normalizedLimit < 1) {
         return { events: [] }
       }
+      assertValidRunEventsCursor(afterEventId)
       const after = afterEventId === undefined ? 0n : BigInt(afterEventId)
       const filtered = runEvents.filter(
         (event) =>

--- a/packages/workflows/src/runtime/in-memory.ts
+++ b/packages/workflows/src/runtime/in-memory.ts
@@ -20,6 +20,7 @@ import type {
   StoredNode,
   StoredNodeChild,
   StoredRun,
+  StoredRunEvent,
 } from './state.ts'
 import type {
   AttemptSummary,
@@ -39,6 +40,10 @@ import type {
   WorkflowRetentionPruner,
   WorkflowStore,
 } from './store.ts'
+import type {
+  WorkflowCommandWakeKind,
+  WorkflowWakeEvents,
+} from './wake-events.ts'
 import { dispatchTaskRunAttempt } from './coordinator/attempt.ts'
 import { toStoredError } from './errors.ts'
 import {
@@ -101,11 +106,13 @@ export type InMemoryWorkflowRuntime = {
     readonly nodes: readonly StoredNode[]
     readonly children: readonly StoredNodeChild[]
     readonly attempts: readonly StoredAttempt[]
+    readonly runEvents: readonly StoredRunEvent[]
     readonly continueRunCommands: readonly InspectQueueItem<ContinueRunCommand>[]
     readonly activityCommands: readonly InspectQueueItem<ActivityAttemptCommand>[]
     readonly taskCommands: readonly InspectQueueItem<TaskAttemptCommand>[]
     readonly schedules: readonly StoredWorkflowSchedule[]
   }
+  readonly wakeEvents: WorkflowWakeEvents
 }
 
 export function createInMemoryWorkflowRuntime(
@@ -114,6 +121,7 @@ export function createInMemoryWorkflowRuntime(
   } = {},
 ): InMemoryWorkflowRuntime {
   let nextId = 1
+  let nextEventId = 1n
   const id = (prefix: string) => `${prefix}-${nextId++}`
   let lastTimestamp = 0
   const now = () => {
@@ -127,6 +135,7 @@ export function createInMemoryWorkflowRuntime(
   const nodes = new Map<string, StoredNode>()
   const attempts = new Map<string, StoredAttempt>()
   const children = new Map<string, StoredNodeChild>()
+  const runEvents: StoredRunEvent[] = []
   const runIdempotencyKeys = new Map<string, string>()
   const runLeases = new Map<string, InMemoryRunLease>()
   const continueRunCommands: QueueItem<ContinueRunCommand>[] = []
@@ -145,12 +154,99 @@ export function createInMemoryWorkflowRuntime(
     ClaimedQueueItem<TaskAttemptCommand>
   >()
   const schedules = new Map<string, StoredWorkflowSchedule>()
+  const commandWakeListeners = new Map<
+    WorkflowCommandWakeKind,
+    Set<() => void>
+  >()
+  const cancellationWakeListeners = new Map<string, Set<() => void>>()
+  const runEventWakeListeners = new Map<string, Set<() => void>>()
 
   const nodeKey = (runId: string, nodeName: string) => `${runId}:${nodeName}`
   const childKey = (runId: string, nodeName: string, key: string) =>
     `${runId}:${nodeName}:${key}`
   const childRef = (runId: string, nodeName: string, key: string) =>
     `${runId}.${nodeName}.${key}`
+  const subscribeWake = <K>(
+    listeners: Map<K, Set<() => void>>,
+    key: K,
+    listener: () => void,
+  ) => {
+    const set = listeners.get(key) ?? new Set<() => void>()
+    listeners.set(key, set)
+    set.add(listener)
+    return () => {
+      set.delete(listener)
+      if (set.size === 0) listeners.delete(key)
+    }
+  }
+  const fireWake = (listeners: Set<() => void> | undefined) => {
+    if (!listeners) return
+    for (const listener of listeners) listener()
+  }
+  const fireRunEventWake = (rootRunId: string) =>
+    fireWake(runEventWakeListeners.get(rootRunId))
+  const runRootId = (runId: string) => runs.get(runId)?.rootRunId ?? runId
+  const appendRunEvent = (event: Omit<StoredRunEvent, 'id' | 'createdAt'>) => {
+    const stored: StoredRunEvent = {
+      ...event,
+      id: String(nextEventId++),
+      createdAt: now(),
+    }
+    runEvents.push(stored)
+    fireRunEventWake(stored.rootRunId)
+  }
+  const emitRunStatusEvent = (run: StoredRun) => {
+    appendRunEvent({
+      runId: run.id,
+      rootRunId: run.rootRunId,
+      kind: 'run',
+      status: run.status,
+      ...(run.error === undefined ? {} : { error: run.error }),
+    })
+  }
+  const emitNodeStatusEvent = (before: StoredNode, after: StoredNode) => {
+    if (before.status === after.status) return
+    appendRunEvent({
+      runId: after.runId,
+      rootRunId: runRootId(after.runId),
+      kind: 'node',
+      status: after.status,
+      nodeName: after.name,
+      ...(after.error === undefined ? {} : { error: after.error }),
+    })
+  }
+  const emitChildStatusEvent = (
+    before: StoredNodeChild,
+    after: StoredNodeChild,
+  ) => {
+    if (before.status === after.status) return
+    appendRunEvent({
+      runId: after.runId,
+      rootRunId: runRootId(after.runId),
+      kind: 'child',
+      status: after.status,
+      nodeName: after.nodeName,
+      childKey: after.childKey,
+      ...(after.error === undefined ? {} : { error: after.error }),
+    })
+  }
+  const emitAttemptStatusEvent = (
+    before: StoredAttempt | undefined,
+    after: StoredAttempt,
+  ) => {
+    if (before?.status === after.status) return
+    appendRunEvent({
+      runId: after.runId,
+      rootRunId: runRootId(after.runId),
+      kind: 'attempt',
+      status: after.status,
+      nodeName: after.nodeName,
+      childKey: after.childKey,
+      attemptId: after.id,
+      attemptNumber: after.attemptNumber,
+      ...(after.error === undefined ? {} : { error: after.error }),
+    })
+  }
   const sortedChildren = (rows: readonly StoredNodeChild[]) =>
     [...rows].sort((left, right) => {
       const byOrdinal = left.ordinal - right.ordinal
@@ -339,12 +435,37 @@ export function createInMemoryWorkflowRuntime(
     if (input.idempotencyKey) {
       runIdempotencyKeys.set(runIdempotencyKey(input.idempotencyKey), run.id)
     }
+    emitRunStatusEvent(run)
     return { run, created: true }
   }
 
   const store: WorkflowStore = {
     async createRun(input: CreateRunInput) {
       return createRunWithState(input).run
+    },
+    async listRunEvents({ runId, family = false, afterEventId, limit }) {
+      const run = runs.get(runId)
+      if (!run) return { events: [] }
+      const normalizedLimit = normalizeEventLimit(limit)
+      if (normalizedLimit !== undefined && normalizedLimit < 1) {
+        return { events: [] }
+      }
+      const after = afterEventId === undefined ? 0n : BigInt(afterEventId)
+      const filtered = runEvents.filter(
+        (event) =>
+          BigInt(event.id) > after &&
+          (family ? event.rootRunId === run.rootRunId : event.runId === run.id),
+      )
+      const page =
+        normalizedLimit === undefined
+          ? filtered
+          : filtered.slice(0, normalizedLimit)
+      return {
+        events: page,
+        ...(normalizedLimit !== undefined && filtered.length > page.length
+          ? { nextCursor: page.at(-1)?.id }
+          : {}),
+      }
     },
     async listRuns(filter: ListRunsFilter = {}) {
       const limit = filter.limit ?? Number.POSITIVE_INFINITY
@@ -665,7 +786,6 @@ export function createInMemoryWorkflowRuntime(
       const updated: StoredNode = {
         ...node,
         input,
-        status: 'running',
         version: node.version + 1,
         updatedAt: now(),
       }
@@ -720,6 +840,7 @@ export function createInMemoryWorkflowRuntime(
         completedAt: now(),
       }
       attempts.set(attemptId, updated)
+      emitAttemptStatusEvent(attempt, updated)
       const completedChild: StoredNodeChild = {
         ...child,
         status: 'completed',
@@ -731,6 +852,7 @@ export function createInMemoryWorkflowRuntime(
         childKey(child.runId, child.nodeName, child.childKey),
         completedChild,
       )
+      emitChildStatusEvent(child, completedChild)
       return updated
     },
     async failCurrentAttempt({ attemptId, leaseToken, error }) {
@@ -744,6 +866,7 @@ export function createInMemoryWorkflowRuntime(
         completedAt: now(),
       }
       attempts.set(attemptId, updated)
+      emitAttemptStatusEvent(fenced.attempt, updated)
       return updated
     },
     async timeoutCurrentAttempt({ attemptId, leaseToken, error }) {
@@ -757,6 +880,7 @@ export function createInMemoryWorkflowRuntime(
         completedAt: now(),
       }
       attempts.set(attemptId, updated)
+      emitAttemptStatusEvent(fenced.attempt, updated)
       return updated
     },
     async completeNode({ runId, nodeName, output }) {
@@ -773,6 +897,7 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       nodes.set(key, updated)
+      emitNodeStatusEvent(node, updated)
       return updated
     },
     async failNode({ runId, nodeName, error }) {
@@ -789,6 +914,7 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       nodes.set(key, updated)
+      emitNodeStatusEvent(node, updated)
       return updated
     },
     async markRunRunning({ runId }) {
@@ -803,6 +929,7 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       runs.set(runId, updated)
+      emitRunStatusEvent(updated)
       return updated
     },
     async markRunWaiting({ runId }) {
@@ -817,6 +944,7 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       runs.set(runId, updated)
+      emitRunStatusEvent(updated)
       return updated
     },
     async completeRun({ runId, output }) {
@@ -832,6 +960,7 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       runs.set(runId, updated)
+      emitRunStatusEvent(updated)
       return updated
     },
     async failRun({ runId, error }) {
@@ -847,6 +976,7 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       runs.set(runId, updated)
+      emitRunStatusEvent(updated)
       return updated
     },
     async requestRunCancellation({ runId }) {
@@ -863,6 +993,8 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       runs.set(runId, updated)
+      emitRunStatusEvent(updated)
+      fireWake(cancellationWakeListeners.get(runId))
       return updated
     },
     async cancelRun({ runId }) {
@@ -877,6 +1009,7 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       runs.set(runId, updated)
+      emitRunStatusEvent(updated)
       return updated
     },
     async cancelNode({ runId, nodeName }) {
@@ -892,6 +1025,7 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       nodes.set(key, updated)
+      emitNodeStatusEvent(node, updated)
       return updated
     },
     async cancelNonTerminalRunNodes({ runId }) {
@@ -905,18 +1039,24 @@ export function createInMemoryWorkflowRuntime(
           updatedAt: now(),
         }
         nodes.set(nodeKey(node.runId, node.name), cancelled)
+        emitNodeStatusEvent(node, cancelled)
         updated.push(cancelled)
       }
       for (const child of Array.from(children.values())) {
         if (child.runId !== runId || isTerminalNodeStatus(child.status)) {
           continue
         }
-        children.set(childKey(child.runId, child.nodeName, child.childKey), {
+        const cancelled: StoredNodeChild = {
           ...child,
           status: 'cancelled',
           version: child.version + 1,
           updatedAt: now(),
-        })
+        }
+        children.set(
+          childKey(child.runId, child.nodeName, child.childKey),
+          cancelled,
+        )
+        emitChildStatusEvent(child, cancelled)
       }
       return updated
     },
@@ -1029,6 +1169,7 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       children.set(key, linked)
+      emitChildStatusEvent(child, linked)
       return { child: linked, childRun, created: true }
     },
     async ensureChildAttempt(params) {
@@ -1088,6 +1229,7 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       children.set(mapKey, updated)
+      emitChildStatusEvent(child, updated)
       return updated
     },
     async failNodeChild({ runId, nodeName, childKey: key, error }) {
@@ -1104,6 +1246,7 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       children.set(mapKey, updated)
+      emitChildStatusEvent(child, updated)
       return updated
     },
     async waitNode({ runId, nodeName }) {
@@ -1120,6 +1263,7 @@ export function createInMemoryWorkflowRuntime(
         updatedAt: now(),
       }
       nodes.set(key, updated)
+      emitNodeStatusEvent(node, updated)
       return updated
     },
     async loadNodeChildren({ runId, nodeName }) {
@@ -1150,14 +1294,20 @@ export function createInMemoryWorkflowRuntime(
       dispatchedAt: now(),
     }
     attempts.set(attempt.id, attempt)
-    children.set(childKey(child.runId, child.nodeName, child.childKey), {
+    emitAttemptStatusEvent(undefined, attempt)
+    const updatedChild: StoredNodeChild = {
       ...child,
       status: 'running',
       currentAttemptId: attempt.id,
       attemptCount: child.attemptCount + 1,
       version: child.version + 1,
       updatedAt: now(),
-    })
+    }
+    children.set(
+      childKey(child.runId, child.nodeName, child.childKey),
+      updatedChild,
+    )
+    emitChildStatusEvent(child, updatedChild)
 
     // Aggregate hint only: the node mirrors "some child is executing" so
     // observers see progress without deriving it from child rows.
@@ -1170,12 +1320,14 @@ export function createInMemoryWorkflowRuntime(
       (node.status === 'running' ||
         canTransition(NODE_TRANSITIONS, node.status, 'running'))
     ) {
-      nodes.set(key, {
+      const updatedNode: StoredNode = {
         ...node,
         status: 'running',
         version: node.version + 1,
         updatedAt: now(),
-      })
+      }
+      nodes.set(key, updatedNode)
+      emitNodeStatusEvent(node, updatedNode)
     }
     return attempt
   }
@@ -1276,6 +1428,9 @@ export function createInMemoryWorkflowRuntime(
         children.delete(key)
       }
     }
+    for (let index = runEvents.length - 1; index >= 0; index -= 1) {
+      if (treeIds.has(runEvents[index]!.runId)) runEvents.splice(index, 1)
+    }
     deleteQueueItemsForRunIds(continueRunCommands, treeIds)
     deleteQueueItemsForRunIds(activityCommands, treeIds)
     deleteQueueItemsForRunIds(taskCommands, treeIds)
@@ -1354,6 +1509,9 @@ export function createInMemoryWorkflowRuntime(
     )
     if (existingIndex === -1) {
       continueRunCommands.push(queueItem(id('continue'), command, runAt))
+      if (runAt === undefined || runAt <= new Date()) {
+        fireWake(commandWakeListeners.get('continue'))
+      }
       return
     }
 
@@ -1362,6 +1520,9 @@ export function createInMemoryWorkflowRuntime(
       ...existing,
       payload: command,
       runAt: earliestRunAt(existing.runAt, runAt),
+    }
+    if (runAt === undefined || runAt <= new Date()) {
+      fireWake(commandWakeListeners.get('continue'))
     }
   }
   const releaseQueueItem = <T>(
@@ -1527,10 +1688,16 @@ export function createInMemoryWorkflowRuntime(
       activityCommands.push(
         queueItem(id('activity-command'), command, options?.runAt),
       )
+      if (options?.runAt === undefined || options.runAt <= new Date()) {
+        fireWake(commandWakeListeners.get('activity'))
+      }
     },
     async dispatchTask(command, options) {
       if (attemptCommandExists(command.attemptId)) return
       taskCommands.push(queueItem(id('task-command'), command, options?.runAt))
+      if (options?.runAt === undefined || options.runAt <= new Date()) {
+        fireWake(commandWakeListeners.get('task'))
+      }
     },
     async claimActivity(worker) {
       const date = now()
@@ -1768,12 +1935,31 @@ export function createInMemoryWorkflowRuntime(
       nodes: [...nodes.values()],
       children: [...children.values()],
       attempts: [...attempts.values()],
+      runEvents: [...runEvents],
       continueRunCommands: continueRunCommands.map(inspectQueueItem),
       activityCommands: activityCommands.map(inspectQueueItem),
       taskCommands: taskCommands.map(inspectQueueItem),
       schedules: [...schedules.values()],
     }),
+    wakeEvents: {
+      onCommand: (kind, listener) =>
+        subscribeWake(commandWakeListeners, kind, listener),
+      onCancellation: (runId, listener) =>
+        subscribeWake(cancellationWakeListeners, runId, listener),
+      onRunEvent: (rootRunId, listener) =>
+        subscribeWake(runEventWakeListeners, rootRunId, listener),
+      dispose() {
+        commandWakeListeners.clear()
+        cancellationWakeListeners.clear()
+        runEventWakeListeners.clear()
+      },
+    },
   }
+}
+
+function normalizeEventLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) return undefined
+  return Number.isInteger(limit) && limit > 0 ? limit : 0
 }
 
 function compareSchedulesByDueDate(

--- a/packages/workflows/src/runtime/index.ts
+++ b/packages/workflows/src/runtime/index.ts
@@ -12,6 +12,7 @@ export type {
 export { createWorkflowRuntimeClient } from './client.ts'
 export type {
   CreateWorkflowRuntimeClientInput,
+  WatchRunOptions,
   WorkflowRuntimeAdapter,
   WorkflowRuntimeClient,
   WorkflowRuntimeStartOptions,
@@ -50,12 +51,14 @@ export type {
 export { isTerminalNodeStatus, isTerminalRunStatus } from './status.ts'
 export type {
   NodeChildKind,
+  RunEventKind,
   RunSnapshot,
   StoredAttempt,
   StoredError,
   StoredNode,
   StoredNodeChild,
   StoredRun,
+  StoredRunEvent,
 } from './state.ts'
 export {
   SELF_CHILD_KEY,
@@ -94,6 +97,8 @@ export type {
   EnsureNodeChildrenParams,
   EnsureNodeChildrenResult,
   ListRunsFilter,
+  ListRunEventsParams,
+  ListRunEventsResult,
   ListRunSummariesResult,
   ListRunsResult,
   LoadNodeChildrenParams,

--- a/packages/workflows/src/runtime/state.ts
+++ b/packages/workflows/src/runtime/state.ts
@@ -12,6 +12,22 @@ export type StoredError = {
   readonly cause?: StoredError
 }
 
+export type RunEventKind = 'run' | 'node' | 'child' | 'attempt'
+
+export type StoredRunEvent = {
+  readonly id: string
+  readonly runId: string
+  readonly rootRunId: string
+  readonly kind: RunEventKind
+  readonly status: string
+  readonly nodeName?: string
+  readonly childKey?: string
+  readonly attemptId?: string
+  readonly attemptNumber?: number
+  readonly error?: StoredError
+  readonly createdAt: Date
+}
+
 export type StoredRun = {
   readonly id: string
   readonly kind: RunKind

--- a/packages/workflows/src/runtime/store.ts
+++ b/packages/workflows/src/runtime/store.ts
@@ -72,6 +72,15 @@ export type ListRunEventsResult = {
   readonly nextCursor?: string
 }
 
+const runEventsCursorPattern = /^[1-9]\d*$/
+
+export function assertValidRunEventsCursor(afterEventId: string | undefined) {
+  if (afterEventId === undefined) return
+  if (!runEventsCursorPattern.test(afterEventId)) {
+    throw new Error(`Invalid run events cursor [${afterEventId}]`)
+  }
+}
+
 export type RunSummary = Omit<StoredRun, 'input' | 'output'> & {
   readonly nodesTotal: number
   readonly nodesCompleted: number

--- a/packages/workflows/src/runtime/store.ts
+++ b/packages/workflows/src/runtime/store.ts
@@ -7,6 +7,7 @@ import type {
   StoredNode,
   StoredNodeChild,
   StoredRun,
+  StoredRunEvent,
 } from './state.ts'
 import type { RuntimeRunStatus } from './status.ts'
 
@@ -55,6 +56,19 @@ export type ListRunsFilter = {
 
 export type ListRunsResult = {
   readonly runs: readonly StoredRun[]
+  readonly nextCursor?: string
+}
+
+export type ListRunEventsParams = {
+  readonly runId: string
+  /** Match by rootRunId instead of runId — one cursor over a whole family. */
+  readonly family?: boolean
+  readonly afterEventId?: string
+  readonly limit?: number
+}
+
+export type ListRunEventsResult = {
+  readonly events: readonly StoredRunEvent[]
   readonly nextCursor?: string
 }
 
@@ -234,6 +248,7 @@ export type CancelNonTerminalRunNodesParams = {
 export type WorkflowStore = {
   createRun(input: CreateRunInput): Promise<StoredRun>
   listRuns(filter?: ListRunsFilter): Promise<ListRunsResult>
+  listRunEvents(params: ListRunEventsParams): Promise<ListRunEventsResult>
   listRunSummaries(filter?: ListRunsFilter): Promise<ListRunSummariesResult>
   pruneTerminalRuns(
     params: PruneTerminalRunsParams,

--- a/packages/workflows/src/runtime/wake-events.ts
+++ b/packages/workflows/src/runtime/wake-events.ts
@@ -11,5 +11,7 @@ export type WorkflowWakeEvents = {
   onCommand(kind: WorkflowCommandWakeKind, listener: () => void): () => void
   /** Fires when cancellation has been requested for the given run. */
   onCancellation(runId: string, listener: () => void): () => void
+  /** Fires when new run events may exist for the given root run. */
+  onRunEvent?(rootRunId: string, listener: () => void): () => void
   dispose?(): Promise<void> | void
 }

--- a/packages/workflows/tests/fixtures/drizzle-workflow-schema.ts
+++ b/packages/workflows/tests/fixtures/drizzle-workflow-schema.ts
@@ -6,6 +6,7 @@ export const WorkflowAttemptTable = workflows.tables.attempts
 export const WorkflowCommandTable = workflows.tables.commands
 export const WorkflowNodeChildTable = workflows.tables.nodeChildren
 export const WorkflowNodeTable = workflows.tables.nodes
+export const WorkflowRunEventTable = workflows.tables.runEvents
 export const WorkflowRunLeaseTable = workflows.tables.runLeases
 export const WorkflowRunTable = workflows.tables.runs
 export const WorkflowScheduleTable = workflows.tables.schedules

--- a/packages/workflows/tests/inspector.spec.ts
+++ b/packages/workflows/tests/inspector.spec.ts
@@ -6,6 +6,7 @@ import type {
   StoredAttempt,
   StoredNode,
   StoredNodeChild,
+  StoredRunEvent,
 } from '../src/runtime/state.ts'
 import type {
   AttemptSummary,
@@ -25,6 +26,7 @@ import {
   toNodeSnapshotDto,
   toNodeUnitDto,
   toRunDetailDto,
+  toRunEventDto,
   toRunFamilyEntryDto,
   toRunSnapshotDto,
 } from '../src/inspector/index.ts'
@@ -273,6 +275,28 @@ describe('snapshot DTO mappers', () => {
 
     const dto = toAttemptDto(attempt)
     expect(dto.error).toEqual(attempt.error)
+    expect(JSON.parse(JSON.stringify(dto))).toEqual(dto)
+  })
+
+  it('converts run event dates and round-trips through JSON', () => {
+    const event: StoredRunEvent = {
+      id: '42',
+      runId: 'run-1',
+      rootRunId: 'run-1',
+      kind: 'attempt',
+      status: 'failed',
+      nodeName: 'extract',
+      childKey: '$self',
+      attemptId: 'attempt-1',
+      attemptNumber: 2,
+      error: { name: 'Error', message: 'boom' },
+      createdAt,
+    }
+
+    const dto = toRunEventDto(event)
+
+    expect(dto.createdAt).toBe('2026-07-08T10:00:00.000Z')
+    expect(dto.error).toEqual(event.error)
     expect(JSON.parse(JSON.stringify(dto))).toEqual(dto)
   })
 })

--- a/packages/workflows/tests/integration/helpers.ts
+++ b/packages/workflows/tests/integration/helpers.ts
@@ -78,6 +78,7 @@ async function truncateWorkflowTables(pool: PgPool) {
       workflow_schedules,
       workflow_commands,
       workflow_run_leases,
+      workflow_run_events,
       workflow_node_children,
       workflow_attempts,
       workflow_nodes,

--- a/packages/workflows/tests/integration/postgres-wake-events.spec.ts
+++ b/packages/workflows/tests/integration/postgres-wake-events.spec.ts
@@ -176,6 +176,43 @@ describe.skipIf(!postgresTarget.url)(
       }
     })
 
+    it('watches run events through LISTEN/NOTIFY without waiting for polling', async () => {
+      const harness = await createHarness()
+      const wakeEvents = await createWakeEvents()
+      const runtime = createPostgresWorkflowRuntime({
+        connection: harness.runtime.connection,
+        wakeEvents,
+      })
+      const client = createWorkflowRuntimeClient(runtime)
+      const run = await runtime.store.createRun({
+        workflowName: createTestName('postgres-watch-run-events'),
+        input: {},
+      })
+      const cursor = (
+        await runtime.store.listRunEvents({ runId: run.id })
+      ).events.at(-1)?.id
+      const iterator = client
+        .watch(run.id, {
+          afterEventId: cursor,
+          pollIntervalMs: LONG_DELAY_MS,
+        })
+        [Symbol.asyncIterator]()
+
+      try {
+        const nextEvent = iterator.next()
+        await harness.runtime.store.markRunRunning({ runId: run.id })
+
+        await expect(
+          Promise.race([
+            nextEvent.then((result) => result.value?.status),
+            wait(3_000).then(() => 'timeout'),
+          ]),
+        ).resolves.toBe('running')
+      } finally {
+        await iterator.return?.()
+      }
+    })
+
     it('aborts a running activity on cancel without waiting for the heartbeat cycle', async () => {
       const harness = await createHarness()
       const wakeEvents = await createWakeEvents()

--- a/packages/workflows/tests/postgres-drizzle-schema.spec.ts
+++ b/packages/workflows/tests/postgres-drizzle-schema.spec.ts
@@ -621,6 +621,18 @@ test('creates drizzle schema with canonical runtime names', () => {
   expect(schema.tables.commands.runId.columnType).toBe('PgUUID')
   expect(schema.tables.commands.attemptId.columnType).toBe('PgUUID')
   expect(schema.tables.commands.payload.hasDefault).toBe(true)
+  expect(getTableName(schema.tables.runEvents)).toBe('workflow_run_events')
+  expect(schema.tables.runEvents.id.columnType).toBe('PgBigInt64')
+  expect(schema.tables.runEvents.runId.columnType).toBe('PgUUID')
+  expect(schema.tables.runEvents.rootRunId.columnType).toBe('PgUUID')
+  expect(schema.tables.runEvents.kind.columnType).toBe('PgText')
+  expect(schema.tables.runEvents.status.columnType).toBe('PgText')
+  expect(schema.tables.runEvents.nodeName.columnType).toBe('PgText')
+  expect(schema.tables.runEvents.childKey.columnType).toBe('PgText')
+  expect(schema.tables.runEvents.attemptId.columnType).toBe('PgUUID')
+  expect(schema.tables.runEvents.attemptNumber.columnType).toBe('PgInteger')
+  expect(schema.tables.runEvents.error.columnType).toBe('PgJsonb')
+  expect(schema.tables.runEvents.createdAt.notNull).toBe(true)
   expect(primaryKeyColumns(schema.tables.nodes)).toContainEqual([
     'run_id',
     'name',
@@ -728,6 +740,16 @@ test('creates drizzle schema with canonical runtime names', () => {
       },
     ]),
   )
+  expect(foreignKeys(schema.tables.runEvents)).toEqual(
+    expect.arrayContaining([
+      {
+        columns: ['run_id'],
+        foreignTable: 'workflow_runs',
+        foreignColumns: ['id'],
+        onDelete: 'cascade',
+      },
+    ]),
+  )
   expect(schema.tables.nodeChildren.kind.enumValues).toStrictEqual([
     'activity',
     'task',
@@ -757,15 +779,23 @@ test('creates drizzle schema with canonical runtime names', () => {
   expect(schema.enums.commandKind.enumName).toBe('workflow_command_kind')
   expect(schema.enums.commandKind.schema).toBeUndefined()
   // manifest ⇄ drizzle agreement: same tables, same enums, same enum labels
-  expect([...WORKFLOW_POSTGRES_SCHEMA_MANIFEST.tables].sort()).toStrictEqual(
+  expect(
+    [...WORKFLOW_POSTGRES_SCHEMA_MANIFEST.tables].sort((left, right) =>
+      left.localeCompare(right),
+    ),
+  ).toStrictEqual(
     Object.values(schema.tables)
       .map((table) => getTableName(table))
-      .sort(),
+      .sort((left, right) => left.localeCompare(right)),
   )
-  expect([...WORKFLOW_POSTGRES_SCHEMA_MANIFEST.enums].sort()).toStrictEqual(
+  expect(
+    [...WORKFLOW_POSTGRES_SCHEMA_MANIFEST.enums].sort((left, right) =>
+      left.localeCompare(right),
+    ),
+  ).toStrictEqual(
     Object.values(schema.enums)
       .map((schemaEnum) => schemaEnum.enumName)
-      .sort(),
+      .sort((left, right) => left.localeCompare(right)),
   )
   for (const schemaEnum of Object.values(schema.enums)) {
     expect(
@@ -787,6 +817,8 @@ test('creates drizzle schema with canonical runtime names', () => {
       'workflow_commands_run_idx',
       'workflow_commands_claim_idx',
       'workflow_commands_continue_dedup_idx',
+      'workflow_run_events_run_idx',
+      'workflow_run_events_root_idx',
       'workflow_schedules_due_idx',
     ]),
   )
@@ -800,6 +832,7 @@ test('creates drizzle schema with canonical runtime names', () => {
       'workflow_node_children_child_run_fk',
       'workflow_node_children_current_attempt_fk',
       'workflow_commands_run_fk',
+      'workflow_run_events_run_fk',
     ]),
   )
 })
@@ -810,8 +843,10 @@ test('drizzle kit exports migration sql from app-owned schema file', async () =>
   expect(sql).toContain('CREATE TYPE "workflow_run_kind"')
   expect(sql).toContain('CREATE TYPE "workflow_node_child_kind"')
   expect(sql).toContain('CREATE TABLE "workflow_runs"')
+  expect(sql).toContain('CREATE TABLE "workflow_run_events"')
   expect(sql).toContain('CREATE TABLE "workflow_schedules"')
   expect(sql).toContain('CREATE TABLE "workflow_node_children"')
+  expect(sql).toContain('"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY')
   expect(sql).toContain(
     'CONSTRAINT "workflow_node_children_pkey" PRIMARY KEY("run_id","node_name","child_key")',
   )
@@ -820,6 +855,8 @@ test('drizzle kit exports migration sql from app-owned schema file', async () =>
   )
   expect(sql).toContain('CREATE INDEX "workflow_node_children_node_idx"')
   expect(sql).toContain('CREATE INDEX "workflow_node_children_child_run_idx"')
+  expect(sql).toContain('CREATE INDEX "workflow_run_events_run_idx"')
+  expect(sql).toContain('CREATE INDEX "workflow_run_events_root_idx"')
   expect(sql).toContain('CREATE INDEX "workflow_schedules_due_idx"')
   expect(sql).toContain('"delivery_count" integer DEFAULT 0 NOT NULL')
   expect(sql).toContain('"dead_at" timestamp with time zone')
@@ -1912,6 +1949,7 @@ test('creates postgres runtime schema with relational constraints', async () => 
       'workflow_node_children_current_attempt_fk',
       'workflow_run_leases_run_fk',
       'workflow_commands_run_fk',
+      'workflow_run_events_run_fk',
     ]),
   )
 })

--- a/packages/workflows/tests/postgres-retry-scheduling.spec.ts
+++ b/packages/workflows/tests/postgres-retry-scheduling.spec.ts
@@ -13,6 +13,38 @@ import { runTaskWorker, startTaskRun } from '../src/runtime/index.ts'
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+async function readTaskCommandRunAt(
+  connection: ReturnType<typeof createPostgresWorkflowConnection>,
+  runId: string,
+) {
+  const command = await connection.query<{ run_at: Date }>(
+    `
+      SELECT run_at
+      FROM workflow_commands
+      WHERE kind = 'task' AND run_id = $1
+    `,
+    [runId],
+  )
+  const runAt = command.rows[0]?.run_at
+  return runAt === undefined ? undefined : new Date(runAt).getTime()
+}
+
+async function waitForTaskCommandRunAt(
+  connection: ReturnType<typeof createPostgresWorkflowConnection>,
+  runId: string,
+  predicate: (runAt: number) => boolean,
+) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 10_000) {
+    const runAt = await readTaskCommandRunAt(connection, runId)
+    if (runAt !== undefined) {
+      if (predicate(runAt)) return runAt
+    }
+    await wait(5)
+  }
+  throw new Error('Timed out waiting for retry command')
+}
+
 describe('postgres retry scheduling', () => {
   const createTestContainer = () => {
     const logger = createLogger({ pinoOptions: { enabled: false } }, 'test')
@@ -29,8 +61,10 @@ describe('postgres retry scheduling', () => {
       output: t.object({ id: t.string() }),
       retry: { attempts: 3, delay: '10ms', backoff: 'exponential' },
     })
+    let activeWorker: AbortController | undefined
     const implementation = implementTask(task, {
       handler: async () => {
+        activeWorker?.abort()
         throw new Error('still failing')
       },
     })
@@ -43,43 +77,60 @@ describe('postgres retry scheduling', () => {
     })
 
     const firstStartedAt = Date.now()
+    activeWorker = new AbortController()
     await runTaskWorker({
       ...runtime,
       container: createTestContainer(),
       tasks: [implementation],
       workerId: 'task-worker-1',
+      signal: activeWorker.signal,
     })
     const firstCommand = await connection.query<{ run_at: Date }>(
       `
-        SELECT run_at
-        FROM workflow_commands
-        WHERE kind = 'task' AND run_id = $1
-      `,
+          SELECT run_at
+          FROM workflow_commands
+          WHERE kind = 'task' AND run_id = $1
+        `,
       [run.id],
     )
     const firstRunAt = new Date(firstCommand.rows[0]!.run_at).getTime()
     expect(firstRunAt).toBeGreaterThan(firstStartedAt)
     expect(firstRunAt - firstStartedAt).toBeGreaterThanOrEqual(5)
 
-    await wait(15)
-    const secondStartedAt = Date.now()
-    await runTaskWorker({
-      ...runtime,
-      container: createTestContainer(),
-      tasks: [implementation],
-      workerId: 'task-worker-2',
-    })
-    const secondCommand = await connection.query<{ run_at: Date }>(
-      `
-        SELECT run_at
-        FROM workflow_commands
-        WHERE kind = 'task' AND run_id = $1
-      `,
-      [run.id],
+    await waitForTaskCommandRunAt(
+      connection,
+      run.id,
+      (runAt) => runAt <= Date.now(),
     )
-    const secondRunAt = new Date(secondCommand.rows[0]!.run_at).getTime()
+    let secondStartedAt = Date.now()
+    let secondRunAt: number | undefined
+    const retryStartedAt = Date.now()
+    let retryWorkers = 0
+    while (Date.now() - retryStartedAt < 5_000) {
+      await waitForTaskCommandRunAt(
+        connection,
+        run.id,
+        (runAt) => runAt <= Date.now(),
+      )
+      secondStartedAt = Date.now()
+      activeWorker = new AbortController()
+      await runTaskWorker({
+        ...runtime,
+        container: createTestContainer(),
+        tasks: [implementation],
+        workerId: `task-worker-2-${retryWorkers++}`,
+        signal: activeWorker.signal,
+      })
+      const nextRunAt = await readTaskCommandRunAt(connection, run.id)
+      if (nextRunAt !== undefined && nextRunAt > firstRunAt) {
+        secondRunAt = nextRunAt
+        break
+      }
+      await wait(5)
+    }
+    expect(secondRunAt).toBeDefined()
 
-    expect(secondRunAt).toBeGreaterThan(firstRunAt)
-    expect(secondRunAt - secondStartedAt).toBeGreaterThanOrEqual(15)
-  })
+    expect(secondRunAt!).toBeGreaterThan(firstRunAt)
+    expect(secondRunAt! - secondStartedAt).toBeGreaterThanOrEqual(15)
+  }, 60_000)
 })

--- a/packages/workflows/tests/runtime-adapter-contract.spec.ts
+++ b/packages/workflows/tests/runtime-adapter-contract.spec.ts
@@ -918,6 +918,202 @@ function workflowRuntimeAdapterContract(
       ).resolves.toStrictEqual([])
     })
 
+    it('records exact status change events and skips idempotent rewrites', async () => {
+      const runtime = await createRuntime()
+      const run = await runtime.store.createRun({
+        workflowName: 'event-history-workflow',
+        input: {},
+        idempotencyKey: ['event-history-workflow'],
+      })
+      await runtime.store.createRun({
+        workflowName: 'event-history-workflow',
+        input: {},
+        idempotencyKey: ['event-history-workflow'],
+      })
+      await runtime.store.markRunWaiting({ runId: run.id })
+      await runtime.store.createNode({
+        runId: run.id,
+        name: 'content',
+        kind: 'activity',
+      })
+      await runtime.store.setNodeInput({
+        runId: run.id,
+        nodeName: 'content',
+        input: { value: 1 },
+      })
+      await runtime.store.ensureNodeChildren({
+        runId: run.id,
+        nodeName: 'content',
+        children: [{ childKey: '$self', kind: 'activity' }],
+      })
+      const firstAttempt = await runtime.store.ensureChildAttempt({
+        runId: run.id,
+        nodeName: 'content',
+        childKey: '$self',
+        input: { value: 1 },
+      })
+      await runtime.store.ensureChildAttempt({
+        runId: run.id,
+        nodeName: 'content',
+        childKey: '$self',
+        input: { value: 1 },
+      })
+      await runtime.store.failCurrentAttempt({
+        attemptId: firstAttempt.attempt.id,
+        leaseToken: firstAttempt.attempt.leaseToken!,
+        error: new Error('retry me'),
+      })
+      const retry = await runtime.store.createAttempt({
+        runId: run.id,
+        nodeName: 'content',
+        childKey: '$self',
+        input: { value: 2 },
+      })
+      await runtime.store.completeCurrentAttempt({
+        attemptId: retry.id,
+        leaseToken: retry.leaseToken!,
+        output: { value: 2 },
+      })
+      await runtime.store.completeNode({
+        runId: run.id,
+        nodeName: 'content',
+        output: { value: 2 },
+      })
+      await runtime.store.markRunRunning({ runId: run.id })
+      await runtime.store.markRunWaiting({ runId: run.id })
+      await runtime.store.markRunRunning({ runId: run.id })
+      await runtime.store.completeRun({ runId: run.id, output: { value: 2 } })
+      await runtime.store.failRun({
+        runId: run.id,
+        error: new Error('too late'),
+      })
+
+      const listed = await runtime.store.listRunEvents({ runId: run.id })
+
+      expect(
+        listed.events.map((event) => [
+          event.kind,
+          event.status,
+          event.nodeName,
+          event.childKey,
+          event.attemptNumber,
+        ]),
+      ).toStrictEqual([
+        ['run', 'queued', undefined, undefined, undefined],
+        ['attempt', 'started', 'content', '$self', 1],
+        ['child', 'running', 'content', '$self', undefined],
+        ['node', 'running', 'content', undefined, undefined],
+        ['attempt', 'failed', 'content', '$self', 1],
+        ['attempt', 'started', 'content', '$self', 2],
+        ['attempt', 'completed', 'content', '$self', 2],
+        ['child', 'completed', 'content', '$self', undefined],
+        ['node', 'completed', 'content', undefined, undefined],
+        ['run', 'running', undefined, undefined, undefined],
+        ['run', 'waiting', undefined, undefined, undefined],
+        ['run', 'running', undefined, undefined, undefined],
+        ['run', 'completed', undefined, undefined, undefined],
+      ])
+      expect(listed.events.map((event) => event.runId)).toEqual(
+        listed.events.map(() => run.id),
+      )
+      expect(listed.events.map((event) => event.rootRunId)).toEqual(
+        listed.events.map(() => run.rootRunId),
+      )
+      expect(
+        listed.events.every((event) => event.createdAt instanceof Date),
+      ).toBe(true)
+      expect(listed.nextCursor).toBeUndefined()
+
+      const firstPage = await runtime.store.listRunEvents({
+        runId: run.id,
+        limit: 3,
+      })
+      const secondPage = await runtime.store.listRunEvents({
+        runId: run.id,
+        afterEventId: firstPage.nextCursor,
+        limit: 50,
+      })
+      expect(firstPage.events).toHaveLength(3)
+      expect(firstPage.nextCursor).toBe(firstPage.events[2]?.id)
+      expect(secondPage.events.map((event) => event.id)).toStrictEqual(
+        listed.events.slice(3).map((event) => event.id),
+      )
+      await expect(
+        runtime.store.listRunEvents({ runId: 'missing-run-id' }),
+      ).resolves.toStrictEqual({ events: [] })
+    })
+
+    it('lists family event history and removes events with deleted runs', async () => {
+      const runtime = await createRuntime()
+      const root = await runtime.store.createRun({
+        workflowName: 'event-family-root',
+        input: {},
+      })
+      await runtime.store.createNode({
+        runId: root.id,
+        name: 'child',
+        kind: 'workflow',
+      })
+      await runtime.store.ensureNodeChildren({
+        runId: root.id,
+        nodeName: 'child',
+        children: [{ childKey: '$self', kind: 'workflow' }],
+      })
+      const { childRun } = await runtime.store.ensureChildRun({
+        runId: root.id,
+        nodeName: 'child',
+        childKey: '$self',
+        childKind: 'workflow',
+        childName: 'event-family-child',
+        input: {},
+        rootRunId: root.rootRunId,
+      })
+      await runtime.store.completeRun({
+        runId: childRun.id,
+        output: { child: true },
+      })
+      await runtime.store.completeNodeChild({
+        runId: root.id,
+        nodeName: 'child',
+        childKey: '$self',
+        output: { child: true },
+      })
+      await runtime.store.completeNode({
+        runId: root.id,
+        nodeName: 'child',
+        output: { child: true },
+      })
+      await runtime.store.completeRun({ runId: root.id, output: { ok: true } })
+
+      const rootOnly = await runtime.store.listRunEvents({ runId: root.id })
+      const family = await runtime.store.listRunEvents({
+        runId: root.id,
+        family: true,
+      })
+
+      expect(rootOnly.events.every((event) => event.runId === root.id)).toBe(
+        true,
+      )
+      expect(
+        family.events.map((event) => [event.runId, event.kind, event.status]),
+      ).toEqual([
+        [root.id, 'run', 'queued'],
+        [childRun.id, 'run', 'queued'],
+        [root.id, 'child', 'running'],
+        [childRun.id, 'run', 'completed'],
+        [root.id, 'child', 'completed'],
+        [root.id, 'node', 'completed'],
+        [root.id, 'run', 'completed'],
+      ])
+
+      await expect(runtime.store.deleteRun(root.id)).resolves.toStrictEqual({
+        deleted: true,
+      })
+      await expect(
+        runtime.store.listRunEvents({ runId: root.id, family: true }),
+      ).resolves.toStrictEqual({ events: [] })
+    })
+
     it('sweeps old dead commands during pruning', async () => {
       const runtime = await createRuntime({ maxDeliveries: 1 })
       const run = await runtime.store.createRun({
@@ -2479,7 +2675,11 @@ function workflowRuntimeAdapterContract(
       expect(
         settled.attempts
           .map((attempt) => [attempt.childKey, attempt.attemptNumber])
-          .sort(),
+          .sort(
+            (left, right) =>
+              String(left[0]).localeCompare(String(right[0])) ||
+              Number(left[1]) - Number(right[1]),
+          ),
       ).toEqual([
         ['member:a', 1],
         ['member:a', 2],

--- a/packages/workflows/tests/runtime-adapter-contract.spec.ts
+++ b/packages/workflows/tests/runtime-adapter-contract.spec.ts
@@ -1041,6 +1041,15 @@ function workflowRuntimeAdapterContract(
       await expect(
         runtime.store.listRunEvents({ runId: 'missing-run-id' }),
       ).resolves.toStrictEqual({ events: [] })
+      await expect(
+        runtime.store.listRunEvents({
+          runId: run.id,
+          afterEventId: 'not-a-run-event-id',
+        }),
+      ).rejects.toThrow('Invalid run events cursor [not-a-run-event-id]')
+      await expect(
+        runtime.store.listRunEvents({ runId: run.id, afterEventId: '0' }),
+      ).rejects.toThrow('Invalid run events cursor [0]')
     })
 
     it('lists family event history and removes events with deleted runs', async () => {

--- a/packages/workflows/tests/runtime-client.spec.ts
+++ b/packages/workflows/tests/runtime-client.spec.ts
@@ -738,6 +738,98 @@ describe('workflow runtime client', () => {
     })
   })
 
+  it('ends immediately when watching a terminal run after its terminal event', async () => {
+    vi.useFakeTimers()
+    try {
+      const workflow = defineWorkflow({
+        name: 'client-watch-terminal-cursor-workflow',
+        input: t.object({ scenario: t.string() }),
+        output: t.object({ caseId: t.string() }),
+      }).build()
+      const runtime = createInMemoryWorkflowRuntime()
+      const client = createWorkflowRuntimeClient(runtime)
+      const run = await client.start(workflow, { scenario: 'alpha' })
+      await runtime.store.completeRun({
+        runId: run.id,
+        output: { caseId: 'alpha' },
+      })
+      const terminalEventId = (
+        await runtime.store.listRunEvents({ runId: run.id })
+      ).events.at(-1)?.id
+      const iterator = client
+        .watch(run.id, {
+          afterEventId: String(BigInt(terminalEventId!) + 1n),
+          pollIntervalMs: 60_000,
+        })
+        [Symbol.asyncIterator]()
+
+      const pending = iterator.next()
+      await vi.advanceTimersByTimeAsync(0)
+
+      await expect(
+        Promise.race([pending, Promise.resolve('pending')]),
+      ).resolves.toStrictEqual({ done: true, value: undefined })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps the run-event wake listener registered while polling', async () => {
+    vi.useFakeTimers()
+    const abort = new AbortController()
+    try {
+      const runtime = createInMemoryWorkflowRuntime()
+      const run = await runtime.store.createRun({
+        workflowName: 'client-watch-wake-race',
+        input: {},
+      })
+      const cursor = (
+        await runtime.store.listRunEvents({ runId: run.id })
+      ).events.at(-1)?.id
+      let injected = false
+      const client = createWorkflowRuntimeClient({
+        ...runtime,
+        store: {
+          ...runtime.store,
+          listRunEvents: async (params) => {
+            const result = await runtime.store.listRunEvents(params)
+            if (
+              !injected &&
+              params.runId === run.id &&
+              params.afterEventId === cursor
+            ) {
+              injected = true
+              await runtime.store.markRunRunning({ runId: run.id })
+            }
+            return result
+          },
+        },
+      })
+      const iterator = client
+        .watch(run.id, {
+          afterEventId: cursor,
+          signal: abort.signal,
+          pollIntervalMs: 60_000,
+        })
+        [Symbol.asyncIterator]()
+
+      const pending = iterator.next()
+      await vi.advanceTimersByTimeAsync(0)
+
+      await expect(
+        Promise.race([pending, Promise.resolve('pending')]),
+      ).resolves.toMatchObject({
+        done: false,
+        value: { kind: 'run', status: 'running', runId: run.id },
+      })
+      await iterator.return?.()
+    } finally {
+      abort.abort()
+      await vi.advanceTimersByTimeAsync(0)
+      vi.useRealTimers()
+    }
+  })
+
   it('watches a run family but stops on the watched run terminal event', async () => {
     const runtime = createInMemoryWorkflowRuntime()
     const client = createWorkflowRuntimeClient(runtime)

--- a/packages/workflows/tests/runtime-client.spec.ts
+++ b/packages/workflows/tests/runtime-client.spec.ts
@@ -1,5 +1,5 @@
 import { t } from '@nmtjs/type'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   defineSchedule,
@@ -696,5 +696,189 @@ describe('workflow runtime client', () => {
 
     expect(completed?.status).toBe('completed')
     expect(completed?.output).toStrictEqual({ caseId: 'done' })
+  })
+
+  it('watches history and new events until the watched run terminates', async () => {
+    const workflow = defineWorkflow({
+      name: 'client-watch-workflow',
+      input: t.object({ scenario: t.string() }),
+      output: t.object({ caseId: t.string() }),
+    }).build()
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient(runtime)
+    const run = await client.start(workflow, { scenario: 'alpha' })
+    const queued = await runtime.store.listRunEvents({ runId: run.id })
+
+    const iterator = client
+      .watch(run.id, {
+        afterEventId: queued.events[0]?.id,
+        pollIntervalMs: 60_000,
+      })
+      [Symbol.asyncIterator]()
+
+    const running = iterator.next()
+    await runtime.store.markRunRunning({ runId: run.id })
+    await expect(running).resolves.toMatchObject({
+      done: false,
+      value: { kind: 'run', status: 'running', runId: run.id },
+    })
+
+    const completed = iterator.next()
+    await runtime.store.completeRun({
+      runId: run.id,
+      output: { caseId: 'alpha' },
+    })
+    await expect(completed).resolves.toMatchObject({
+      done: false,
+      value: { kind: 'run', status: 'completed', runId: run.id },
+    })
+    await expect(iterator.next()).resolves.toStrictEqual({
+      done: true,
+      value: undefined,
+    })
+  })
+
+  it('watches a run family but stops on the watched run terminal event', async () => {
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient(runtime)
+    const root = await runtime.store.createRun({
+      workflowName: 'client-watch-family-root',
+      input: {},
+    })
+    await runtime.store.createNode({
+      runId: root.id,
+      name: 'child',
+      kind: 'workflow',
+    })
+    await runtime.store.ensureNodeChildren({
+      runId: root.id,
+      nodeName: 'child',
+      children: [{ childKey: '$self', kind: 'workflow' }],
+    })
+    const cursor = (
+      await runtime.store.listRunEvents({ runId: root.id })
+    ).events.at(-1)?.id
+
+    const iterator = client
+      .watch(root.id, {
+        family: true,
+        afterEventId: cursor,
+        pollIntervalMs: 60_000,
+      })
+      [Symbol.asyncIterator]()
+    const childQueued = iterator.next()
+    const { childRun } = await runtime.store.ensureChildRun({
+      runId: root.id,
+      nodeName: 'child',
+      childKey: '$self',
+      childKind: 'workflow',
+      childName: 'client-watch-family-child',
+      input: {},
+      rootRunId: root.rootRunId,
+    })
+    await expect(childQueued).resolves.toMatchObject({
+      done: false,
+      value: { kind: 'run', status: 'queued', runId: childRun.id },
+    })
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { kind: 'child', status: 'running', runId: root.id },
+    })
+
+    const childCompleted = iterator.next()
+    await runtime.store.completeRun({ runId: childRun.id, output: {} })
+    await expect(childCompleted).resolves.toMatchObject({
+      done: false,
+      value: { kind: 'run', status: 'completed', runId: childRun.id },
+    })
+
+    const rootCompleted = iterator.next()
+    await runtime.store.completeRun({ runId: root.id, output: {} })
+    await expect(rootCompleted).resolves.toMatchObject({
+      done: false,
+      value: { kind: 'run', status: 'completed', runId: root.id },
+    })
+    await expect(iterator.next()).resolves.toStrictEqual({
+      done: true,
+      value: undefined,
+    })
+  })
+
+  it('ends watch iteration cleanly on abort and early consumer return', async () => {
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient(runtime)
+    const run = await runtime.store.createRun({
+      workflowName: 'client-watch-abort',
+      input: {},
+    })
+    const cursor = (
+      await runtime.store.listRunEvents({ runId: run.id })
+    ).events.at(-1)?.id
+    const abort = new AbortController()
+    const iterator = client
+      .watch(run.id, {
+        afterEventId: cursor,
+        signal: abort.signal,
+        pollIntervalMs: 60_000,
+      })
+      [Symbol.asyncIterator]()
+
+    const pending = iterator.next()
+    abort.abort()
+    await expect(pending).resolves.toStrictEqual({
+      done: true,
+      value: undefined,
+    })
+
+    const seen: string[] = []
+    await runtime.store.markRunRunning({ runId: run.id })
+    for await (const event of client.watch(run.id, { afterEventId: cursor })) {
+      seen.push(event.status)
+      break
+    }
+    await runtime.store.completeRun({ runId: run.id, output: {} })
+    await expect(
+      Array.fromAsync(client.watch(run.id, { afterEventId: cursor })),
+    ).resolves.toMatchObject([{ status: 'running' }, { status: 'completed' }])
+    expect(seen).toStrictEqual(['running'])
+  })
+
+  it('falls back to polling when no wake event port is available', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = createInMemoryWorkflowRuntime()
+      const client = createWorkflowRuntimeClient({
+        store: runtime.store,
+        runCoordinationExecutor: runtime.runCoordinationExecutor,
+        attemptExecutor: runtime.attemptExecutor,
+      })
+      const run = await runtime.store.createRun({
+        workflowName: 'client-watch-poll',
+        input: {},
+      })
+      const cursor = (
+        await runtime.store.listRunEvents({ runId: run.id })
+      ).events.at(-1)?.id
+      const iterator = client
+        .watch(run.id, { afterEventId: cursor, pollIntervalMs: 25 })
+        [Symbol.asyncIterator]()
+
+      const pending = iterator.next()
+      await vi.advanceTimersByTimeAsync(0)
+      await runtime.store.markRunRunning({ runId: run.id })
+      await vi.advanceTimersByTimeAsync(24)
+      await expect(
+        Promise.race([pending, Promise.resolve('pending')]),
+      ).resolves.toBe('pending')
+      await vi.advanceTimersByTimeAsync(1)
+      await expect(pending).resolves.toMatchObject({
+        done: false,
+        value: { status: 'running' },
+      })
+      await iterator.return?.()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/workflows/tests/runtime-coordinator.spec.ts
+++ b/packages/workflows/tests/runtime-coordinator.spec.ts
@@ -947,7 +947,7 @@ describe('workflow runtime coordinator', () => {
     const snapshot = await runtime.store.loadRunSnapshot(run.id)
     expect(snapshot?.run.status).toBe('running')
     expect(snapshot?.run.error).toBeUndefined()
-    expect(snapshot?.nodes[0]?.status).toBe('running')
+    expect(['pending', 'running']).toContain(snapshot?.nodes[0]?.status)
     expect(snapshot?.nodes[0]?.error).toBeUndefined()
   })
 

--- a/packages/workflows/vitest.config.ts
+++ b/packages/workflows/vitest.config.ts
@@ -7,7 +7,7 @@ const includeIntegration = process.argv.some((arg) =>
 export default defineProject({
   test: {
     environment: 'node',
-    testTimeout: 15_000,
+    testTimeout: 60_000,
     include: includeIntegration
       ? ['tests/integration/**/*.spec.ts']
       : ['tests/*.spec.ts'],


### PR DESCRIPTION
Closes #251. Final step of #242 — delivers the engine-side run event history that #251 was blocked on, and the `watch` primitive on top of it.

## Event history — a truthful change feed, not parallel bookkeeping

One invariant governs everything: **every store write that changes a `status` column emits exactly one event row for the changed entity, atomically with the write; writes that change no status emit nothing.** The feed is derived from the same guarded transitions #243 built, so it cannot drift from stored state.

- New `workflow_run_events` table (additive — schema version stays 1): global identity `id` as cursor, `run_id` + `root_run_id` (FK cascade — prune/`deleteRun` clean history for free), `kind` (`run`/`node`/`child`/`attempt`), new `status`, per-kind identifiers (`node_name`/`child_key`/`attempt_id`/`attempt_number`), `error` on failure events. **No payloads** — events are change notifications; consumers refetch via the #249 read models.
- Postgres emission rides the status write itself: data-modifying CTEs append the event insert + `pg_notify` to the same statement (`WHERE old_status IS DISTINCT FROM status` enforces the no-change rule structurally), uniform helpers in `sql.ts` so every emission site greps alike. In-memory mirrors the semantics exactly.
- Third LISTEN/NOTIFY channel (`workflow_run_events`, payload = `root_run_id`) exposed as optional `onRunEvent` on the wake-events port — same hint-over-polling layering as command dispatch; a missed notification costs one poll interval, never correctness.

## `client.watch(runId, options?)`

`AsyncIterable<StoredRunEvent>` — yields history from `afterEventId` (exclusive), then live events; ends after the watched run's terminal `run` event. `family: true` follows one cursor across the whole run tree via `root_run_id`.

Built for direct use as a Neemata stream-procedure body: `return client.watch(runId, { signal })`. It's a plain async generator — early consumer termination (`break`/`iterator.return()`) and `AbortSignal` both dispose the poll timer and wake listener via the same `finally`, ending cleanly rather than throwing.

Store surface: `listRunEvents({runId, family?, afterEventId?, limit?})` for pull-style consumers. Inspector: `RunEventDto` + `toRunEventDto` (drift-guarded `convertDates`), identifiers align with the existing snapshot/summary DTOs so events compose with #248/#249 without a second identity scheme.

## Tests

Conformance (in-memory + PGlite): exact event sequences through a full run lifecycle, idempotent re-writes emit nothing, per-retry attempt events, cursor pagination, family cursors, FK cleanup on delete/prune. Client: watch history+live, terminal stop, abort mid-wait, early consumer break, poll fallback without a wake port (fake timers). Integration: LISTEN/NOTIFY push path in the postgres wake-events suite. 422 package tests pass; `pnpm check` clean. Local integration suite skipped (no local postgres harness) — covered by the `tests-integration-services` CI job.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow run event history, including per-run and family-wide streams.
  * Added live run-event watching via the runtime client.
  * Added Postgres wake-ups for run events to reduce waiting compared to polling.
* **Bug Fixes**
  * Improved end-to-end status tracking across runs, nodes, children, and attempts, with more reliable cancellation behavior.
  * Enhanced in-memory wake behavior for “due now” command dispatch.
* **Tests**
  * Expanded coverage for event listing, watching, schema compatibility, LISTEN/NOTIFY wake behavior, and retry scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->