### PR TITLE
workflows: presentation metadata (title/description) on definitions

### DIFF
--- a/packages/workflows/src/contract/index.ts
+++ b/packages/workflows/src/contract/index.ts
@@ -50,6 +50,8 @@ type LeafCaseMap = Record<string, BranchCaseDefinition>
 type BranchActivityCaseOptions<BranchOutput, InputSchema, OutputSchema> = {
   input: InputSchema
   output: OutputSchema
+  title?: string
+  description?: string
   retry?: RetryPolicy
   timeout?: DurationString
 } & (OutputSchema extends Schema
@@ -91,6 +93,8 @@ export type BranchCaseHelpers = {
   >(options: {
     input: InputSchema
     output: OutputSchema
+    title?: string
+    description?: string
     retry?: RetryPolicy
     timeout?: DurationString
   }): BranchCaseDefinition<
@@ -101,6 +105,8 @@ export type BranchCaseHelpers = {
   task<Task extends AnyTaskDefinition>(
     task: Task,
     options?: {
+      title?: string
+      description?: string
       retry?: RetryPolicy
       timeout?: DurationString
     },
@@ -108,6 +114,8 @@ export type BranchCaseHelpers = {
   workflow<Workflow extends AnyWorkflowDefinition>(
     workflow: Workflow,
     options?: {
+      title?: string
+      description?: string
       cancellation?: CancellationPolicy
     },
   ): BranchCaseDefinition<
@@ -134,6 +142,8 @@ export type ConvergedBranchCaseHelpers<BranchOutput> = {
         'task case output does not satisfy branch output'
       >,
     options?: {
+      title?: string
+      description?: string
       retry?: RetryPolicy
       timeout?: DurationString
     },
@@ -146,6 +156,8 @@ export type ConvergedBranchCaseHelpers<BranchOutput> = {
         'workflow case output does not satisfy branch output'
       >,
     options?: {
+      title?: string
+      description?: string
       cancellation?: CancellationPolicy
     },
   ): BranchCaseDefinition<
@@ -176,6 +188,8 @@ export type WorkflowBuilder<
     options: {
       input: InputSchema
       output: OutputSchema
+      title?: string
+      description?: string
       retry?: RetryPolicy
       timeout?: DurationString
     },
@@ -197,6 +211,8 @@ export type WorkflowBuilder<
     name: AvailableNodeName<NodeName>,
     task: Task,
     options?: {
+      title?: string
+      description?: string
       retry?: RetryPolicy
       timeout?: DurationString
     },
@@ -211,6 +227,8 @@ export type WorkflowBuilder<
     name: AvailableNodeName<NodeName>,
     workflow: Workflow,
     options?: {
+      title?: string
+      description?: string
       cancellation?: CancellationPolicy
     },
   ): WorkflowBuilder<
@@ -228,6 +246,8 @@ export type WorkflowBuilder<
     name: AvailableNodeName<NodeName>,
     options: {
       output: OutputSchema
+      title?: string
+      description?: string
       cases: (
         helpers: ConvergedBranchCaseHelpers<SchemaOutput<OutputSchema>>,
       ) => Cases
@@ -242,6 +262,8 @@ export type WorkflowBuilder<
   branch<NodeName extends string, Cases extends LeafCaseMap>(
     name: AvailableNodeName<NodeName>,
     options: {
+      title?: string
+      description?: string
       cases: (helpers: BranchCaseHelpers) => Cases
     },
   ): WorkflowBuilder<
@@ -257,6 +279,10 @@ export type WorkflowBuilder<
   parallel<NodeName extends string, Cases extends LeafCaseMap>(
     name: AvailableNodeName<NodeName>,
     cases: (helpers: BranchCaseHelpers) => Cases,
+    options?: {
+      title?: string
+      description?: string
+    },
   ): WorkflowBuilder<
     Name,
     Input,
@@ -275,6 +301,8 @@ export type WorkflowBuilder<
     options: {
       item: ItemSchema
       mode: Mode
+      title?: string
+      description?: string
       concurrency?: number
       retry?: RetryPolicy
       timeout?: DurationString
@@ -300,6 +328,8 @@ export type WorkflowBuilder<
     options: {
       item: ItemSchema
       mode: Mode
+      title?: string
+      description?: string
       concurrency?: number
       cancellation?: CancellationPolicy
     },
@@ -332,6 +362,8 @@ export type TaskOptions<
   OutputSchema extends Schema,
 > = {
   name: Name
+  title?: string
+  description?: string
   input: InputSchema
   output: OutputSchema
   retry?: RetryPolicy
@@ -360,6 +392,8 @@ export type WorkflowOptions<
   OutputSchema extends Schema | undefined,
 > = {
   name: Name
+  title?: string
+  description?: string
   input: InputSchema
   output?: OutputSchema
   retention?: DurationString
@@ -457,18 +491,26 @@ class WorkflowDraftBuilder<Name extends string> {
       Object.freeze({
         kind: 'branch',
         name,
+        ...(options.title === undefined ? {} : { title: options.title }),
+        ...(options.description === undefined
+          ? {}
+          : { description: options.description }),
         output: options.output,
         cases: Object.freeze(options.cases(createBranchCaseHelpers())),
       }),
     )
   }
 
-  parallel(name: string, casesFactory: any) {
+  parallel(name: string, casesFactory: any, options?: any) {
     assertNodeName(name, this.nodes)
     return this.withNode(
       Object.freeze({
         kind: 'parallel',
         name,
+        ...(options?.title === undefined ? {} : { title: options.title }),
+        ...(options?.description === undefined
+          ? {}
+          : { description: options.description }),
         cases: Object.freeze(casesFactory(createBranchCaseHelpers())),
       }),
     )
@@ -494,6 +536,12 @@ class WorkflowDraftBuilder<Name extends string> {
     return Object.freeze({
       kind: 'workflow',
       name: this.options.name,
+      ...(this.options.title === undefined
+        ? {}
+        : { title: this.options.title }),
+      ...(this.options.description === undefined
+        ? {}
+        : { description: this.options.description }),
       input: this.options.input,
       output: this.options.output,
       nodes: Object.freeze([...this.nodes]),

--- a/packages/workflows/src/inspector/index.ts
+++ b/packages/workflows/src/inspector/index.ts
@@ -31,12 +31,16 @@ import { parseChildKey, type ParsedChildKey } from '../runtime/child-key.ts'
  */
 export type WorkflowGraph = {
   readonly name: string
+  readonly title?: string
+  readonly description?: string
   readonly nodes: readonly WorkflowGraphNode[]
 }
 
 export type WorkflowGraphNode = {
   readonly name: string
   readonly kind: WorkflowNodeKind
+  readonly title?: string
+  readonly description?: string
   /** Referenced task/workflow for task, workflow, mapTask and mapWorkflow nodes. */
   readonly target?: WorkflowGraphTarget
   /** Branch and parallel members, in definition order. */
@@ -48,13 +52,40 @@ export type WorkflowGraphNode = {
 export type WorkflowGraphTarget = {
   readonly kind: 'task' | 'workflow'
   readonly name: string
+  readonly title?: string
+  readonly description?: string
 }
 
 export type WorkflowGraphCase = {
   readonly key: string
   readonly kind: BranchCaseKind
+  readonly title?: string
+  readonly description?: string
   /** Absent for inline activity cases — they have no named target. */
   readonly target?: WorkflowGraphTarget
+}
+
+function presentationMetadata(input: {
+  readonly title?: string
+  readonly description?: string
+}) {
+  return {
+    ...(input.title === undefined ? {} : { title: input.title }),
+    ...(input.description === undefined
+      ? {}
+      : { description: input.description }),
+  }
+}
+
+function serializeWorkflowGraphTarget(
+  kind: WorkflowGraphTarget['kind'],
+  target: AnyTaskDefinition | AnyWorkflowDefinition,
+): WorkflowGraphTarget {
+  return {
+    kind,
+    name: target.name,
+    ...presentationMetadata(target),
+  }
 }
 
 export function serializeWorkflowGraph(
@@ -62,60 +93,72 @@ export function serializeWorkflowGraph(
 ): WorkflowGraph {
   return {
     name: definition.name,
+    ...presentationMetadata(definition),
     nodes: definition.nodes.map((node): WorkflowGraphNode => {
       switch (node.kind) {
         case 'activity':
-          return { name: node.name, kind: node.kind }
+          return {
+            name: node.name,
+            kind: node.kind,
+            ...presentationMetadata(node),
+          }
         case 'task':
           return {
             name: node.name,
             kind: node.kind,
-            target: { kind: 'task', name: node.task.name },
+            ...presentationMetadata(node),
+            target: serializeWorkflowGraphTarget('task', node.task),
           }
         case 'workflow':
           return {
             name: node.name,
             kind: node.kind,
-            target: { kind: 'workflow', name: node.workflow.name },
+            ...presentationMetadata(node),
+            target: serializeWorkflowGraphTarget('workflow', node.workflow),
           }
         case 'branch':
         case 'parallel':
           return {
             name: node.name,
             kind: node.kind,
+            ...presentationMetadata(node),
             cases: Object.entries(node.cases).map(
-              ([key, branchCase]): WorkflowGraphCase =>
-                branchCase.kind === 'activity'
-                  ? { key, kind: branchCase.kind }
-                  : {
-                      key,
-                      kind: branchCase.kind,
-                      target: {
-                        kind: branchCase.kind,
-                        // BranchCaseDefinition's conditional payload doesn't
-                        // narrow on `kind` at the union default, so the cast
-                        // lives here once instead of in every consumer.
-                        name: (
-                          branchCase as unknown as {
-                            target: AnyTaskDefinition | AnyWorkflowDefinition
-                          }
-                        ).target.name,
-                      },
-                    },
+              ([key, branchCase]): WorkflowGraphCase => {
+                const base = {
+                  key,
+                  kind: branchCase.kind,
+                  ...presentationMetadata(branchCase),
+                }
+                if (branchCase.kind === 'activity') return base
+
+                // BranchCaseDefinition's conditional payload doesn't narrow on
+                // `kind` at the union default, so the cast lives here once.
+                const target = (
+                  branchCase as unknown as {
+                    target: AnyTaskDefinition | AnyWorkflowDefinition
+                  }
+                ).target
+                return {
+                  ...base,
+                  target: serializeWorkflowGraphTarget(branchCase.kind, target),
+                }
+              },
             ),
           }
         case 'mapTask':
           return {
             name: node.name,
             kind: node.kind,
-            target: { kind: 'task', name: node.task.name },
+            ...presentationMetadata(node),
+            target: serializeWorkflowGraphTarget('task', node.task),
             mode: node.mode,
           }
         case 'mapWorkflow':
           return {
             name: node.name,
             kind: node.kind,
-            target: { kind: 'workflow', name: node.workflow.name },
+            ...presentationMetadata(node),
+            target: serializeWorkflowGraphTarget('workflow', node.workflow),
             mode: node.mode,
           }
       }
@@ -130,6 +173,8 @@ export type WorkflowCatalog = {
 
 export type WorkflowCatalogTask = {
   readonly name: string
+  readonly title?: string
+  readonly description?: string
 }
 
 /**
@@ -143,7 +188,10 @@ export function serializeWorkflowCatalog(input: {
 }): WorkflowCatalog {
   return {
     workflows: Array.from(input.workflows ?? [], serializeWorkflowGraph),
-    tasks: Array.from(input.tasks ?? [], (task) => ({ name: task.name })),
+    tasks: Array.from(input.tasks ?? [], (task) => ({
+      name: task.name,
+      ...presentationMetadata(task),
+    })),
   }
 }
 

--- a/packages/workflows/src/types/index.ts
+++ b/packages/workflows/src/types/index.ts
@@ -61,6 +61,8 @@ export type TaskDefinition<
 > = {
   readonly kind: 'task'
   readonly name: Name
+  readonly title?: string
+  readonly description?: string
   readonly input: Schema
   readonly output: Schema
   readonly retry?: RetryPolicy
@@ -107,6 +109,8 @@ export type WorkflowNodeBase<
 > = {
   readonly kind: Kind
   readonly name: Name
+  readonly title?: string
+  readonly description?: string
 }
 
 export type WorkflowActivityNode<
@@ -275,6 +279,8 @@ export type BranchCaseDefinition<
   Target = unknown,
 > = {
   readonly kind: Kind
+  readonly title?: string
+  readonly description?: string
   readonly _types?: { readonly input: Input; readonly output: Output }
 } & (Kind extends 'activity'
   ? {
@@ -334,6 +340,8 @@ export type WorkflowDefinition<
 > = {
   readonly kind: 'workflow'
   readonly name: Name
+  readonly title?: string
+  readonly description?: string
   readonly input: Schema
   readonly output?: Schema
   readonly nodes: Nodes

--- a/packages/workflows/tests/contract-graph.spec.ts
+++ b/packages/workflows/tests/contract-graph.spec.ts
@@ -72,6 +72,167 @@ describe('workflow contract graph', () => {
     >()
   })
 
+  it('preserves declarative presentation metadata on definitions, nodes, and cases', () => {
+    const metadataTask = defineTask({
+      name: 'metadata-task',
+      title: 'Metadata task',
+      description: 'Task description',
+      input: t.object({ text: t.string() }),
+      output: t.object({ text: t.string() }),
+    })
+    const metadataWorkflow = defineWorkflow({
+      name: 'metadata-child',
+      title: 'Metadata child workflow',
+      description: 'Child workflow description',
+      input: t.object({ text: t.string() }),
+      output: t.object({ text: t.string() }),
+    }).build()
+
+    expect(metadataTask.title).toBe('Metadata task')
+    expect(metadataTask.description).toBe('Task description')
+
+    const withMetadata = defineWorkflow({
+      name: 'metadata-parent',
+      title: 'Metadata parent workflow',
+      description: 'Parent workflow description',
+      input: t.object({ text: t.string() }),
+      output: t.object({ text: t.string() }),
+    })
+      .activity('activityNode', {
+        title: 'Activity node',
+        description: 'Activity node description',
+        input: t.object({ text: t.string() }),
+        output: t.object({ text: t.string() }),
+      })
+      .task('taskNode', metadataTask, {
+        title: 'Task node',
+        description: 'Task node description',
+      })
+      .workflow('workflowNode', metadataWorkflow, {
+        title: 'Workflow node',
+        description: 'Workflow node description',
+      })
+      .branch('branchNode', {
+        title: 'Branch node',
+        description: 'Branch node description',
+        output: t.object({ text: t.string() }),
+        cases: (helpers) => ({
+          inline: helpers.activity({
+            title: 'Inline case',
+            description: 'Inline case description',
+            input: t.object({ text: t.string() }),
+            output: t.object({ text: t.string() }),
+          }),
+          taskCase: helpers.task(metadataTask, {
+            title: 'Task case',
+            description: 'Task case description',
+          }),
+          workflowCase: helpers.workflow(metadataWorkflow, {
+            title: 'Workflow case',
+            description: 'Workflow case description',
+          }),
+        }),
+      })
+      .parallel(
+        'parallelNode',
+        (helpers) => ({
+          inline: helpers.activity({
+            title: 'Parallel inline case',
+            description: 'Parallel inline case description',
+            input: t.object({ text: t.string() }),
+            output: t.object({ text: t.string() }),
+          }),
+          taskCase: helpers.task(metadataTask, {
+            title: 'Parallel task case',
+            description: 'Parallel task case description',
+          }),
+          workflowCase: helpers.workflow(metadataWorkflow, {
+            title: 'Parallel workflow case',
+            description: 'Parallel workflow case description',
+          }),
+        }),
+        {
+          title: 'Parallel node',
+          description: 'Parallel node description',
+        },
+      )
+      .mapTask('mapTaskNode', metadataTask, {
+        title: 'Map task node',
+        description: 'Map task node description',
+        item: t.object({ text: t.string() }),
+        mode: 'wait-all',
+      })
+      .mapWorkflow('mapWorkflowNode', metadataWorkflow, {
+        title: 'Map workflow node',
+        description: 'Map workflow node description',
+        item: t.object({ text: t.string() }),
+        mode: 'wait-settled',
+      })
+      .build()
+
+    expect(withMetadata.title).toBe('Metadata parent workflow')
+    expect(withMetadata.description).toBe('Parent workflow description')
+    expect(withMetadata.nodes.map((node) => node.title)).toEqual([
+      'Activity node',
+      'Task node',
+      'Workflow node',
+      'Branch node',
+      'Parallel node',
+      'Map task node',
+      'Map workflow node',
+    ])
+    expect(withMetadata.nodes.map((node) => node.description)).toEqual([
+      'Activity node description',
+      'Task node description',
+      'Workflow node description',
+      'Branch node description',
+      'Parallel node description',
+      'Map task node description',
+      'Map workflow node description',
+    ])
+
+    const branchNode = withMetadata.nodes[3]
+    const parallelNode = withMetadata.nodes[4]
+
+    expect(branchNode.kind).toBe('branch')
+    expect(branchNode.cases.inline.title).toBe('Inline case')
+    expect(branchNode.cases.inline.description).toBe('Inline case description')
+    expect(branchNode.cases.taskCase.title).toBe('Task case')
+    expect(branchNode.cases.workflowCase.description).toBe(
+      'Workflow case description',
+    )
+
+    expect(parallelNode.kind).toBe('parallel')
+    expect(parallelNode.cases.inline.title).toBe('Parallel inline case')
+    expect(parallelNode.cases.taskCase.description).toBe(
+      'Parallel task case description',
+    )
+    expect(parallelNode.cases.workflowCase.title).toBe('Parallel workflow case')
+
+    const withoutMetadata = defineWorkflow({
+      name: 'metadata-free',
+      input: t.object({ text: t.string() }),
+    })
+      .activity('plainActivity', {
+        input: t.object({ text: t.string() }),
+        output: t.object({ text: t.string() }),
+      })
+      .parallel('plainParallel', (helpers) => ({
+        plainCase: helpers.activity({
+          input: t.object({ text: t.string() }),
+          output: t.object({ text: t.string() }),
+        }),
+      }))
+      .build()
+
+    expect('title' in withoutMetadata).toBe(false)
+    expect(withoutMetadata.nodes.every((node) => !('title' in node))).toBe(true)
+
+    const plainParallel = withoutMetadata.nodes[1]
+    expect(plainParallel.kind).toBe('parallel')
+    expect('title' in plainParallel.cases.plainCase).toBe(false)
+  })
+
   it('rejects converged branch task and workflow cases with mismatched outputs', () => {
     defineWorkflow({
       name: 'invalid-converged-branch',

--- a/packages/workflows/tests/inspector.spec.ts
+++ b/packages/workflows/tests/inspector.spec.ts
@@ -78,6 +78,95 @@ const workflow = defineWorkflow({
   })
   .build()
 
+const metadataTask = defineTask({
+  name: 'metadata-score',
+  title: 'Metadata score task',
+  description: 'Scores text for metadata graph',
+  input: t.object({ text: t.string() }),
+  output: t.object({ text: t.string() }),
+})
+
+const metadataChildWorkflow = defineWorkflow({
+  name: 'metadata-child',
+  title: 'Metadata child workflow',
+  description: 'Enriches text for metadata graph',
+  input: t.object({ text: t.string() }),
+  output: t.object({ text: t.string() }),
+}).build()
+
+const metadataWorkflow = defineWorkflow({
+  name: 'metadata-everything',
+  title: 'Metadata workflow',
+  description: 'Workflow graph with presentation metadata',
+  input: t.object({ text: t.string() }),
+  output: t.object({ text: t.string() }),
+})
+  .activity('extract', {
+    title: 'Extract text',
+    description: 'Extracts text from input',
+    input: t.object({ text: t.string() }),
+    output: t.object({ text: t.string() }),
+  })
+  .task('scoring', metadataTask, {
+    title: 'Score text',
+    description: 'Scores extracted text',
+  })
+  .workflow('enrich', metadataChildWorkflow, {
+    title: 'Enrich text',
+    description: 'Delegates enrichment',
+  })
+  .branch('route', {
+    title: 'Route text',
+    description: 'Chooses inline or delegated work',
+    output: t.object({ text: t.string() }),
+    cases: (helpers) => ({
+      inline: helpers.activity({
+        title: 'Inline route',
+        description: 'Runs inline route',
+        input: t.object({ text: t.string() }),
+        output: t.object({ text: t.string() }),
+      }),
+      scored: helpers.task(metadataTask, {
+        title: 'Task route',
+        description: 'Routes through task',
+      }),
+      delegated: helpers.workflow(metadataChildWorkflow, {
+        title: 'Workflow route',
+        description: 'Routes through workflow',
+      }),
+    }),
+  })
+  .parallel(
+    'fanout',
+    (helpers) => ({
+      scored: helpers.task(metadataTask, {
+        title: 'Parallel task route',
+        description: 'Runs task in parallel',
+      }),
+      enriched: helpers.workflow(metadataChildWorkflow, {
+        title: 'Parallel workflow route',
+        description: 'Runs workflow in parallel',
+      }),
+    }),
+    {
+      title: 'Fan out',
+      description: 'Runs members in parallel',
+    },
+  )
+  .mapTask('scoreAll', metadataTask, {
+    title: 'Score all',
+    description: 'Scores every item',
+    item: t.object({ text: t.string() }),
+    mode: 'wait-all',
+  })
+  .mapWorkflow('enrichAll', metadataChildWorkflow, {
+    title: 'Enrich all',
+    description: 'Enriches every item',
+    item: t.object({ text: t.string() }),
+    mode: 'wait-settled',
+  })
+  .build()
+
 describe('serializeWorkflowGraph', () => {
   it('serializes every node kind to the stable JSON shape', () => {
     expect(serializeWorkflowGraph(workflow)).toEqual({
@@ -138,9 +227,172 @@ describe('serializeWorkflowGraph', () => {
     })
   })
 
+  it('serializes presentation metadata on graphs, nodes, cases, and targets', () => {
+    const graph = serializeWorkflowGraph(metadataWorkflow)
+
+    expect(graph).toEqual({
+      name: 'metadata-everything',
+      title: 'Metadata workflow',
+      description: 'Workflow graph with presentation metadata',
+      nodes: [
+        {
+          name: 'extract',
+          kind: 'activity',
+          title: 'Extract text',
+          description: 'Extracts text from input',
+        },
+        {
+          name: 'scoring',
+          kind: 'task',
+          title: 'Score text',
+          description: 'Scores extracted text',
+          target: {
+            kind: 'task',
+            name: 'metadata-score',
+            title: 'Metadata score task',
+            description: 'Scores text for metadata graph',
+          },
+        },
+        {
+          name: 'enrich',
+          kind: 'workflow',
+          title: 'Enrich text',
+          description: 'Delegates enrichment',
+          target: {
+            kind: 'workflow',
+            name: 'metadata-child',
+            title: 'Metadata child workflow',
+            description: 'Enriches text for metadata graph',
+          },
+        },
+        {
+          name: 'route',
+          kind: 'branch',
+          title: 'Route text',
+          description: 'Chooses inline or delegated work',
+          cases: [
+            {
+              key: 'inline',
+              kind: 'activity',
+              title: 'Inline route',
+              description: 'Runs inline route',
+            },
+            {
+              key: 'scored',
+              kind: 'task',
+              title: 'Task route',
+              description: 'Routes through task',
+              target: {
+                kind: 'task',
+                name: 'metadata-score',
+                title: 'Metadata score task',
+                description: 'Scores text for metadata graph',
+              },
+            },
+            {
+              key: 'delegated',
+              kind: 'workflow',
+              title: 'Workflow route',
+              description: 'Routes through workflow',
+              target: {
+                kind: 'workflow',
+                name: 'metadata-child',
+                title: 'Metadata child workflow',
+                description: 'Enriches text for metadata graph',
+              },
+            },
+          ],
+        },
+        {
+          name: 'fanout',
+          kind: 'parallel',
+          title: 'Fan out',
+          description: 'Runs members in parallel',
+          cases: [
+            {
+              key: 'scored',
+              kind: 'task',
+              title: 'Parallel task route',
+              description: 'Runs task in parallel',
+              target: {
+                kind: 'task',
+                name: 'metadata-score',
+                title: 'Metadata score task',
+                description: 'Scores text for metadata graph',
+              },
+            },
+            {
+              key: 'enriched',
+              kind: 'workflow',
+              title: 'Parallel workflow route',
+              description: 'Runs workflow in parallel',
+              target: {
+                kind: 'workflow',
+                name: 'metadata-child',
+                title: 'Metadata child workflow',
+                description: 'Enriches text for metadata graph',
+              },
+            },
+          ],
+        },
+        {
+          name: 'scoreAll',
+          kind: 'mapTask',
+          title: 'Score all',
+          description: 'Scores every item',
+          target: {
+            kind: 'task',
+            name: 'metadata-score',
+            title: 'Metadata score task',
+            description: 'Scores text for metadata graph',
+          },
+          mode: 'wait-all',
+        },
+        {
+          name: 'enrichAll',
+          kind: 'mapWorkflow',
+          title: 'Enrich all',
+          description: 'Enriches every item',
+          target: {
+            kind: 'workflow',
+            name: 'metadata-child',
+            title: 'Metadata child workflow',
+            description: 'Enriches text for metadata graph',
+          },
+          mode: 'wait-settled',
+        },
+      ],
+    })
+    expect(JSON.parse(JSON.stringify(graph))).toEqual(graph)
+  })
+
   it('survives JSON transport unchanged', () => {
     const graph = serializeWorkflowGraph(workflow)
     expect(JSON.parse(JSON.stringify(graph))).toEqual(graph)
+  })
+
+  it('omits presentation metadata keys when definitions do not provide them', () => {
+    const graph = serializeWorkflowGraph(workflow)
+
+    expect('title' in graph).toBe(false)
+    expect(graph.nodes.every((node) => !('title' in node))).toBe(true)
+    expect(
+      graph.nodes.every(
+        (node) => node.target === undefined || !('title' in node.target),
+      ),
+    ).toBe(true)
+    expect(
+      graph.nodes.every(
+        (node) =>
+          node.cases === undefined ||
+          node.cases.every(
+            (branchCase) =>
+              !('title' in branchCase) &&
+              (branchCase.target === undefined ||
+                !('title' in branchCase.target)),
+          ),
+      ),
+    ).toBe(true)
   })
 })
 
@@ -157,6 +409,20 @@ describe('serializeWorkflowCatalog', () => {
     ])
     expect(catalog.workflows[0]).toEqual(serializeWorkflowGraph(workflow))
     expect(catalog.tasks).toEqual([{ name: 'score' }])
+  })
+
+  it('lists task presentation metadata when present', () => {
+    expect(
+      serializeWorkflowCatalog({
+        tasks: [metadataTask],
+      }).tasks,
+    ).toEqual([
+      {
+        name: 'metadata-score',
+        title: 'Metadata score task',
+        description: 'Scores text for metadata graph',
+      },
+    ])
   })
 
   it('defaults missing inputs to empty lists', () => {


### PR DESCRIPTION
Closes #254.

Optional `title` and `description` on workflow, task, node, and branch/parallel case definitions — purely declarative presentation metadata for UIs. No effect on execution, identity keys, idempotency, or storage: runs still store names only, and UIs join run rows to the graph/catalog by name.

## Definition surface

- `defineWorkflow({ name, title?, description?, ... })`, `defineTask({ ... })`.
- Every node builder options object: `.activity()`, `.task()`, `.workflow()`, `.branch()` (both overloads), `.mapTask()`, `.mapWorkflow()`.
- `.parallel(name, cases)` gains an optional third `options` argument (additive — existing call sites unchanged) since it had no options object to extend.
- Branch/parallel case helpers (`helpers.activity/task/workflow`) accept the fields too — inline activity cases have no named target, and per-case overrides of a target's label are legitimate.

Type-level, the fields live once on `WorkflowNodeBase` (covers all seven node kinds) plus `WorkflowDefinition`, `TaskDefinition`, and `BranchCaseDefinition`'s common part.

## Inspector

`serializeWorkflowGraph`/`serializeWorkflowCatalog` thread metadata through: `WorkflowGraph`, `WorkflowGraphNode`, `WorkflowGraphCase`, `WorkflowCatalogTask`, and `WorkflowGraphTarget` — targets carry the referenced task/workflow definition's own metadata so graph consumers can label targets without a second catalog lookup. Keys are absent (not `undefined`) when the definition provides none, keeping serialized graphs stable for snapshot/diff use.

## Out of scope

Schedule metadata, tags/categories, per-run definition snapshots (would pair naturally — metadata versioned with the definition keeps historical runs labeled — but that's its own issue).

## Tests

Builder: metadata carried verbatim at every level (workflow, all node kinds, all case kinds); metadata-free definitions carry no keys. Inspector: graph/catalog serialization includes metadata on nodes, cases, and targets; metadata-free graphs serialize without the keys; JSON round-trip stability. 428 package tests pass; `pnpm check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `title` and `description` metadata to workflow definitions, nodes, branches, parallel paths, map steps, and tasks.
  * Workflow graphs and catalog output now surface this metadata when present.

* **Bug Fixes**
  * Metadata is now preserved consistently across built workflows, serialized graphs, and case targets.
  * Outputs omit these fields when they aren’t provided, keeping existing structures clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->