### PR TITLE
workflows: wake-yielding watch() with debounce; drop persisted run event history

### DIFF
--- a/packages/workflows/src/adapters/postgres/drizzle.ts
+++ b/packages/workflows/src/adapters/postgres/drizzle.ts
@@ -25,7 +25,6 @@ type TableKey =
   | 'attempts'
   | 'nodeChildren'
   | 'runLeases'
-  | 'runEvents'
   | 'commands'
 
 type EnumKey =
@@ -83,7 +82,6 @@ const tableNames = {
   attempts: 'workflow_attempts',
   nodeChildren: 'workflow_node_children',
   runLeases: 'workflow_run_leases',
-  runEvents: 'workflow_run_events',
   commands: 'workflow_commands',
 } as const satisfies Record<TableKey, string>
 
@@ -109,7 +107,17 @@ function createEnums() {
   }
 }
 
-export function createSchema() {
+export type CreateSchemaOptions = {
+  /**
+   * GIN indexes over `workflow_runs.input`/`tags` for inspector search.
+   * Off by default: they amplify every run insert, and most deployments
+   * never filter by whole payloads.
+   */
+  readonly searchIndexes?: boolean
+}
+
+export function createSchema(options?: CreateSchemaOptions) {
+  const searchIndexes = options?.searchIndexes ?? false
   const enums = createEnums()
   const createTable = pgTable
 
@@ -153,14 +161,23 @@ export function createSchema() {
         .on(t.parentRunId)
         .where(sql.raw('parent_run_id IS NOT NULL')),
       index('workflow_runs_root_idx').on(t.rootRunId),
-      index('workflow_runs_input_gin_idx').using(
-        'gin',
-        t.input.op('jsonb_path_ops'),
-      ),
-      index('workflow_runs_tags_gin_idx').using(
-        'gin',
-        t.tags.op('jsonb_path_ops'),
-      ),
+      // retention prune scans terminal roots by age every tick; without this
+      // the sweep is a seq scan of the biggest table
+      index('workflow_runs_prune_idx')
+        .on(t.status, t.updatedAt)
+        .where(sql.raw('parent_run_id IS NULL')),
+      ...(searchIndexes
+        ? [
+            index('workflow_runs_input_gin_idx').using(
+              'gin',
+              t.input.op('jsonb_path_ops'),
+            ),
+            index('workflow_runs_tags_gin_idx').using(
+              'gin',
+              t.tags.op('jsonb_path_ops'),
+            ),
+          ]
+        : []),
       foreignKey({
         name: 'workflow_runs_parent_run_fk',
         columns: [t.parentRunId],
@@ -334,33 +351,6 @@ export function createSchema() {
       }).onDelete('cascade'),
     ],
   )
-  const runEvents = createTable(
-    tableNames.runEvents,
-    {
-      id: bigint('id', { mode: 'bigint' })
-        .primaryKey()
-        .generatedAlwaysAsIdentity(),
-      runId: uuid('run_id').notNull(),
-      rootRunId: uuid('root_run_id').notNull(),
-      kind: text('kind').notNull(),
-      status: text('status').notNull(),
-      nodeName: text('node_name'),
-      childKey: text('child_key'),
-      attemptId: uuid('attempt_id'),
-      attemptNumber: integer('attempt_number'),
-      error: jsonb('error'),
-      createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
-    },
-    (t) => [
-      index('workflow_run_events_run_idx').on(t.runId, t.id),
-      index('workflow_run_events_root_idx').on(t.rootRunId, t.id),
-      foreignKey({
-        name: 'workflow_run_events_run_fk',
-        columns: [t.runId],
-        foreignColumns: [runs.id],
-      }).onDelete('cascade'),
-    ],
-  )
   const commands = createTable(
     tableNames.commands,
     {
@@ -388,13 +378,14 @@ export function createSchema() {
     },
     (t) => [
       index('workflow_commands_run_idx').on(t.runId),
-      index('workflow_commands_claim_idx').on(
-        t.kind,
-        t.priority.desc(),
-        t.runAt,
-        t.createdAt,
-        t.id,
-      ),
+      // dead-lettered commands accumulate until retention prunes them; keep
+      // them out of the claim scan's index entirely
+      index('workflow_commands_claim_idx')
+        .on(t.kind, t.priority.desc(), t.runAt, t.createdAt, t.id)
+        .where(sql.raw('dead_at IS NULL')),
+      index('workflow_commands_dead_idx')
+        .on(t.deadAt)
+        .where(sql.raw('dead_at IS NOT NULL')),
       uniqueIndex('workflow_commands_continue_dedup_idx')
         .on(t.runId)
         .where(sql.raw("kind = 'continue' AND lease_token IS NULL")),
@@ -415,7 +406,6 @@ export function createSchema() {
       attempts,
       nodeChildren,
       runLeases,
-      runEvents,
       commands,
     },
     enums,

--- a/packages/workflows/src/adapters/postgres/manifest.ts
+++ b/packages/workflows/src/adapters/postgres/manifest.ts
@@ -57,7 +57,6 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
     'workflow_attempts',
     'workflow_node_children',
     'workflow_run_leases',
-    'workflow_run_events',
     'workflow_commands',
   ],
   constraints: [
@@ -72,7 +71,6 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
     'workflow_attempts_child_attempt_key',
     'workflow_node_children_pkey',
     'workflow_run_leases_pkey',
-    'workflow_run_events_pkey',
     'workflow_commands_pkey',
     'workflow_runs_parent_run_fk',
     'workflow_runs_root_run_fk',
@@ -84,7 +82,6 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
     'workflow_node_children_child_run_fk',
     'workflow_node_children_current_attempt_fk',
     'workflow_run_leases_run_fk',
-    'workflow_run_events_run_fk',
     'workflow_commands_run_fk',
   ],
   indexes: [
@@ -92,16 +89,20 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
     'workflow_schedules_due_idx',
     'workflow_runs_parent_idx',
     'workflow_runs_root_idx',
-    'workflow_runs_input_gin_idx',
-    'workflow_runs_tags_gin_idx',
+    'workflow_runs_prune_idx',
     'workflow_attempts_node_idx',
     'workflow_node_children_node_idx',
     'workflow_node_children_child_run_idx',
-    'workflow_run_events_run_idx',
-    'workflow_run_events_root_idx',
     'workflow_commands_run_idx',
     'workflow_commands_claim_idx',
+    'workflow_commands_dead_idx',
     'workflow_commands_continue_dedup_idx',
+  ],
+  // verified when present, allowed to be absent — see createSchema's
+  // searchIndexes option
+  optionalIndexes: [
+    'workflow_runs_input_gin_idx',
+    'workflow_runs_tags_gin_idx',
   ],
   constraintDefinitions: {
     workflow_attempts_child_attempt_key: {
@@ -111,11 +112,6 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
     },
     workflow_commands_run_fk: {
       table: 'workflow_commands',
-      type: 'f',
-      columns: ['run_id'],
-    },
-    workflow_run_events_run_fk: {
-      table: 'workflow_run_events',
       type: 'f',
       columns: ['run_id'],
     },
@@ -148,6 +144,12 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
       unique: false,
       columns: ['root_run_id'],
     },
+    workflow_runs_prune_idx: {
+      table: 'workflow_runs',
+      unique: false,
+      columns: ['status', 'updated_at'],
+      predicate: 'parent_run_id IS NULL',
+    },
     workflow_runs_input_gin_idx: {
       table: 'workflow_runs',
       unique: false,
@@ -163,6 +165,13 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
       unique: false,
       columns: ['kind', 'priority', 'run_at', 'created_at', 'id'],
       directions: ['ASC', 'DESC', 'ASC', 'ASC', 'ASC'],
+      predicate: 'dead_at IS NULL',
+    },
+    workflow_commands_dead_idx: {
+      table: 'workflow_commands',
+      unique: false,
+      columns: ['dead_at'],
+      predicate: 'dead_at IS NOT NULL',
     },
     workflow_commands_run_idx: {
       table: 'workflow_commands',
@@ -190,16 +199,6 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
       table: 'workflow_node_children',
       unique: false,
       columns: ['child_run_id'],
-    },
-    workflow_run_events_run_idx: {
-      table: 'workflow_run_events',
-      unique: false,
-      columns: ['run_id', 'id'],
-    },
-    workflow_run_events_root_idx: {
-      table: 'workflow_run_events',
-      unique: false,
-      columns: ['root_run_id', 'id'],
     },
   },
   columns: {
@@ -296,19 +295,6 @@ export const WORKFLOW_POSTGRES_SCHEMA_MANIFEST = {
       lease_token: { type: 'text', nullable: false },
       version: { type: 'int4', nullable: false },
       expires_at: { type: 'timestamptz', nullable: false },
-    },
-    workflow_run_events: {
-      id: { type: 'int8', nullable: false },
-      run_id: { type: 'uuid', nullable: false },
-      root_run_id: { type: 'uuid', nullable: false },
-      kind: { type: 'text', nullable: false },
-      status: { type: 'text', nullable: false },
-      node_name: { type: 'text', nullable: true },
-      child_key: { type: 'text', nullable: true },
-      attempt_id: { type: 'uuid', nullable: true },
-      attempt_number: { type: 'int4', nullable: true },
-      error: { type: 'jsonb', nullable: true },
-      created_at: { type: 'timestamptz', nullable: false },
     },
     workflow_commands: {
       id: { type: 'uuid', nullable: false },

--- a/packages/workflows/src/adapters/postgres/sql.ts
+++ b/packages/workflows/src/adapters/postgres/sql.ts
@@ -6,7 +6,6 @@ import type {
   StoredNodeChild,
   StoredError,
   StoredRun,
-  StoredRunEvent,
 } from '../../runtime/state.ts'
 import type {
   RuntimeNodeStatus,
@@ -320,20 +319,6 @@ export const mapDeadCommand = (row: JsonRecord): DeadWorkflowCommand => ({
   createdAt: row.created_at as Date,
 })
 
-export const mapRunEvent = (row: JsonRecord): StoredRunEvent => ({
-  id: String(row.id),
-  runId: row.run_id as string,
-  rootRunId: row.root_run_id as string,
-  kind: row.kind as StoredRunEvent['kind'],
-  status: row.status as string,
-  ...optional('nodeName', row.node_name as string | undefined),
-  ...optional('childKey', row.child_key as string | undefined),
-  ...optional('attemptId', row.attempt_id as string | undefined),
-  ...optional('attemptNumber', row.attempt_number as number | undefined),
-  ...optional('error', fromOptional(row.error) as StoredError | undefined),
-  createdAt: row.created_at as Date,
-})
-
 export const notifyRunStatusEventSql = (cteName: string) => `
   ${cteName}_notified AS (
     SELECT pg_notify('${WORKFLOW_RUN_EVENTS_CHANNEL}', root_run_id::text)
@@ -353,69 +338,18 @@ export const notifyRunStatusEventColumnsSql = (
     )
     .join('')
 
-export const emitRunStatusEventSql = (sourceAlias: string, cteName: string) => `
-  ${cteName}_events AS (
-    INSERT INTO workflow_run_events (
-      run_id, root_run_id, kind, status, error, created_at
-    )
-    SELECT
-      id, root_run_id, 'run', status::text, error, now()
-    FROM ${sourceAlias}
-    WHERE old_status IS DISTINCT FROM status::text
-    RETURNING root_run_id
-  ),
-  ${notifyRunStatusEventSql(cteName)}
-`
-
-export const emitNodeStatusEventSql = (
+// Nothing is persisted for status changes: the `_events` CTE is a plain
+// projection of the changed rows feeding the pg_notify CTE, so watchers
+// learn the family changed and re-read state. One shape serves run, node,
+// child, and attempt transitions alike.
+export const emitStatusChangeNotifySql = (
   sourceAlias: string,
   cteName: string,
 ) => `
   ${cteName}_events AS (
-    INSERT INTO workflow_run_events (
-      run_id, root_run_id, kind, status, node_name, error, created_at
-    )
-    SELECT
-      run_id, root_run_id, 'node', status::text, name, error, now()
+    SELECT root_run_id
     FROM ${sourceAlias}
     WHERE old_status IS DISTINCT FROM status::text
-    RETURNING root_run_id
-  ),
-  ${notifyRunStatusEventSql(cteName)}
-`
-
-export const emitChildStatusEventSql = (
-  sourceAlias: string,
-  cteName: string,
-) => `
-  ${cteName}_events AS (
-    INSERT INTO workflow_run_events (
-      run_id, root_run_id, kind, status, node_name, child_key, error, created_at
-    )
-    SELECT
-      run_id, root_run_id, 'child', status::text, node_name, child_key, error, now()
-    FROM ${sourceAlias}
-    WHERE old_status IS DISTINCT FROM status::text
-    RETURNING root_run_id
-  ),
-  ${notifyRunStatusEventSql(cteName)}
-`
-
-export const emitAttemptStatusEventSql = (
-  sourceAlias: string,
-  cteName: string,
-) => `
-  ${cteName}_events AS (
-    INSERT INTO workflow_run_events (
-      run_id, root_run_id, kind, status, node_name, child_key,
-      attempt_id, attempt_number, error, created_at
-    )
-    SELECT
-      run_id, root_run_id, 'attempt', status::text, node_name, child_key,
-      id, attempt_number, error, now()
-    FROM ${sourceAlias}
-    WHERE old_status IS DISTINCT FROM status::text
-    RETURNING root_run_id
   ),
   ${notifyRunStatusEventSql(cteName)}
 `

--- a/packages/workflows/src/adapters/postgres/store-children.ts
+++ b/packages/workflows/src/adapters/postgres/store-children.ts
@@ -8,9 +8,7 @@ import type { WorkflowPostgresConnection } from './connection.ts'
 import { toStoredError } from '../../runtime/errors.ts'
 import { isTerminalNodeStatus } from '../../runtime/status.ts'
 import {
-  emitAttemptStatusEventSql,
-  emitChildStatusEventSql,
-  emitNodeStatusEventSql,
+  emitStatusChangeNotifySql,
   id,
   isUniqueViolation,
   json,
@@ -269,7 +267,7 @@ export const createPostgresWorkflowChildStore = (
               AND workflow_node_children.status IN (${nodeStatusSourcesSql('running', { self: true })})
             RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
             ),
-            ${emitChildStatusEventSql('updated', 'child_run_linked')}
+            ${emitStatusChangeNotifySql('updated', 'child_run_linked')}
             SELECT updated.*${notifyRunStatusEventColumnsSql('child_run_linked')}
             FROM updated
           `,
@@ -343,7 +341,7 @@ export const createPostgresWorkflowChildStore = (
               FROM inserted
               JOIN workflow_runs r ON r.id = inserted.run_id
             ),
-            ${emitAttemptStatusEventSql('event_source', 'attempt_started')}
+            ${emitStatusChangeNotifySql('event_source', 'attempt_started')}
             SELECT inserted.*${notifyRunStatusEventColumnsSql('attempt_started')}
             FROM inserted
           `,
@@ -381,7 +379,7 @@ export const createPostgresWorkflowChildStore = (
               AND workflow_node_children.status IN (${nodeStatusSourcesSql('running', { self: true })})
             RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
             ),
-            ${emitChildStatusEventSql('updated', 'child_running')}
+            ${emitStatusChangeNotifySql('updated', 'child_running')}
             SELECT updated.*${notifyRunStatusEventColumnsSql('child_running')}
             FROM updated
           `,
@@ -411,7 +409,7 @@ export const createPostgresWorkflowChildStore = (
               AND workflow_nodes.status IN (${nodeStatusSourcesSql('running', { self: true })})
             RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
             ),
-            ${emitNodeStatusEventSql('updated', 'node_running')}
+            ${emitStatusChangeNotifySql('updated', 'node_running')}
             SELECT count(*)${notifyRunStatusEventColumnsSql('node_running')}
             FROM updated
           `,
@@ -502,7 +500,7 @@ export const createPostgresWorkflowChildStore = (
           AND workflow_node_children.status IN (${nodeStatusSourcesSql('completed')})
         RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
         ),
-        ${emitChildStatusEventSql('updated', 'child_completed')}
+        ${emitStatusChangeNotifySql('updated', 'child_completed')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('child_completed')}
         FROM updated
       `,
@@ -542,7 +540,7 @@ export const createPostgresWorkflowChildStore = (
           AND workflow_node_children.status IN (${nodeStatusSourcesSql('failed')})
         RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
         ),
-        ${emitChildStatusEventSql('updated', 'child_failed')}
+        ${emitStatusChangeNotifySql('updated', 'child_failed')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('child_failed')}
         FROM updated
       `,
@@ -584,7 +582,7 @@ export const createPostgresWorkflowChildStore = (
           AND workflow_nodes.status IN (${nodeStatusSourcesSql('waiting', { self: true })})
         RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
         ),
-        ${emitNodeStatusEventSql('updated', 'node_waiting')}
+        ${emitStatusChangeNotifySql('updated', 'node_waiting')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('node_waiting')}
         FROM updated
       `,

--- a/packages/workflows/src/adapters/postgres/store-nodes.ts
+++ b/packages/workflows/src/adapters/postgres/store-nodes.ts
@@ -13,10 +13,7 @@ import {
 } from '../../runtime/status.ts'
 import {
   WORKFLOW_CANCELLATIONS_CHANNEL,
-  emitAttemptStatusEventSql,
-  emitChildStatusEventSql,
-  emitNodeStatusEventSql,
-  emitRunStatusEventSql,
+  emitStatusChangeNotifySql,
   id,
   isUuid,
   jsonRecordArrayColumn,
@@ -250,7 +247,7 @@ export const createPostgresWorkflowNodeStore = (
             FROM inserted
             JOIN workflow_runs r ON r.id = inserted.run_id
           ),
-          ${emitAttemptStatusEventSql('event_source', 'attempt_started')}
+          ${emitStatusChangeNotifySql('event_source', 'attempt_started')}
           SELECT inserted.*${notifyRunStatusEventColumnsSql('attempt_started')}
           FROM inserted
         `,
@@ -289,7 +286,7 @@ export const createPostgresWorkflowNodeStore = (
             AND workflow_node_children.status IN (${nodeStatusSourcesSql('running', { self: true })})
           RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
           ),
-          ${emitChildStatusEventSql('updated', 'child_running')}
+          ${emitStatusChangeNotifySql('updated', 'child_running')}
           SELECT updated.*${notifyRunStatusEventColumnsSql('child_running')}
           FROM updated
         `,
@@ -319,7 +316,7 @@ export const createPostgresWorkflowNodeStore = (
             AND workflow_nodes.status IN (${nodeStatusSourcesSql('running', { self: true })})
           RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
           ),
-          ${emitNodeStatusEventSql('updated', 'node_running')}
+          ${emitStatusChangeNotifySql('updated', 'node_running')}
           SELECT count(*)${notifyRunStatusEventColumnsSql('node_running')}
           FROM updated
         `,
@@ -356,7 +353,7 @@ export const createPostgresWorkflowNodeStore = (
             WHERE workflow_attempts.id = candidate.id
             RETURNING workflow_attempts.*, candidate.old_status, candidate.root_run_id
             ),
-            ${emitAttemptStatusEventSql('updated', 'attempt_completed')}
+            ${emitStatusChangeNotifySql('updated', 'attempt_completed')}
             SELECT updated.*${notifyRunStatusEventColumnsSql('attempt_completed')}
             FROM updated
           `,
@@ -387,7 +384,7 @@ export const createPostgresWorkflowNodeStore = (
               AND workflow_node_children.status IN (${nodeStatusSourcesSql('completed')})
             RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
             ),
-            ${emitChildStatusEventSql('updated', 'child_completed')}
+            ${emitStatusChangeNotifySql('updated', 'child_completed')}
             SELECT updated.*${notifyRunStatusEventColumnsSql('child_completed')}
             FROM updated
           `,
@@ -422,7 +419,7 @@ export const createPostgresWorkflowNodeStore = (
         WHERE workflow_attempts.id = candidate.id
         RETURNING workflow_attempts.*, candidate.old_status, candidate.root_run_id
         ),
-        ${emitAttemptStatusEventSql('updated', 'attempt_failed')}
+        ${emitStatusChangeNotifySql('updated', 'attempt_failed')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('attempt_failed')}
         FROM updated
       `,
@@ -451,7 +448,7 @@ export const createPostgresWorkflowNodeStore = (
         WHERE workflow_attempts.id = candidate.id
         RETURNING workflow_attempts.*, candidate.old_status, candidate.root_run_id
         ),
-        ${emitAttemptStatusEventSql('updated', 'attempt_timed_out')}
+        ${emitStatusChangeNotifySql('updated', 'attempt_timed_out')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('attempt_timed_out')}
         FROM updated
       `,
@@ -491,7 +488,7 @@ export const createPostgresWorkflowNodeStore = (
           AND workflow_nodes.status IN (${nodeStatusSourcesSql('completed')})
         RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
         ),
-        ${emitNodeStatusEventSql('updated', 'node_completed')}
+        ${emitStatusChangeNotifySql('updated', 'node_completed')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('node_completed')}
         FROM updated
       `,
@@ -537,7 +534,7 @@ export const createPostgresWorkflowNodeStore = (
           AND workflow_nodes.status IN (${nodeStatusSourcesSql('failed')})
         RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
         ),
-        ${emitNodeStatusEventSql('updated', 'node_failed')}
+        ${emitStatusChangeNotifySql('updated', 'node_failed')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('node_failed')}
         FROM updated
       `,
@@ -571,7 +568,7 @@ export const createPostgresWorkflowNodeStore = (
           AND workflow_runs.status IN (${runStatusSourcesSql('running')})
         RETURNING workflow_runs.*, candidate.old_status
         ),
-        ${emitRunStatusEventSql('updated', 'run_running')}
+        ${emitStatusChangeNotifySql('updated', 'run_running')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('run_running')}
         FROM updated
       `,
@@ -605,7 +602,7 @@ export const createPostgresWorkflowNodeStore = (
           AND workflow_runs.status IN (${runStatusSourcesSql('waiting')})
         RETURNING workflow_runs.*, candidate.old_status
         ),
-        ${emitRunStatusEventSql('updated', 'run_waiting')}
+        ${emitStatusChangeNotifySql('updated', 'run_waiting')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('run_waiting')}
         FROM updated
       `,
@@ -647,7 +644,7 @@ export const createPostgresWorkflowNodeStore = (
           AND workflow_runs.status IN (${runStatusSourcesSql('completed')})
         RETURNING workflow_runs.*, candidate.old_status
         ),
-        ${emitRunStatusEventSql('updated', 'run_completed')}
+        ${emitStatusChangeNotifySql('updated', 'run_completed')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('run_completed')}
         FROM updated
       `,
@@ -689,7 +686,7 @@ export const createPostgresWorkflowNodeStore = (
           AND workflow_runs.status IN (${runStatusSourcesSql('failed')})
         RETURNING workflow_runs.*, candidate.old_status
         ),
-        ${emitRunStatusEventSql('updated', 'run_failed')}
+        ${emitStatusChangeNotifySql('updated', 'run_failed')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('run_failed')}
         FROM updated
       `,
@@ -735,7 +732,7 @@ export const createPostgresWorkflowNodeStore = (
             AND workflow_runs.status IN (${runStatusSourcesSql('cancelling')})
           RETURNING workflow_runs.*, candidate.old_status
         ),
-        ${emitRunStatusEventSql('updated', 'run_cancelling')},
+        ${emitStatusChangeNotifySql('updated', 'run_cancelling')},
         cancellation_notified AS (
           SELECT pg_notify('${WORKFLOW_CANCELLATIONS_CHANNEL}', id::text)
           FROM updated
@@ -781,7 +778,7 @@ export const createPostgresWorkflowNodeStore = (
           AND workflow_runs.status IN (${runStatusSourcesSql('cancelled')})
         RETURNING workflow_runs.*, candidate.old_status
         ),
-        ${emitRunStatusEventSql('updated', 'run_cancelled')}
+        ${emitStatusChangeNotifySql('updated', 'run_cancelled')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('run_cancelled')}
         FROM updated
       `,
@@ -826,7 +823,7 @@ export const createPostgresWorkflowNodeStore = (
           AND workflow_nodes.status IN (${nodeStatusSourcesSql('cancelled')})
         RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
         ),
-        ${emitNodeStatusEventSql('updated', 'node_cancelled')}
+        ${emitStatusChangeNotifySql('updated', 'node_cancelled')}
         SELECT updated.*${notifyRunStatusEventColumnsSql('node_cancelled')}
         FROM updated
       `,
@@ -863,7 +860,7 @@ export const createPostgresWorkflowNodeStore = (
             AND workflow_nodes.status IN (${nodeStatusSourcesSql('cancelled')})
           RETURNING workflow_nodes.*, candidate.old_status, candidate.root_run_id
           ),
-          ${emitNodeStatusEventSql('updated', 'nodes_cancelled')}
+          ${emitStatusChangeNotifySql('updated', 'nodes_cancelled')}
           SELECT updated.*${notifyRunStatusEventColumnsSql('nodes_cancelled')}
           FROM updated
         `,
@@ -890,7 +887,7 @@ export const createPostgresWorkflowNodeStore = (
             AND workflow_node_children.status IN (${nodeStatusSourcesSql('cancelled')})
           RETURNING workflow_node_children.*, candidate.old_status, candidate.root_run_id
           ),
-          ${emitChildStatusEventSql('updated', 'children_cancelled')}
+          ${emitStatusChangeNotifySql('updated', 'children_cancelled')}
           SELECT count(*)${notifyRunStatusEventColumnsSql('children_cancelled')}
           FROM updated
         `,

--- a/packages/workflows/src/adapters/postgres/store-runs.ts
+++ b/packages/workflows/src/adapters/postgres/store-runs.ts
@@ -10,7 +10,6 @@ import type {
 } from '../../runtime/store.ts'
 import type { WorkflowPostgresConnection } from './connection.ts'
 import type { JsonRecord } from './sql.ts'
-import { assertValidRunEventsCursor } from '../../runtime/store.ts'
 import {
   id,
   isUniqueViolation,
@@ -27,10 +26,9 @@ import {
   mapNodeChildSummary,
   mapNodeSummary,
   mapRun,
-  mapRunEvent,
   mapRunSummary,
   DEFAULT_PRUNE_STATUSES,
-  emitRunStatusEventSql,
+  emitStatusChangeNotifySql,
   normalizePruneBatchSize,
   normalizePruneStatuses,
   notifyRunStatusEventColumnsSql,
@@ -50,7 +48,6 @@ type PostgresWorkflowRunStore = Pick<
   WorkflowStore,
   | 'createRun'
   | 'listRuns'
-  | 'listRunEvents'
   | 'listRunSummaries'
   | 'pruneTerminalRuns'
   | 'deleteRun'
@@ -67,10 +64,14 @@ type PostgresWorkflowRunStore = Pick<
   | 'loadRuns'
 >
 
+export type CreateStoredRunOptions = {
+  readonly recoverUniqueViolation?: boolean
+}
+
 export const createStoredRunWithState = async (
   connection: WorkflowPostgresConnection,
   input: CreateRunInput,
-  options: { readonly recoverUniqueViolation?: boolean } = {},
+  options: CreateStoredRunOptions = {},
 ): Promise<{ readonly run: StoredRun; readonly created: boolean }> => {
   const recoverUniqueViolation = options.recoverUniqueViolation ?? true
   const loadIdempotentRun = async () => {
@@ -119,7 +120,7 @@ export const createStoredRunWithState = async (
         )
         RETURNING *, NULL::text AS old_status
       ),
-      ${emitRunStatusEventSql('inserted', 'run_created')}
+      ${emitStatusChangeNotifySql('inserted', 'run_created')}
       SELECT inserted.*${notifyRunStatusEventColumnsSql('run_created')}
       FROM inserted
       `,
@@ -155,7 +156,7 @@ export const createStoredRunWithState = async (
 export const createStoredRun = async (
   connection: WorkflowPostgresConnection,
   input: CreateRunInput,
-  options: { readonly recoverUniqueViolation?: boolean } = {},
+  options: CreateStoredRunOptions = {},
 ) => (await createStoredRunWithState(connection, input, options)).run
 
 export const pruneTerminalRunsInTransaction = async (
@@ -441,49 +442,6 @@ export const createPostgresWorkflowRunStore = (
         runs: page.map(mapRun),
         ...(query.limit !== null && rows.length > query.limit
           ? { nextCursor: String(query.offset + query.limit) }
-          : {}),
-      }
-    },
-    async listRunEvents({ runId, family = false, afterEventId, limit }) {
-      await ready
-      if (!isUuid(runId)) return { events: [] }
-      const normalizedLimit = normalizeEventLimit(limit)
-      if (normalizedLimit !== undefined && normalizedLimit < 1) {
-        return { events: [] }
-      }
-      assertValidRunEventsCursor(afterEventId)
-
-      const params: unknown[] = [runId, afterEventId ?? '0']
-      const limitSql =
-        normalizedLimit === undefined
-          ? ''
-          : `LIMIT $${params.push(normalizedLimit + 1)}`
-      const rows = await many(
-        db,
-        `
-        SELECT e.*
-        FROM workflow_run_events e
-        JOIN workflow_runs target
-          ON target.id = $1
-        WHERE e.id > $2::bigint
-          AND ${
-            family
-              ? 'e.root_run_id = target.root_run_id'
-              : 'e.run_id = target.id'
-          }
-        ORDER BY e.id ASC
-        ${limitSql}
-      `,
-        params,
-      )
-      const page =
-        normalizedLimit === undefined ? rows : rows.slice(0, normalizedLimit)
-      return {
-        events: page
-          .map((row) => withDateColumns(row, ['created_at']))
-          .map(mapRunEvent),
-        ...(normalizedLimit !== undefined && rows.length > normalizedLimit
-          ? { nextCursor: String(page.at(-1)?.id) }
           : {}),
       }
     },
@@ -867,9 +825,4 @@ export const createPostgresWorkflowRunStore = (
       }))
     },
   }
-}
-
-function normalizeEventLimit(limit: number | undefined): number | undefined {
-  if (limit === undefined) return undefined
-  return Number.isInteger(limit) && limit > 0 ? limit : 0
 }

--- a/packages/workflows/src/adapters/postgres/testing.ts
+++ b/packages/workflows/src/adapters/postgres/testing.ts
@@ -144,6 +144,11 @@ export async function installPostgresWorkflowSchemaForTesting(
     ON workflow_runs (root_run_id)
   `)
   await db.query(`
+    CREATE INDEX IF NOT EXISTS workflow_runs_prune_idx
+    ON workflow_runs (status, updated_at)
+    WHERE parent_run_id IS NULL
+  `)
+  await db.query(`
     CREATE INDEX IF NOT EXISTS workflow_runs_input_gin_idx
     ON workflow_runs USING gin (input jsonb_path_ops)
   `)
@@ -218,21 +223,8 @@ export async function installPostgresWorkflowSchemaForTesting(
       expires_at timestamptz NOT NULL
     )
   `)
-  await db.query(`
-    CREATE TABLE IF NOT EXISTS workflow_run_events (
-      id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-      run_id uuid NOT NULL,
-      root_run_id uuid NOT NULL,
-      kind text NOT NULL,
-      status text NOT NULL,
-      node_name text,
-      child_key text,
-      attempt_id uuid,
-      attempt_number integer,
-      error jsonb,
-      created_at timestamptz NOT NULL
-    )
-  `)
+  // dropped in beta.5: run event history is gone; clean stale test databases
+  await db.query('DROP TABLE IF EXISTS workflow_run_events')
   await db.query(`
     CREATE TABLE IF NOT EXISTS workflow_commands (
       id uuid PRIMARY KEY,
@@ -269,9 +261,32 @@ export async function installPostgresWorkflowSchemaForTesting(
     ADD COLUMN IF NOT EXISTS dead_at timestamptz,
     ADD COLUMN IF NOT EXISTS reaped_at timestamptz
   `)
+  // drop-and-create: pre-existing test databases may hold the older
+  // non-partial shape under the same name; the advisory lock serializes
+  // concurrent installers (integration spec files share one database)
   await db.query(`
-    CREATE INDEX IF NOT EXISTS workflow_commands_claim_idx
-    ON workflow_commands (kind, priority DESC, run_at, created_at, id)
+    DO $$
+    BEGIN
+      PERFORM pg_advisory_xact_lock(hashtext('workflow_commands_claim_idx_install'));
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indexrelid
+        WHERE c.relname = 'workflow_commands_claim_idx'
+          AND i.indpred IS NOT NULL
+      ) THEN
+        DROP INDEX IF EXISTS workflow_commands_claim_idx;
+        CREATE INDEX workflow_commands_claim_idx
+        ON workflow_commands (kind, priority DESC, run_at, created_at, id)
+        WHERE dead_at IS NULL;
+      END IF;
+    END
+    $$;
+  `)
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS workflow_commands_dead_idx
+    ON workflow_commands (dead_at)
+    WHERE dead_at IS NOT NULL
   `)
   await db.query(`
     CREATE INDEX IF NOT EXISTS workflow_commands_run_idx
@@ -293,14 +308,6 @@ export async function installPostgresWorkflowSchemaForTesting(
   await db.query(`
     CREATE INDEX IF NOT EXISTS workflow_node_children_child_run_idx
     ON workflow_node_children (child_run_id)
-  `)
-  await db.query(`
-    CREATE INDEX IF NOT EXISTS workflow_run_events_run_idx
-    ON workflow_run_events (run_id, id)
-  `)
-  await db.query(`
-    CREATE INDEX IF NOT EXISTS workflow_run_events_root_idx
-    ON workflow_run_events (root_run_id, id)
   `)
   await db.query(`
     DO $$
@@ -386,14 +393,6 @@ export async function installPostgresWorkflowSchemaForTesting(
       IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'workflow_run_leases_run_fk') THEN
         ALTER TABLE workflow_run_leases
         ADD CONSTRAINT workflow_run_leases_run_fk
-        FOREIGN KEY (run_id)
-        REFERENCES workflow_runs(id)
-        ON DELETE CASCADE;
-      END IF;
-
-      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'workflow_run_events_run_fk') THEN
-        ALTER TABLE workflow_run_events
-        ADD CONSTRAINT workflow_run_events_run_fk
         FOREIGN KEY (run_id)
         REFERENCES workflow_runs(id)
         ON DELETE CASCADE;

--- a/packages/workflows/src/adapters/postgres/verify.ts
+++ b/packages/workflows/src/adapters/postgres/verify.ts
@@ -284,11 +284,16 @@ export async function verifyPostgresWorkflowSchema(
   const indexDefinitionsByName = new Map(
     indexDefinitions.map((definition) => [definition.name, definition]),
   )
+  const optionalIndexes = new Set<string>(
+    WORKFLOW_POSTGRES_SCHEMA_MANIFEST.optionalIndexes,
+  )
   const invalidIndexes = Object.entries(
     WORKFLOW_POSTGRES_SCHEMA_MANIFEST.indexDefinitions,
   )
     .filter(([name, expected]) => {
       const actual = indexDefinitionsByName.get(name)
+      // optional indexes may be absent, but when present must match
+      if (!actual && optionalIndexes.has(name)) return false
       return (
         !actual ||
         actual.table_name !== expected.table ||

--- a/packages/workflows/src/adapters/postgres/wake-events.ts
+++ b/packages/workflows/src/adapters/postgres/wake-events.ts
@@ -58,6 +58,7 @@ export function createPostgresWorkflowWakeEvents(
   let disposed = false
   let client: WorkflowPostgresListenerClient | undefined
   let reconnectTimer: ReturnType<typeof setTimeout> | undefined
+  let everListened = false
 
   // shutdown intentionally interrupts in-flight connect/LISTEN work; don't
   // surface those interruptions as errors
@@ -127,6 +128,16 @@ export function createPostgresWorkflowWakeEvents(
       await connected.query(
         `LISTEN "${WORKFLOW_COMMANDS_CHANNEL}"; LISTEN "${WORKFLOW_CANCELLATIONS_CHANNEL}"; LISTEN "${WORKFLOW_RUN_EVENTS_CHANNEL}"`,
       )
+      // Reconnect pulse: everything notified during the gap is lost, and there
+      // is no history to replay, so tell every subscriber "maybe changed" —
+      // wakes are idempotent, so a spurious one costs one refetch/claim pass,
+      // never correctness. Heals watchers and worker dispatch alike.
+      if (everListened) {
+        for (const listeners of commandListeners.values()) fire(listeners)
+        for (const listeners of cancellationListeners.values()) fire(listeners)
+        for (const listeners of runEventListeners.values()) fire(listeners)
+      }
+      everListened = true
     } catch (error) {
       reportError(error)
       scheduleReconnect()

--- a/packages/workflows/src/adapters/postgres/wake-events.ts
+++ b/packages/workflows/src/adapters/postgres/wake-events.ts
@@ -107,8 +107,9 @@ export function createPostgresWorkflowWakeEvents(
 
   const connect = async () => {
     if (disposed || client) return
+    let connected: WorkflowPostgresListenerClient | undefined
     try {
-      const connected = await params.connect()
+      connected = await params.connect()
       if (disposed) {
         await connected.end()
         return
@@ -139,6 +140,15 @@ export function createPostgresWorkflowWakeEvents(
       }
       everListened = true
     } catch (error) {
+      // a LISTEN failure after the slot was claimed must release it, or the
+      // scheduled retry no-ops on the `client` guard and the hub silently
+      // degrades to poll-only forever
+      if (connected !== undefined && client === connected) {
+        client = undefined
+        try {
+          await connected.end()
+        } catch {}
+      }
       reportError(error)
       scheduleReconnect()
     }

--- a/packages/workflows/src/inspector/index.ts
+++ b/packages/workflows/src/inspector/index.ts
@@ -4,7 +4,6 @@ import type {
   StoredNode,
   StoredNodeChild,
   StoredRun,
-  StoredRunEvent,
 } from '../runtime/state.ts'
 import type {
   AttemptSummary,
@@ -234,7 +233,6 @@ export type RunDto = WireSafe<StoredRun>
 export type NodeDto = WireSafe<StoredNode>
 export type NodeChildDto = WireSafe<StoredNodeChild>
 export type AttemptDto = WireSafe<StoredAttempt>
-export type RunEventDto = WireSafe<StoredRunEvent>
 
 export type RunSnapshotDto = {
   readonly run: RunDto
@@ -301,10 +299,6 @@ export function toAttemptDto(attempt: StoredAttempt): AttemptDto {
     heartbeatAt: true,
     completedAt: true,
   })
-}
-
-export function toRunEventDto(event: StoredRunEvent): RunEventDto {
-  return convertDates(event, { createdAt: true })
 }
 
 export function toRunSnapshotDto(snapshot: RunSnapshot): RunSnapshotDto {

--- a/packages/workflows/src/runtime/client.ts
+++ b/packages/workflows/src/runtime/client.ts
@@ -290,7 +290,10 @@ async function* watchRun(params: {
   // one consumption when the window closes (trailing edge). Every wake inside
   // the window still peeks at the run row so a status transition — terminal
   // above all — is consumed without delay: the window only coalesces coarse
-  // change yields, whose downstream refetches are the load being capped.
+  // change yields, whose downstream refetches are the load being capped. The
+  // peek reads themselves are deliberately uncapped (one cheap PK read per
+  // wake, bounded by the window) — capping them would trade terminal latency
+  // for savings on the wrong side of the debounce.
   let lastStatus: string | undefined
   let lastWakeConsumedAt = 0
   const waitForChange = async (): Promise<boolean> => {

--- a/packages/workflows/src/runtime/client.ts
+++ b/packages/workflows/src/runtime/client.ts
@@ -13,7 +13,7 @@ import type {
 import type { WorkflowRuntimeAtomicStart } from './coordinator.ts'
 import type { AttemptExecutor, RunCoordinationExecutor } from './executors.ts'
 import type { WorkflowScheduler } from './scheduler.ts'
-import type { RunSnapshot, StoredRun, StoredRunEvent } from './state.ts'
+import type { RunSnapshot, StoredError, StoredRun } from './state.ts'
 import type {
   DeadWorkflowCommand,
   DeleteRunResult,
@@ -49,11 +49,34 @@ export type WorkflowRuntimeStartOptions = {
 }
 
 export type WatchRunOptions = {
-  readonly family?: boolean
-  readonly afterEventId?: string
+  /**
+   * Also yield a coarse `{ kind: 'change' }` event on every wake notification
+   * for the watched run's family. Family-granular by construction: the notify
+   * key is the root run id, and node-level transitions don't touch any row a
+   * run-scoped watcher could re-read to self-filter. Coarse events have no
+   * poll backstop — a missed notification is invisible until the next wake or
+   * the terminal transition. Best-effort intermediates; terminal delivery
+   * stays poll-guaranteed.
+   */
+  readonly wake?: boolean
+  /**
+   * Coalesce wake-driven yields: first wake after quiet passes immediately
+   * (leading edge), further wakes inside the window collapse into one more
+   * yield when it closes (trailing edge). Terminal discovery is never
+   * suppressed. 0/absent = raw wakes.
+   */
+  readonly debounceMs?: number
   readonly signal?: AbortSignal
   readonly pollIntervalMs?: number
 }
+
+export type WatchEvent =
+  | { readonly kind: 'change' }
+  | {
+      readonly kind: 'run'
+      readonly status: StoredRun['status']
+      readonly error?: StoredError
+    }
 
 export type WorkflowRuntimeAdapter = {
   readonly store: WorkflowStore
@@ -106,7 +129,7 @@ export type WorkflowRuntimeClient = {
   readonly watch: (
     runId: string,
     options?: WatchRunOptions,
-  ) => AsyncIterable<StoredRunEvent>
+  ) => AsyncIterable<WatchEvent>
   readonly pruneRuns: (
     params: PruneTerminalRunsParams,
   ) => Promise<PruneTerminalRunsResult>
@@ -216,33 +239,31 @@ async function* watchRun(params: {
   readonly wakeEvents?: WorkflowWakeEvents
   readonly runId: string
   readonly options?: WatchRunOptions
-}): AsyncIterable<StoredRunEvent> {
+}): AsyncIterable<WatchEvent> {
   const [run] = await params.store.loadRuns([params.runId])
   if (!run) return
 
-  const rootRunId = run.rootRunId
+  const signal = params.options?.signal
   const pollIntervalMs = normalizePollInterval(params.options?.pollIntervalMs)
-  let afterEventId = params.options?.afterEventId
-  let cleanupWait: (() => void) | undefined
-  let resolveWait: (() => void) | undefined
+  const debounceMs = normalizeDebounce(params.options?.debounceMs)
+  const coarse = params.options?.wake === true
+
+  // Wakes arriving while a read/yield is in flight are latched, never lost.
   let wakePending = false
-  const removeWake = params.wakeEvents?.onRunEvent?.(rootRunId, () => {
+  let resolveWait: (() => void) | undefined
+  const removeWake = params.wakeEvents?.onRunEvent?.(run.rootRunId, () => {
     wakePending = true
     resolveWait?.()
   })
 
+  let cleanupWait: (() => void) | undefined
   const cleanup = () => {
     cleanupWait?.()
     cleanupWait = undefined
     resolveWait = undefined
   }
-
-  const waitForChange = async () => {
-    if (wakePending) {
-      wakePending = false
-      return
-    }
-    await new Promise<void>((resolve) => {
+  const sleep = (ms: number) =>
+    new Promise<void>((resolve) => {
       let settled = false
       const finish = () => {
         if (settled) return
@@ -250,68 +271,67 @@ async function* watchRun(params: {
         cleanup()
         resolve()
       }
-      const timer = setTimeout(finish, pollIntervalMs)
+      const timer = setTimeout(finish, ms)
       const removeAbort =
-        params.options?.signal === undefined
+        signal === undefined
           ? undefined
-          : () => params.options?.signal?.removeEventListener('abort', finish)
-      params.options?.signal?.addEventListener('abort', finish, {
-        once: true,
-      })
+          : () => signal.removeEventListener('abort', finish)
+      signal?.addEventListener('abort', finish, { once: true })
       resolveWait = finish
       cleanupWait = () => {
         clearTimeout(timer)
         removeAbort?.()
       }
     })
+
+  // Returns true when a wake was consumed (vs. a poll tick or abort). The
+  // debounce window is anchored at the last consumed wake: a wake outside the
+  // window passes immediately (leading edge), wakes inside it collapse into
+  // one consumption when the window closes (trailing edge). Every wake inside
+  // the window still peeks at the run row so a status transition — terminal
+  // above all — is consumed without delay: the window only coalesces coarse
+  // change yields, whose downstream refetches are the load being capped.
+  let lastStatus: string | undefined
+  let lastWakeConsumedAt = 0
+  const waitForChange = async (): Promise<boolean> => {
+    if (!wakePending) await sleep(pollIntervalMs)
+    if (signal?.aborted || !wakePending) return false
+    while (!signal?.aborted) {
+      const remaining = lastWakeConsumedAt + debounceMs - Date.now()
+      if (remaining <= 0) break
+      wakePending = false
+      const [current] = await params.store.loadRuns([params.runId])
+      if (!current || current.status !== lastStatus) break
+      if (!wakePending) await sleep(remaining)
+      if (!wakePending) break
+    }
     wakePending = false
+    lastWakeConsumedAt = Date.now()
+    return !signal?.aborted
   }
 
-  let checkedBeforeFirstWait = false
+  // The subscription is in place before this baseline read, so nothing
+  // committed after the read can slip through unnoticed. Coarse events are
+  // NOTIFY-only best-effort; run-status transitions (including terminal) are
+  // additionally guaranteed by the poll backstop re-reading the run row.
+  let woke = false
   try {
-    while (!params.options?.signal?.aborted) {
-      const result = await params.store.listRunEvents({
-        runId: params.runId,
-        family: params.options?.family,
-        afterEventId,
-      })
-
-      for (const event of result.events) {
-        afterEventId = event.id
-        yield event
-        if (
-          event.kind === 'run' &&
-          event.runId === params.runId &&
-          isTerminalRunStatus(event.status as StoredRun['status'])
-        ) {
-          return
+    while (!signal?.aborted) {
+      const [current] = await params.store.loadRuns([params.runId])
+      if (!current) return
+      if (current.status !== lastStatus) {
+        lastStatus = current.status
+        yield {
+          kind: 'run',
+          status: current.status,
+          ...(current.error === undefined ? {} : { error: current.error }),
         }
-        if (params.options?.signal?.aborted) return
+        if (isTerminalRunStatus(current.status)) return
+      } else if (coarse && woke) {
+        yield { kind: 'change' }
       }
-
-      if (params.options?.signal?.aborted) return
-
-      if (result.events.length === 0 || !checkedBeforeFirstWait) {
-        checkedBeforeFirstWait = true
-        const [latestRun] = await params.store.loadRuns([params.runId])
-        if (latestRun && isTerminalRunStatus(latestRun.status)) {
-          // Event ids are allocated before commit, so concurrent commits can
-          // hide the terminal event behind the cursor; stored status is truth.
-          const finalResult = await params.store.listRunEvents({
-            runId: params.runId,
-            family: params.options?.family,
-            afterEventId,
-          })
-          for (const event of finalResult.events) {
-            afterEventId = event.id
-            yield event
-            if (params.options?.signal?.aborted) return
-          }
-          return
-        }
-      }
-
-      await waitForChange()
+      if (signal?.aborted) return
+      woke = await waitForChange()
     }
   } finally {
     cleanup()
@@ -381,6 +401,11 @@ function normalizePruneBatchSize(batchSize: number | undefined): number {
   if (batchSize === undefined) return 100
   if (!Number.isInteger(batchSize) || batchSize < 1) return 0
   return batchSize
+}
+
+function normalizeDebounce(debounceMs: number | undefined): number {
+  if (debounceMs === undefined) return 0
+  return Number.isFinite(debounceMs) && debounceMs > 0 ? debounceMs : 0
 }
 
 function normalizePollInterval(intervalMs: number | undefined): number {

--- a/packages/workflows/src/runtime/in-memory.ts
+++ b/packages/workflows/src/runtime/in-memory.ts
@@ -20,7 +20,6 @@ import type {
   StoredNode,
   StoredNodeChild,
   StoredRun,
-  StoredRunEvent,
 } from './state.ts'
 import type {
   AttemptSummary,
@@ -52,7 +51,6 @@ import {
   startStoredScheduleRun,
 } from './scheduler.ts'
 import { isTerminalNodeStatus, isTerminalRunStatus } from './status.ts'
-import { assertValidRunEventsCursor } from './store.ts'
 import {
   NODE_TRANSITIONS,
   RUN_TRANSITIONS,
@@ -107,7 +105,6 @@ export type InMemoryWorkflowRuntime = {
     readonly nodes: readonly StoredNode[]
     readonly children: readonly StoredNodeChild[]
     readonly attempts: readonly StoredAttempt[]
-    readonly runEvents: readonly StoredRunEvent[]
     readonly continueRunCommands: readonly InspectQueueItem<ContinueRunCommand>[]
     readonly activityCommands: readonly InspectQueueItem<ActivityAttemptCommand>[]
     readonly taskCommands: readonly InspectQueueItem<TaskAttemptCommand>[]
@@ -122,7 +119,6 @@ export function createInMemoryWorkflowRuntime(
   } = {},
 ): InMemoryWorkflowRuntime {
   let nextId = 1
-  let nextEventId = 1n
   const id = (prefix: string) => `${prefix}-${nextId++}`
   let lastTimestamp = 0
   const now = () => {
@@ -136,7 +132,6 @@ export function createInMemoryWorkflowRuntime(
   const nodes = new Map<string, StoredNode>()
   const attempts = new Map<string, StoredAttempt>()
   const children = new Map<string, StoredNodeChild>()
-  const runEvents: StoredRunEvent[] = []
   const runIdempotencyKeys = new Map<string, string>()
   const runLeases = new Map<string, InMemoryRunLease>()
   const continueRunCommands: QueueItem<ContinueRunCommand>[] = []
@@ -187,66 +182,28 @@ export function createInMemoryWorkflowRuntime(
   const fireRunEventWake = (rootRunId: string) =>
     fireWake(runEventWakeListeners.get(rootRunId))
   const runRootId = (runId: string) => runs.get(runId)?.rootRunId ?? runId
-  const appendRunEvent = (event: Omit<StoredRunEvent, 'id' | 'createdAt'>) => {
-    const stored: StoredRunEvent = {
-      ...event,
-      id: String(nextEventId++),
-      createdAt: now(),
-    }
-    runEvents.push(stored)
-    fireRunEventWake(stored.rootRunId)
-  }
+  // Nothing is persisted for status changes: the wake hub is the in-process
+  // twin of the Postgres NOTIFY hint, and watchers re-read state on it.
   const emitRunStatusEvent = (run: StoredRun) => {
-    appendRunEvent({
-      runId: run.id,
-      rootRunId: run.rootRunId,
-      kind: 'run',
-      status: run.status,
-      ...(run.error === undefined ? {} : { error: run.error }),
-    })
+    fireRunEventWake(run.rootRunId)
   }
   const emitNodeStatusEvent = (before: StoredNode, after: StoredNode) => {
     if (before.status === after.status) return
-    appendRunEvent({
-      runId: after.runId,
-      rootRunId: runRootId(after.runId),
-      kind: 'node',
-      status: after.status,
-      nodeName: after.name,
-      ...(after.error === undefined ? {} : { error: after.error }),
-    })
+    fireRunEventWake(runRootId(after.runId))
   }
   const emitChildStatusEvent = (
     before: StoredNodeChild,
     after: StoredNodeChild,
   ) => {
     if (before.status === after.status) return
-    appendRunEvent({
-      runId: after.runId,
-      rootRunId: runRootId(after.runId),
-      kind: 'child',
-      status: after.status,
-      nodeName: after.nodeName,
-      childKey: after.childKey,
-      ...(after.error === undefined ? {} : { error: after.error }),
-    })
+    fireRunEventWake(runRootId(after.runId))
   }
   const emitAttemptStatusEvent = (
     before: StoredAttempt | undefined,
     after: StoredAttempt,
   ) => {
     if (before?.status === after.status) return
-    appendRunEvent({
-      runId: after.runId,
-      rootRunId: runRootId(after.runId),
-      kind: 'attempt',
-      status: after.status,
-      nodeName: after.nodeName,
-      childKey: after.childKey,
-      attemptId: after.id,
-      attemptNumber: after.attemptNumber,
-      ...(after.error === undefined ? {} : { error: after.error }),
-    })
+    fireRunEventWake(runRootId(after.runId))
   }
   const sortedChildren = (rows: readonly StoredNodeChild[]) =>
     [...rows].sort((left, right) => {
@@ -443,31 +400,6 @@ export function createInMemoryWorkflowRuntime(
   const store: WorkflowStore = {
     async createRun(input: CreateRunInput) {
       return createRunWithState(input).run
-    },
-    async listRunEvents({ runId, family = false, afterEventId, limit }) {
-      const run = runs.get(runId)
-      if (!run) return { events: [] }
-      const normalizedLimit = normalizeEventLimit(limit)
-      if (normalizedLimit !== undefined && normalizedLimit < 1) {
-        return { events: [] }
-      }
-      assertValidRunEventsCursor(afterEventId)
-      const after = afterEventId === undefined ? 0n : BigInt(afterEventId)
-      const filtered = runEvents.filter(
-        (event) =>
-          BigInt(event.id) > after &&
-          (family ? event.rootRunId === run.rootRunId : event.runId === run.id),
-      )
-      const page =
-        normalizedLimit === undefined
-          ? filtered
-          : filtered.slice(0, normalizedLimit)
-      return {
-        events: page,
-        ...(normalizedLimit !== undefined && filtered.length > page.length
-          ? { nextCursor: page.at(-1)?.id }
-          : {}),
-      }
     },
     async listRuns(filter: ListRunsFilter = {}) {
       const limit = filter.limit ?? Number.POSITIVE_INFINITY
@@ -1430,9 +1362,6 @@ export function createInMemoryWorkflowRuntime(
         children.delete(key)
       }
     }
-    for (let index = runEvents.length - 1; index >= 0; index -= 1) {
-      if (treeIds.has(runEvents[index]!.runId)) runEvents.splice(index, 1)
-    }
     deleteQueueItemsForRunIds(continueRunCommands, treeIds)
     deleteQueueItemsForRunIds(activityCommands, treeIds)
     deleteQueueItemsForRunIds(taskCommands, treeIds)
@@ -1937,7 +1866,6 @@ export function createInMemoryWorkflowRuntime(
       nodes: [...nodes.values()],
       children: [...children.values()],
       attempts: [...attempts.values()],
-      runEvents: [...runEvents],
       continueRunCommands: continueRunCommands.map(inspectQueueItem),
       activityCommands: activityCommands.map(inspectQueueItem),
       taskCommands: taskCommands.map(inspectQueueItem),
@@ -1957,11 +1885,6 @@ export function createInMemoryWorkflowRuntime(
       },
     },
   }
-}
-
-function normalizeEventLimit(limit: number | undefined): number | undefined {
-  if (limit === undefined) return undefined
-  return Number.isInteger(limit) && limit > 0 ? limit : 0
 }
 
 function compareSchedulesByDueDate(

--- a/packages/workflows/src/runtime/index.ts
+++ b/packages/workflows/src/runtime/index.ts
@@ -12,6 +12,7 @@ export type {
 export { createWorkflowRuntimeClient } from './client.ts'
 export type {
   CreateWorkflowRuntimeClientInput,
+  WatchEvent,
   WatchRunOptions,
   WorkflowRuntimeAdapter,
   WorkflowRuntimeClient,
@@ -51,14 +52,12 @@ export type {
 export { isTerminalNodeStatus, isTerminalRunStatus } from './status.ts'
 export type {
   NodeChildKind,
-  RunEventKind,
   RunSnapshot,
   StoredAttempt,
   StoredError,
   StoredNode,
   StoredNodeChild,
   StoredRun,
-  StoredRunEvent,
 } from './state.ts'
 export {
   SELF_CHILD_KEY,
@@ -97,8 +96,6 @@ export type {
   EnsureNodeChildrenParams,
   EnsureNodeChildrenResult,
   ListRunsFilter,
-  ListRunEventsParams,
-  ListRunEventsResult,
   ListRunSummariesResult,
   ListRunsResult,
   LoadNodeChildrenParams,

--- a/packages/workflows/src/runtime/state.ts
+++ b/packages/workflows/src/runtime/state.ts
@@ -12,22 +12,6 @@ export type StoredError = {
   readonly cause?: StoredError
 }
 
-export type RunEventKind = 'run' | 'node' | 'child' | 'attempt'
-
-export type StoredRunEvent = {
-  readonly id: string
-  readonly runId: string
-  readonly rootRunId: string
-  readonly kind: RunEventKind
-  readonly status: string
-  readonly nodeName?: string
-  readonly childKey?: string
-  readonly attemptId?: string
-  readonly attemptNumber?: number
-  readonly error?: StoredError
-  readonly createdAt: Date
-}
-
 export type StoredRun = {
   readonly id: string
   readonly kind: RunKind

--- a/packages/workflows/src/runtime/store.ts
+++ b/packages/workflows/src/runtime/store.ts
@@ -7,7 +7,6 @@ import type {
   StoredNode,
   StoredNodeChild,
   StoredRun,
-  StoredRunEvent,
 } from './state.ts'
 import type { RuntimeRunStatus } from './status.ts'
 
@@ -57,28 +56,6 @@ export type ListRunsFilter = {
 export type ListRunsResult = {
   readonly runs: readonly StoredRun[]
   readonly nextCursor?: string
-}
-
-export type ListRunEventsParams = {
-  readonly runId: string
-  /** Match by rootRunId instead of runId — one cursor over a whole family. */
-  readonly family?: boolean
-  readonly afterEventId?: string
-  readonly limit?: number
-}
-
-export type ListRunEventsResult = {
-  readonly events: readonly StoredRunEvent[]
-  readonly nextCursor?: string
-}
-
-const runEventsCursorPattern = /^[1-9]\d*$/
-
-export function assertValidRunEventsCursor(afterEventId: string | undefined) {
-  if (afterEventId === undefined) return
-  if (!runEventsCursorPattern.test(afterEventId)) {
-    throw new Error(`Invalid run events cursor [${afterEventId}]`)
-  }
 }
 
 export type RunSummary = Omit<StoredRun, 'input' | 'output'> & {
@@ -257,7 +234,6 @@ export type CancelNonTerminalRunNodesParams = {
 export type WorkflowStore = {
   createRun(input: CreateRunInput): Promise<StoredRun>
   listRuns(filter?: ListRunsFilter): Promise<ListRunsResult>
-  listRunEvents(params: ListRunEventsParams): Promise<ListRunEventsResult>
   listRunSummaries(filter?: ListRunsFilter): Promise<ListRunSummariesResult>
   pruneTerminalRuns(
     params: PruneTerminalRunsParams,

--- a/packages/workflows/tests/fixtures/drizzle-workflow-schema.ts
+++ b/packages/workflows/tests/fixtures/drizzle-workflow-schema.ts
@@ -6,7 +6,6 @@ export const WorkflowAttemptTable = workflows.tables.attempts
 export const WorkflowCommandTable = workflows.tables.commands
 export const WorkflowNodeChildTable = workflows.tables.nodeChildren
 export const WorkflowNodeTable = workflows.tables.nodes
-export const WorkflowRunEventTable = workflows.tables.runEvents
 export const WorkflowRunLeaseTable = workflows.tables.runLeases
 export const WorkflowRunTable = workflows.tables.runs
 export const WorkflowScheduleTable = workflows.tables.schedules

--- a/packages/workflows/tests/inspector.spec.ts
+++ b/packages/workflows/tests/inspector.spec.ts
@@ -6,7 +6,6 @@ import type {
   StoredAttempt,
   StoredNode,
   StoredNodeChild,
-  StoredRunEvent,
 } from '../src/runtime/state.ts'
 import type {
   AttemptSummary,
@@ -26,7 +25,6 @@ import {
   toNodeSnapshotDto,
   toNodeUnitDto,
   toRunDetailDto,
-  toRunEventDto,
   toRunFamilyEntryDto,
   toRunSnapshotDto,
 } from '../src/inspector/index.ts'
@@ -541,28 +539,6 @@ describe('snapshot DTO mappers', () => {
 
     const dto = toAttemptDto(attempt)
     expect(dto.error).toEqual(attempt.error)
-    expect(JSON.parse(JSON.stringify(dto))).toEqual(dto)
-  })
-
-  it('converts run event dates and round-trips through JSON', () => {
-    const event: StoredRunEvent = {
-      id: '42',
-      runId: 'run-1',
-      rootRunId: 'run-1',
-      kind: 'attempt',
-      status: 'failed',
-      nodeName: 'extract',
-      childKey: '$self',
-      attemptId: 'attempt-1',
-      attemptNumber: 2,
-      error: { name: 'Error', message: 'boom' },
-      createdAt,
-    }
-
-    const dto = toRunEventDto(event)
-
-    expect(dto.createdAt).toBe('2026-07-08T10:00:00.000Z')
-    expect(dto.error).toEqual(event.error)
     expect(JSON.parse(JSON.stringify(dto))).toEqual(dto)
   })
 })

--- a/packages/workflows/tests/integration/helpers.ts
+++ b/packages/workflows/tests/integration/helpers.ts
@@ -78,7 +78,6 @@ async function truncateWorkflowTables(pool: PgPool) {
       workflow_schedules,
       workflow_commands,
       workflow_run_leases,
-      workflow_run_events,
       workflow_node_children,
       workflow_attempts,
       workflow_nodes,

--- a/packages/workflows/tests/integration/postgres-wake-events.spec.ts
+++ b/packages/workflows/tests/integration/postgres-wake-events.spec.ts
@@ -176,7 +176,28 @@ describe.skipIf(!postgresTarget.url)(
       }
     })
 
-    it('watches run events through LISTEN/NOTIFY without waiting for polling', async () => {
+    it('notifies run changes even with run event history disabled', async () => {
+      const { runtime } = await createHarness()
+      const wakeEvents = await createWakeEvents()
+
+      const run = await runtime.store.createRun({
+        workflowName: createTestName('postgres-wake-notify-only'),
+        input: {},
+      })
+      const runChanged = new Promise<void>((resolve) => {
+        wakeEvents.onRunEvent!(run.rootRunId, resolve)
+      })
+      await runtime.store.markRunRunning({ runId: run.id })
+
+      await expect(
+        Promise.race([
+          runChanged.then(() => 'woken'),
+          wait(3_000).then(() => 'timeout'),
+        ]),
+      ).resolves.toBe('woken')
+    })
+
+    it('watches run status and coarse family changes through LISTEN/NOTIFY', async () => {
       const harness = await createHarness()
       const wakeEvents = await createWakeEvents()
       const runtime = createPostgresWorkflowRuntime({
@@ -188,23 +209,52 @@ describe.skipIf(!postgresTarget.url)(
         workflowName: createTestName('postgres-watch-run-events'),
         input: {},
       })
-      const cursor = (
-        await runtime.store.listRunEvents({ runId: run.id })
-      ).events.at(-1)?.id
+      await runtime.store.createNode({
+        runId: run.id,
+        name: 'step',
+        kind: 'activity',
+      })
+      await runtime.store.ensureNodeChildren({
+        runId: run.id,
+        nodeName: 'step',
+        children: [{ childKey: '$self', kind: 'activity' }],
+      })
+      // a poll interval far above the assertion timeout proves every yield
+      // below is NOTIFY-driven
       const iterator = client
-        .watch(run.id, {
-          afterEventId: cursor,
-          pollIntervalMs: LONG_DELAY_MS,
-        })
+        .watch(run.id, { wake: true, pollIntervalMs: LONG_DELAY_MS })
         [Symbol.asyncIterator]()
 
       try {
-        const nextEvent = iterator.next()
-        await harness.runtime.store.markRunRunning({ runId: run.id })
+        expect((await iterator.next()).value).toStrictEqual({
+          kind: 'run',
+          status: 'queued',
+        })
 
+        // node-level transition: run row untouched, coarse change signal
+        const changed = iterator.next()
+        await runtime.store.ensureChildAttempt({
+          runId: run.id,
+          nodeName: 'step',
+          childKey: '$self',
+          input: {},
+        })
         await expect(
           Promise.race([
-            nextEvent.then((result) => result.value?.status),
+            changed.then((result) => result.value),
+            wait(3_000).then(() => 'timeout'),
+          ]),
+        ).resolves.toStrictEqual({ kind: 'change' })
+
+        const running = iterator.next()
+        await runtime.store.markRunRunning({ runId: run.id })
+        await expect(
+          Promise.race([
+            running.then((result) =>
+              result.value && 'status' in result.value
+                ? result.value.status
+                : undefined,
+            ),
             wait(3_000).then(() => 'timeout'),
           ]),
         ).resolves.toBe('running')

--- a/packages/workflows/tests/postgres-drizzle-schema.spec.ts
+++ b/packages/workflows/tests/postgres-drizzle-schema.spec.ts
@@ -621,18 +621,6 @@ test('creates drizzle schema with canonical runtime names', () => {
   expect(schema.tables.commands.runId.columnType).toBe('PgUUID')
   expect(schema.tables.commands.attemptId.columnType).toBe('PgUUID')
   expect(schema.tables.commands.payload.hasDefault).toBe(true)
-  expect(getTableName(schema.tables.runEvents)).toBe('workflow_run_events')
-  expect(schema.tables.runEvents.id.columnType).toBe('PgBigInt64')
-  expect(schema.tables.runEvents.runId.columnType).toBe('PgUUID')
-  expect(schema.tables.runEvents.rootRunId.columnType).toBe('PgUUID')
-  expect(schema.tables.runEvents.kind.columnType).toBe('PgText')
-  expect(schema.tables.runEvents.status.columnType).toBe('PgText')
-  expect(schema.tables.runEvents.nodeName.columnType).toBe('PgText')
-  expect(schema.tables.runEvents.childKey.columnType).toBe('PgText')
-  expect(schema.tables.runEvents.attemptId.columnType).toBe('PgUUID')
-  expect(schema.tables.runEvents.attemptNumber.columnType).toBe('PgInteger')
-  expect(schema.tables.runEvents.error.columnType).toBe('PgJsonb')
-  expect(schema.tables.runEvents.createdAt.notNull).toBe(true)
   expect(primaryKeyColumns(schema.tables.nodes)).toContainEqual([
     'run_id',
     'name',
@@ -740,16 +728,6 @@ test('creates drizzle schema with canonical runtime names', () => {
       },
     ]),
   )
-  expect(foreignKeys(schema.tables.runEvents)).toEqual(
-    expect.arrayContaining([
-      {
-        columns: ['run_id'],
-        foreignTable: 'workflow_runs',
-        foreignColumns: ['id'],
-        onDelete: 'cascade',
-      },
-    ]),
-  )
   expect(schema.tables.nodeChildren.kind.enumValues).toStrictEqual([
     'activity',
     'task',
@@ -809,19 +787,22 @@ test('creates drizzle schema with canonical runtime names', () => {
       'workflow_runs_idempotency_idx',
       'workflow_runs_parent_idx',
       'workflow_runs_root_idx',
-      'workflow_runs_input_gin_idx',
-      'workflow_runs_tags_gin_idx',
+      'workflow_runs_prune_idx',
       'workflow_attempts_node_idx',
       'workflow_node_children_node_idx',
       'workflow_node_children_child_run_idx',
       'workflow_commands_run_idx',
       'workflow_commands_claim_idx',
+      'workflow_commands_dead_idx',
       'workflow_commands_continue_dedup_idx',
-      'workflow_run_events_run_idx',
-      'workflow_run_events_root_idx',
       'workflow_schedules_due_idx',
     ]),
   )
+  // search GIN indexes are opt-in: never required, always definition-checked
+  expect(WORKFLOW_POSTGRES_SCHEMA_MANIFEST.optionalIndexes).toStrictEqual([
+    'workflow_runs_input_gin_idx',
+    'workflow_runs_tags_gin_idx',
+  ])
   expect(WORKFLOW_POSTGRES_SCHEMA_MANIFEST.constraints).toEqual(
     expect.arrayContaining([
       'workflow_schedules_name_key',
@@ -832,7 +813,6 @@ test('creates drizzle schema with canonical runtime names', () => {
       'workflow_node_children_child_run_fk',
       'workflow_node_children_current_attempt_fk',
       'workflow_commands_run_fk',
-      'workflow_run_events_run_fk',
     ]),
   )
 })
@@ -843,10 +823,8 @@ test('drizzle kit exports migration sql from app-owned schema file', async () =>
   expect(sql).toContain('CREATE TYPE "workflow_run_kind"')
   expect(sql).toContain('CREATE TYPE "workflow_node_child_kind"')
   expect(sql).toContain('CREATE TABLE "workflow_runs"')
-  expect(sql).toContain('CREATE TABLE "workflow_run_events"')
   expect(sql).toContain('CREATE TABLE "workflow_schedules"')
   expect(sql).toContain('CREATE TABLE "workflow_node_children"')
-  expect(sql).toContain('"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY')
   expect(sql).toContain(
     'CONSTRAINT "workflow_node_children_pkey" PRIMARY KEY("run_id","node_name","child_key")',
   )
@@ -855,8 +833,6 @@ test('drizzle kit exports migration sql from app-owned schema file', async () =>
   )
   expect(sql).toContain('CREATE INDEX "workflow_node_children_node_idx"')
   expect(sql).toContain('CREATE INDEX "workflow_node_children_child_run_idx"')
-  expect(sql).toContain('CREATE INDEX "workflow_run_events_run_idx"')
-  expect(sql).toContain('CREATE INDEX "workflow_run_events_root_idx"')
   expect(sql).toContain('CREATE INDEX "workflow_schedules_due_idx"')
   expect(sql).toContain('"delivery_count" integer DEFAULT 0 NOT NULL')
   expect(sql).toContain('"dead_at" timestamp with time zone')
@@ -866,7 +842,18 @@ test('drizzle kit exports migration sql from app-owned schema file', async () =>
   expect(sql).toContain(
     'CREATE INDEX "workflow_runs_parent_idx" ON "workflow_runs" ("parent_run_id") WHERE parent_run_id IS NOT NULL',
   )
-  expect(sql).toContain('CREATE INDEX "workflow_runs_input_gin_idx"')
+  expect(sql).toContain(
+    'CREATE INDEX "workflow_runs_prune_idx" ON "workflow_runs" ("status","updated_at") WHERE parent_run_id IS NULL',
+  )
+  expect(sql).toMatch(
+    /CREATE INDEX "workflow_commands_claim_idx" ON "workflow_commands" \(.+\) WHERE dead_at IS NULL/,
+  )
+  expect(sql).toContain(
+    'CREATE INDEX "workflow_commands_dead_idx" ON "workflow_commands" ("dead_at") WHERE dead_at IS NOT NULL',
+  )
+  // search GIN indexes are opt-in and absent from the default export
+  expect(sql).not.toContain('workflow_runs_input_gin_idx')
+  expect(sql).not.toContain('workflow_runs_tags_gin_idx')
 })
 
 test('drizzle schema passes postgres workflow schema verification', async () => {
@@ -883,6 +870,64 @@ test('drizzle schema passes postgres workflow schema verification', async () => 
   await expect(
     verifyPostgresWorkflowSchema(connection),
   ).resolves.toBeUndefined()
+})
+
+test('drizzle schema includes search GIN indexes only on opt-in', () => {
+  const runIndexNames = (schema: ReturnType<typeof createSchema>) =>
+    getTableConfig(schema.tables.runs).indexes.map((index) => index.config.name)
+
+  expect(runIndexNames(createSchema())).not.toEqual(
+    expect.arrayContaining(['workflow_runs_input_gin_idx']),
+  )
+  expect(runIndexNames(createSchema({ searchIndexes: true }))).toEqual(
+    expect.arrayContaining([
+      'workflow_runs_input_gin_idx',
+      'workflow_runs_tags_gin_idx',
+    ]),
+  )
+})
+
+test('status transitions are notify-only; watch yields run status changes', async () => {
+  const connection = createPgliteConnection()
+  await installPostgresWorkflowSchemaForTesting(connection)
+
+  const runtime = createPostgresWorkflowRuntime({ connection })
+  const run = await runtime.store.createRun({
+    workflowName: 'run-events-notify-only',
+    input: {},
+  })
+  await runtime.store.markRunRunning({ runId: run.id })
+  // nothing persists per transition anymore — the table itself is gone
+  const eventTables = await connection.query<{ tablename: string }>(
+    "SELECT tablename FROM pg_tables WHERE tablename = 'workflow_run_events'",
+  )
+  expect(eventTables.rows).toStrictEqual([])
+
+  const client = createWorkflowRuntimeClient(runtime)
+  const iterator = client
+    .watch(run.id, { pollIntervalMs: 25 })
+    [Symbol.asyncIterator]()
+  try {
+    expect((await iterator.next()).value).toStrictEqual({
+      kind: 'run',
+      status: 'running',
+    })
+    await runtime.store.failRun({
+      runId: run.id,
+      error: new Error('boom'),
+    })
+    const terminal = (await iterator.next()).value
+    expect(terminal?.kind).toBe('run')
+    expect(terminal && 'status' in terminal ? terminal.status : undefined).toBe(
+      'failed',
+    )
+    expect(
+      terminal && 'error' in terminal ? terminal.error?.message : undefined,
+    ).toBe('boom')
+    expect((await iterator.next()).done).toBe(true)
+  } finally {
+    await iterator.return?.()
+  }
 })
 
 test('uses one postgres command table for all command kinds', async () => {
@@ -1949,7 +1994,6 @@ test('creates postgres runtime schema with relational constraints', async () => 
       'workflow_node_children_current_attempt_fk',
       'workflow_run_leases_run_fk',
       'workflow_commands_run_fk',
-      'workflow_run_events_run_fk',
     ]),
   )
 })
@@ -2031,10 +2075,31 @@ test('verifies postgres schema indexes', async () => {
     verifyPostgresWorkflowSchema(connection),
   ).resolves.toBeUndefined()
 
+  // search GIN indexes are optional: dropping them keeps the schema valid
   await connection.query('DROP INDEX workflow_runs_tags_gin_idx')
+  await connection.query('DROP INDEX workflow_runs_input_gin_idx')
+  await expect(
+    verifyPostgresWorkflowSchema(connection),
+  ).resolves.toBeUndefined()
+
+  await connection.query('DROP INDEX workflow_runs_root_idx')
 
   await expect(verifyPostgresWorkflowSchema(connection)).rejects.toThrow(
-    'Missing workflow Postgres schema objects: workflow_runs_tags_gin_idx',
+    'Missing workflow Postgres schema objects: workflow_runs_root_idx',
+  )
+})
+
+test('verifies optional postgres schema indexes when present', async () => {
+  const connection = createPgliteConnection()
+  await installPostgresWorkflowSchemaForTesting(connection)
+
+  await connection.query('DROP INDEX workflow_runs_tags_gin_idx')
+  await connection.query(
+    'CREATE INDEX workflow_runs_tags_gin_idx ON workflow_runs (created_at)',
+  )
+
+  await expect(verifyPostgresWorkflowSchema(connection)).rejects.toThrow(
+    'Invalid workflow Postgres schema indexes: workflow_runs_tags_gin_idx',
   )
 })
 
@@ -2118,8 +2183,9 @@ test('rejects a v2 workflow postgres schema missing v3 command columns and index
     `,
   )
 
+  // dropping dead_at also cascades away the partial claim/dead indexes
   await expect(verifyPostgresWorkflowSchema(connection)).rejects.toThrow(
-    'Missing workflow Postgres schema objects: workflow_runs_parent_idx, workflow_runs_root_idx, workflow_commands_continue_dedup_idx',
+    'Missing workflow Postgres schema objects: workflow_runs_parent_idx, workflow_runs_root_idx, workflow_commands_claim_idx, workflow_commands_dead_idx, workflow_commands_continue_dedup_idx',
   )
 })
 

--- a/packages/workflows/tests/postgres-wake-events-reconnect.spec.ts
+++ b/packages/workflows/tests/postgres-wake-events-reconnect.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test, vi } from 'vitest'
+
+import {
+  createPostgresWorkflowWakeEvents,
+  type WorkflowPostgresListenerClient,
+  type WorkflowPostgresNotification,
+} from '../src/adapters/postgres.ts'
+
+type FakeListenerClient = WorkflowPostgresListenerClient & {
+  emit(event: 'notification' | 'error' | 'end', arg?: unknown): void
+}
+
+function createFakeListenerClient(): FakeListenerClient {
+  const listeners = new Map<string, Set<(arg?: unknown) => void>>()
+  return {
+    async query() {
+      return undefined
+    },
+    on(event, listener) {
+      const set = listeners.get(event) ?? new Set()
+      listeners.set(event, set)
+      set.add(listener)
+      return undefined
+    },
+    end() {},
+    emit(event, arg) {
+      for (const listener of listeners.get(event) ?? []) listener(arg)
+    },
+  }
+}
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+test('fires a synthetic wake to all listeners on reconnect, not on first connect', async () => {
+  vi.useFakeTimers()
+  try {
+    const clients: FakeListenerClient[] = []
+    const wakeEvents = createPostgresWorkflowWakeEvents({
+      connect: async () => {
+        const client = createFakeListenerClient()
+        clients.push(client)
+        return client
+      },
+      reconnectDelayMs: 10,
+    })
+
+    let commandWakes = 0
+    let cancellationWakes = 0
+    let runEventWakes = 0
+    wakeEvents.onCommand('continue', () => {
+      commandWakes += 1
+    })
+    wakeEvents.onCancellation('run-1', () => {
+      cancellationWakes += 1
+    })
+    wakeEvents.onRunEvent!('root-1', () => {
+      runEventWakes += 1
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(clients).toHaveLength(1)
+    // first connect: no gap to heal, no pulse
+    expect(commandWakes).toBe(0)
+    expect(cancellationWakes).toBe(0)
+    expect(runEventWakes).toBe(0)
+
+    // notifications still dispatch normally
+    clients[0]!.emit('notification', {
+      channel: 'workflow_commands',
+      payload: 'continue',
+    } satisfies WorkflowPostgresNotification)
+    expect(commandWakes).toBe(1)
+
+    // connection loss → reconnect → every subscriber gets one pulse, because
+    // anything notified during the gap is unrecoverable
+    clients[0]!.emit('end')
+    await vi.advanceTimersByTimeAsync(10)
+    expect(clients).toHaveLength(2)
+    expect(commandWakes).toBe(2)
+    expect(cancellationWakes).toBe(1)
+    expect(runEventWakes).toBe(1)
+
+    await wakeEvents.dispose()
+  } finally {
+    vi.useRealTimers()
+    await flush()
+  }
+})

--- a/packages/workflows/tests/postgres-wake-events-reconnect.spec.ts
+++ b/packages/workflows/tests/postgres-wake-events-reconnect.spec.ts
@@ -31,6 +31,52 @@ function createFakeListenerClient(): FakeListenerClient {
 
 const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
 
+test('retries after a LISTEN failure that never drops the connection', async () => {
+  vi.useFakeTimers()
+  try {
+    const clients: FakeListenerClient[] = []
+    let failListenOnce = true
+    const wakeEvents = createPostgresWorkflowWakeEvents({
+      connect: async () => {
+        const client = createFakeListenerClient()
+        if (failListenOnce) {
+          failListenOnce = false
+          client.query = async () => {
+            throw new Error('LISTEN rejected')
+          }
+        }
+        clients.push(client)
+        return client
+      },
+      reconnectDelayMs: 10,
+    })
+
+    let commandWakes = 0
+    wakeEvents.onCommand('continue', () => {
+      commandWakes += 1
+    })
+
+    // first attempt claims the client slot, then LISTEN rejects without the
+    // connection emitting error/end — the slot must be released so the
+    // scheduled retry actually connects instead of no-oping forever
+    await vi.advanceTimersByTimeAsync(0)
+    expect(clients).toHaveLength(1)
+    await vi.advanceTimersByTimeAsync(10)
+    expect(clients).toHaveLength(2)
+
+    clients[1]!.emit('notification', {
+      channel: 'workflow_commands',
+      payload: 'continue',
+    } satisfies WorkflowPostgresNotification)
+    expect(commandWakes).toBe(1)
+
+    await wakeEvents.dispose()
+  } finally {
+    vi.useRealTimers()
+    await flush()
+  }
+})
+
 test('fires a synthetic wake to all listeners on reconnect, not on first connect', async () => {
   vi.useFakeTimers()
   try {

--- a/packages/workflows/tests/runtime-adapter-contract.spec.ts
+++ b/packages/workflows/tests/runtime-adapter-contract.spec.ts
@@ -918,209 +918,93 @@ function workflowRuntimeAdapterContract(
       ).resolves.toStrictEqual([])
     })
 
-    it('records exact status change events and skips idempotent rewrites', async () => {
+    it('watch yields run status transitions and ends at terminal', async () => {
       const runtime = await createRuntime()
+      const client = createWorkflowRuntimeClient(runtime)
       const run = await runtime.store.createRun({
-        workflowName: 'event-history-workflow',
+        workflowName: 'watch-status-workflow',
         input: {},
-        idempotencyKey: ['event-history-workflow'],
       })
-      await runtime.store.createRun({
-        workflowName: 'event-history-workflow',
-        input: {},
-        idempotencyKey: ['event-history-workflow'],
-      })
-      await runtime.store.markRunWaiting({ runId: run.id })
-      await runtime.store.createNode({
-        runId: run.id,
-        name: 'content',
-        kind: 'activity',
-      })
-      await runtime.store.setNodeInput({
-        runId: run.id,
-        nodeName: 'content',
-        input: { value: 1 },
-      })
-      await runtime.store.ensureNodeChildren({
-        runId: run.id,
-        nodeName: 'content',
-        children: [{ childKey: '$self', kind: 'activity' }],
-      })
-      const firstAttempt = await runtime.store.ensureChildAttempt({
-        runId: run.id,
-        nodeName: 'content',
-        childKey: '$self',
-        input: { value: 1 },
-      })
-      await runtime.store.ensureChildAttempt({
-        runId: run.id,
-        nodeName: 'content',
-        childKey: '$self',
-        input: { value: 1 },
-      })
-      await runtime.store.failCurrentAttempt({
-        attemptId: firstAttempt.attempt.id,
-        leaseToken: firstAttempt.attempt.leaseToken!,
-        error: new Error('retry me'),
-      })
-      const retry = await runtime.store.createAttempt({
-        runId: run.id,
-        nodeName: 'content',
-        childKey: '$self',
-        input: { value: 2 },
-      })
-      await runtime.store.completeCurrentAttempt({
-        attemptId: retry.id,
-        leaseToken: retry.leaseToken!,
-        output: { value: 2 },
-      })
-      await runtime.store.completeNode({
-        runId: run.id,
-        nodeName: 'content',
-        output: { value: 2 },
-      })
-      await runtime.store.markRunRunning({ runId: run.id })
-      await runtime.store.markRunWaiting({ runId: run.id })
-      await runtime.store.markRunRunning({ runId: run.id })
-      await runtime.store.completeRun({ runId: run.id, output: { value: 2 } })
-      await runtime.store.failRun({
-        runId: run.id,
-        error: new Error('too late'),
-      })
-
-      const listed = await runtime.store.listRunEvents({ runId: run.id })
-
-      expect(
-        listed.events.map((event) => [
-          event.kind,
-          event.status,
-          event.nodeName,
-          event.childKey,
-          event.attemptNumber,
-        ]),
-      ).toStrictEqual([
-        ['run', 'queued', undefined, undefined, undefined],
-        ['attempt', 'started', 'content', '$self', 1],
-        ['child', 'running', 'content', '$self', undefined],
-        ['node', 'running', 'content', undefined, undefined],
-        ['attempt', 'failed', 'content', '$self', 1],
-        ['attempt', 'started', 'content', '$self', 2],
-        ['attempt', 'completed', 'content', '$self', 2],
-        ['child', 'completed', 'content', '$self', undefined],
-        ['node', 'completed', 'content', undefined, undefined],
-        ['run', 'running', undefined, undefined, undefined],
-        ['run', 'waiting', undefined, undefined, undefined],
-        ['run', 'running', undefined, undefined, undefined],
-        ['run', 'completed', undefined, undefined, undefined],
-      ])
-      expect(listed.events.map((event) => event.runId)).toEqual(
-        listed.events.map(() => run.id),
-      )
-      expect(listed.events.map((event) => event.rootRunId)).toEqual(
-        listed.events.map(() => run.rootRunId),
-      )
-      expect(
-        listed.events.every((event) => event.createdAt instanceof Date),
-      ).toBe(true)
-      expect(listed.nextCursor).toBeUndefined()
-
-      const firstPage = await runtime.store.listRunEvents({
-        runId: run.id,
-        limit: 3,
-      })
-      const secondPage = await runtime.store.listRunEvents({
-        runId: run.id,
-        afterEventId: firstPage.nextCursor,
-        limit: 50,
-      })
-      expect(firstPage.events).toHaveLength(3)
-      expect(firstPage.nextCursor).toBe(firstPage.events[2]?.id)
-      expect(secondPage.events.map((event) => event.id)).toStrictEqual(
-        listed.events.slice(3).map((event) => event.id),
-      )
-      await expect(
-        runtime.store.listRunEvents({ runId: 'missing-run-id' }),
-      ).resolves.toStrictEqual({ events: [] })
-      await expect(
-        runtime.store.listRunEvents({
+      const iterator = client
+        .watch(run.id, { pollIntervalMs: 10 })
+        [Symbol.asyncIterator]()
+      try {
+        expect((await iterator.next()).value).toStrictEqual({
+          kind: 'run',
+          status: 'queued',
+        })
+        await runtime.store.markRunRunning({ runId: run.id })
+        expect((await iterator.next()).value).toStrictEqual({
+          kind: 'run',
+          status: 'running',
+        })
+        await runtime.store.failRun({
           runId: run.id,
-          afterEventId: 'not-a-run-event-id',
-        }),
-      ).rejects.toThrow('Invalid run events cursor [not-a-run-event-id]')
-      await expect(
-        runtime.store.listRunEvents({ runId: run.id, afterEventId: '0' }),
-      ).rejects.toThrow('Invalid run events cursor [0]')
+          error: new Error('watch me fail'),
+        })
+        const terminal = (await iterator.next()).value
+        expect(terminal).toMatchObject({ kind: 'run', status: 'failed' })
+        expect(
+          terminal && 'error' in terminal ? terminal.error?.message : undefined,
+        ).toBe('watch me fail')
+        expect((await iterator.next()).done).toBe(true)
+      } finally {
+        await iterator.return?.()
+      }
     })
 
-    it('lists family event history and removes events with deleted runs', async () => {
+    it('watch with wake yields coarse change events for family transitions', async () => {
       const runtime = await createRuntime()
-      const root = await runtime.store.createRun({
-        workflowName: 'event-family-root',
+      // coarse events are NOTIFY-only; adapters without a wake hub are
+      // covered by the integration suite instead
+      if (!runtime.wakeEvents) return
+      const client = createWorkflowRuntimeClient(runtime)
+      const run = await runtime.store.createRun({
+        workflowName: 'watch-wake-workflow',
         input: {},
       })
       await runtime.store.createNode({
-        runId: root.id,
-        name: 'child',
-        kind: 'workflow',
+        runId: run.id,
+        name: 'step',
+        kind: 'activity',
       })
-      await runtime.store.ensureNodeChildren({
-        runId: root.id,
-        nodeName: 'child',
-        children: [{ childKey: '$self', kind: 'workflow' }],
-      })
-      const { childRun } = await runtime.store.ensureChildRun({
-        runId: root.id,
-        nodeName: 'child',
-        childKey: '$self',
-        childKind: 'workflow',
-        childName: 'event-family-child',
-        input: {},
-        rootRunId: root.rootRunId,
-      })
-      await runtime.store.completeRun({
-        runId: childRun.id,
-        output: { child: true },
-      })
-      await runtime.store.completeNodeChild({
-        runId: root.id,
-        nodeName: 'child',
-        childKey: '$self',
-        output: { child: true },
-      })
-      await runtime.store.completeNode({
-        runId: root.id,
-        nodeName: 'child',
-        output: { child: true },
-      })
-      await runtime.store.completeRun({ runId: root.id, output: { ok: true } })
-
-      const rootOnly = await runtime.store.listRunEvents({ runId: root.id })
-      const family = await runtime.store.listRunEvents({
-        runId: root.id,
-        family: true,
-      })
-
-      expect(rootOnly.events.every((event) => event.runId === root.id)).toBe(
-        true,
-      )
-      expect(
-        family.events.map((event) => [event.runId, event.kind, event.status]),
-      ).toEqual([
-        [root.id, 'run', 'queued'],
-        [childRun.id, 'run', 'queued'],
-        [root.id, 'child', 'running'],
-        [childRun.id, 'run', 'completed'],
-        [root.id, 'child', 'completed'],
-        [root.id, 'node', 'completed'],
-        [root.id, 'run', 'completed'],
-      ])
-
-      await expect(runtime.store.deleteRun(root.id)).resolves.toStrictEqual({
-        deleted: true,
-      })
-      await expect(
-        runtime.store.listRunEvents({ runId: root.id, family: true }),
-      ).resolves.toStrictEqual({ events: [] })
+      // a huge poll interval proves every yield below is wake-driven
+      const iterator = client
+        .watch(run.id, { wake: true, pollIntervalMs: 60_000 })
+        [Symbol.asyncIterator]()
+      try {
+        expect((await iterator.next()).value).toStrictEqual({
+          kind: 'run',
+          status: 'queued',
+        })
+        // node-level transition leaves the run row untouched — without the
+        // wake option this signal would be swallowed
+        await runtime.store.ensureNodeChildren({
+          runId: run.id,
+          nodeName: 'step',
+          children: [{ childKey: '$self', kind: 'activity' }],
+        })
+        await runtime.store.ensureChildAttempt({
+          runId: run.id,
+          nodeName: 'step',
+          childKey: '$self',
+          input: {},
+        })
+        expect((await iterator.next()).value).toStrictEqual({ kind: 'change' })
+        await runtime.store.markRunRunning({ runId: run.id })
+        expect((await iterator.next()).value).toStrictEqual({
+          kind: 'run',
+          status: 'running',
+        })
+        await runtime.store.completeRun({ runId: run.id, output: {} })
+        expect((await iterator.next()).value).toStrictEqual({
+          kind: 'run',
+          status: 'completed',
+        })
+        expect((await iterator.next()).done).toBe(true)
+      } finally {
+        await iterator.return?.()
+      }
     })
 
     it('sweeps old dead commands during pruning', async () => {

--- a/packages/workflows/tests/runtime-client.spec.ts
+++ b/packages/workflows/tests/runtime-client.spec.ts
@@ -698,7 +698,7 @@ describe('workflow runtime client', () => {
     expect(completed?.output).toStrictEqual({ caseId: 'done' })
   })
 
-  it('watches history and new events until the watched run terminates', async () => {
+  it('watches run status changes until the watched run terminates', async () => {
     const workflow = defineWorkflow({
       name: 'client-watch-workflow',
       input: t.object({ scenario: t.string() }),
@@ -707,20 +707,21 @@ describe('workflow runtime client', () => {
     const runtime = createInMemoryWorkflowRuntime()
     const client = createWorkflowRuntimeClient(runtime)
     const run = await client.start(workflow, { scenario: 'alpha' })
-    const queued = await runtime.store.listRunEvents({ runId: run.id })
 
     const iterator = client
-      .watch(run.id, {
-        afterEventId: queued.events[0]?.id,
-        pollIntervalMs: 60_000,
-      })
+      .watch(run.id, { pollIntervalMs: 60_000 })
       [Symbol.asyncIterator]()
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { kind: 'run', status: 'queued' },
+    })
 
     const running = iterator.next()
     await runtime.store.markRunRunning({ runId: run.id })
     await expect(running).resolves.toMatchObject({
       done: false,
-      value: { kind: 'run', status: 'running', runId: run.id },
+      value: { kind: 'run', status: 'running' },
     })
 
     const completed = iterator.next()
@@ -730,7 +731,7 @@ describe('workflow runtime client', () => {
     })
     await expect(completed).resolves.toMatchObject({
       done: false,
-      value: { kind: 'run', status: 'completed', runId: run.id },
+      value: { kind: 'run', status: 'completed' },
     })
     await expect(iterator.next()).resolves.toStrictEqual({
       done: true,
@@ -738,163 +739,156 @@ describe('workflow runtime client', () => {
     })
   })
 
-  it('ends immediately when watching a terminal run after its terminal event', async () => {
-    vi.useFakeTimers()
-    try {
-      const workflow = defineWorkflow({
-        name: 'client-watch-terminal-cursor-workflow',
-        input: t.object({ scenario: t.string() }),
-        output: t.object({ caseId: t.string() }),
-      }).build()
-      const runtime = createInMemoryWorkflowRuntime()
-      const client = createWorkflowRuntimeClient(runtime)
-      const run = await client.start(workflow, { scenario: 'alpha' })
-      await runtime.store.completeRun({
-        runId: run.id,
-        output: { caseId: 'alpha' },
-      })
-      const terminalEventId = (
-        await runtime.store.listRunEvents({ runId: run.id })
-      ).events.at(-1)?.id
-      const iterator = client
-        .watch(run.id, {
-          afterEventId: String(BigInt(terminalEventId!) + 1n),
-          pollIntervalMs: 60_000,
-        })
-        [Symbol.asyncIterator]()
-
-      const pending = iterator.next()
-      await vi.advanceTimersByTimeAsync(0)
-
-      await expect(
-        Promise.race([pending, Promise.resolve('pending')]),
-      ).resolves.toStrictEqual({ done: true, value: undefined })
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it('keeps the run-event wake listener registered while polling', async () => {
-    vi.useFakeTimers()
-    const abort = new AbortController()
-    try {
-      const runtime = createInMemoryWorkflowRuntime()
-      const run = await runtime.store.createRun({
-        workflowName: 'client-watch-wake-race',
-        input: {},
-      })
-      const cursor = (
-        await runtime.store.listRunEvents({ runId: run.id })
-      ).events.at(-1)?.id
-      let injected = false
-      const client = createWorkflowRuntimeClient({
-        ...runtime,
-        store: {
-          ...runtime.store,
-          listRunEvents: async (params) => {
-            const result = await runtime.store.listRunEvents(params)
-            if (
-              !injected &&
-              params.runId === run.id &&
-              params.afterEventId === cursor
-            ) {
-              injected = true
-              await runtime.store.markRunRunning({ runId: run.id })
-            }
-            return result
-          },
-        },
-      })
-      const iterator = client
-        .watch(run.id, {
-          afterEventId: cursor,
-          signal: abort.signal,
-          pollIntervalMs: 60_000,
-        })
-        [Symbol.asyncIterator]()
-
-      const pending = iterator.next()
-      await vi.advanceTimersByTimeAsync(0)
-
-      await expect(
-        Promise.race([pending, Promise.resolve('pending')]),
-      ).resolves.toMatchObject({
-        done: false,
-        value: { kind: 'run', status: 'running', runId: run.id },
-      })
-      await iterator.return?.()
-    } finally {
-      abort.abort()
-      await vi.advanceTimersByTimeAsync(0)
-      vi.useRealTimers()
-    }
-  })
-
-  it('watches a run family but stops on the watched run terminal event', async () => {
+  it('yields the terminal status once and ends when watching a terminal run', async () => {
+    const workflow = defineWorkflow({
+      name: 'client-watch-terminal-workflow',
+      input: t.object({ scenario: t.string() }),
+      output: t.object({ caseId: t.string() }),
+    }).build()
     const runtime = createInMemoryWorkflowRuntime()
     const client = createWorkflowRuntimeClient(runtime)
-    const root = await runtime.store.createRun({
-      workflowName: 'client-watch-family-root',
-      input: {},
+    const run = await client.start(workflow, { scenario: 'alpha' })
+    await runtime.store.completeRun({
+      runId: run.id,
+      output: { caseId: 'alpha' },
     })
-    await runtime.store.createNode({
-      runId: root.id,
-      name: 'child',
-      kind: 'workflow',
-    })
-    await runtime.store.ensureNodeChildren({
-      runId: root.id,
-      nodeName: 'child',
-      children: [{ childKey: '$self', kind: 'workflow' }],
-    })
-    const cursor = (
-      await runtime.store.listRunEvents({ runId: root.id })
-    ).events.at(-1)?.id
 
-    const iterator = client
-      .watch(root.id, {
-        family: true,
-        afterEventId: cursor,
-        pollIntervalMs: 60_000,
-      })
-      [Symbol.asyncIterator]()
-    const childQueued = iterator.next()
-    const { childRun } = await runtime.store.ensureChildRun({
-      runId: root.id,
-      nodeName: 'child',
-      childKey: '$self',
-      childKind: 'workflow',
-      childName: 'client-watch-family-child',
+    await expect(
+      Array.fromAsync(client.watch(run.id, { pollIntervalMs: 60_000 })),
+    ).resolves.toStrictEqual([{ kind: 'run', status: 'completed' }])
+  })
+
+  it('latches wakes that fire while a read is in flight', async () => {
+    const runtime = createInMemoryWorkflowRuntime()
+    const run = await runtime.store.createRun({
+      workflowName: 'client-watch-wake-race',
       input: {},
-      rootRunId: root.rootRunId,
     })
-    await expect(childQueued).resolves.toMatchObject({
-      done: false,
-      value: { kind: 'run', status: 'queued', runId: childRun.id },
+    // transition the run right after the post-subscription baseline read
+    // returns: the wake must latch and be consumed without a poll tick
+    let reads = 0
+    const client = createWorkflowRuntimeClient({
+      ...runtime,
+      store: {
+        ...runtime.store,
+        loadRuns: async (runIds) => {
+          const result = await runtime.store.loadRuns(runIds)
+          reads += 1
+          if (reads === 2) {
+            await runtime.store.markRunRunning({ runId: run.id })
+          }
+          return result
+        },
+      },
     })
+    const iterator = client
+      .watch(run.id, { pollIntervalMs: 60_000 })
+      [Symbol.asyncIterator]()
 
     await expect(iterator.next()).resolves.toMatchObject({
       done: false,
-      value: { kind: 'child', status: 'running', runId: root.id },
+      value: { kind: 'run', status: 'queued' },
     })
-
-    const childCompleted = iterator.next()
-    await runtime.store.completeRun({ runId: childRun.id, output: {} })
-    await expect(childCompleted).resolves.toMatchObject({
+    await expect(iterator.next()).resolves.toMatchObject({
       done: false,
-      value: { kind: 'run', status: 'completed', runId: childRun.id },
+      value: { kind: 'run', status: 'running' },
     })
+    await iterator.return?.()
+  })
 
-    const rootCompleted = iterator.next()
-    await runtime.store.completeRun({ runId: root.id, output: {} })
-    await expect(rootCompleted).resolves.toMatchObject({
-      done: false,
-      value: { kind: 'run', status: 'completed', runId: root.id },
-    })
-    await expect(iterator.next()).resolves.toStrictEqual({
-      done: true,
-      value: undefined,
-    })
+  it('debounces coarse wake events with leading and trailing edges', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = createInMemoryWorkflowRuntime()
+      const client = createWorkflowRuntimeClient(runtime)
+      const run = await runtime.store.createRun({
+        workflowName: 'client-watch-debounce',
+        input: {},
+      })
+      await runtime.store.createNode({
+        runId: run.id,
+        name: 'step',
+        kind: 'activity',
+      })
+      await runtime.store.ensureNodeChildren({
+        runId: run.id,
+        nodeName: 'step',
+        children: [{ childKey: '$self', kind: 'activity' }],
+      })
+      const iterator = client
+        .watch(run.id, {
+          wake: true,
+          debounceMs: 100,
+          pollIntervalMs: 60_000,
+        })
+        [Symbol.asyncIterator]()
+
+      await expect(iterator.next()).resolves.toMatchObject({
+        done: false,
+        value: { kind: 'run', status: 'queued' },
+      })
+
+      // leading edge: first wake after quiet passes through immediately
+      const leading = iterator.next()
+      await runtime.store.ensureChildAttempt({
+        runId: run.id,
+        nodeName: 'step',
+        childKey: '$self',
+        input: {},
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(leading).resolves.toStrictEqual({
+        done: false,
+        value: { kind: 'change' },
+      })
+
+      // wakes inside the window coalesce into one trailing yield at close
+      const trailing = iterator.next()
+      await runtime.store.completeNodeChild({
+        runId: run.id,
+        nodeName: 'step',
+        childKey: '$self',
+        output: {},
+      })
+      await runtime.store.completeNode({
+        runId: run.id,
+        nodeName: 'step',
+        output: {},
+      })
+      await vi.advanceTimersByTimeAsync(99)
+      await expect(
+        Promise.race([trailing, Promise.resolve('pending')]),
+      ).resolves.toBe('pending')
+      await vi.advanceTimersByTimeAsync(1)
+      await expect(trailing).resolves.toStrictEqual({
+        done: false,
+        value: { kind: 'change' },
+      })
+
+      // status transitions bypass the debounce window entirely: no timer
+      // advancement between the transition and its yield
+      const running = iterator.next()
+      await runtime.store.markRunRunning({ runId: run.id })
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(running).resolves.toStrictEqual({
+        done: false,
+        value: { kind: 'run', status: 'running' },
+      })
+      const completed = iterator.next()
+      await runtime.store.completeRun({ runId: run.id, output: {} })
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(completed).resolves.toStrictEqual({
+        done: false,
+        value: { kind: 'run', status: 'completed' },
+      })
+      await expect(iterator.next()).resolves.toStrictEqual({
+        done: true,
+        value: undefined,
+      })
+      await iterator.return?.()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('ends watch iteration cleanly on abort and early consumer return', async () => {
@@ -904,18 +898,19 @@ describe('workflow runtime client', () => {
       workflowName: 'client-watch-abort',
       input: {},
     })
-    const cursor = (
-      await runtime.store.listRunEvents({ runId: run.id })
-    ).events.at(-1)?.id
     const abort = new AbortController()
     const iterator = client
       .watch(run.id, {
-        afterEventId: cursor,
         signal: abort.signal,
         pollIntervalMs: 60_000,
       })
       [Symbol.asyncIterator]()
 
+    // the initial status yield happens regardless; abort ends the wait after
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { kind: 'run', status: 'queued' },
+    })
     const pending = iterator.next()
     abort.abort()
     await expect(pending).resolves.toStrictEqual({
@@ -925,15 +920,16 @@ describe('workflow runtime client', () => {
 
     const seen: string[] = []
     await runtime.store.markRunRunning({ runId: run.id })
-    for await (const event of client.watch(run.id, { afterEventId: cursor })) {
-      seen.push(event.status)
+    for await (const event of client.watch(run.id)) {
+      if (event.kind === 'run') seen.push(event.status)
       break
     }
-    await runtime.store.completeRun({ runId: run.id, output: {} })
-    await expect(
-      Array.fromAsync(client.watch(run.id, { afterEventId: cursor })),
-    ).resolves.toMatchObject([{ status: 'running' }, { status: 'completed' }])
     expect(seen).toStrictEqual(['running'])
+
+    await runtime.store.completeRun({ runId: run.id, output: {} })
+    await expect(Array.fromAsync(client.watch(run.id))).resolves.toStrictEqual([
+      { kind: 'run', status: 'completed' },
+    ])
   })
 
   it('falls back to polling when no wake event port is available', async () => {
@@ -949,13 +945,16 @@ describe('workflow runtime client', () => {
         workflowName: 'client-watch-poll',
         input: {},
       })
-      const cursor = (
-        await runtime.store.listRunEvents({ runId: run.id })
-      ).events.at(-1)?.id
       const iterator = client
-        .watch(run.id, { afterEventId: cursor, pollIntervalMs: 25 })
+        .watch(run.id, { pollIntervalMs: 25 })
         [Symbol.asyncIterator]()
 
+      const queued = iterator.next()
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(queued).resolves.toMatchObject({
+        done: false,
+        value: { kind: 'run', status: 'queued' },
+      })
       const pending = iterator.next()
       await vi.advanceTimersByTimeAsync(0)
       await runtime.store.markRunRunning({ runId: run.id })

--- a/skills/build-neem-runtime/SKILL.md
+++ b/skills/build-neem-runtime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-neem-runtime
-description: "Use when authoring custom @nmtjs/neem runtimes or package runtime helpers: defineRuntime, createRuntime, defineRuntimeHost, defineRuntimeWorker, defineRuntimePlanner, host/worker ports, planner output, lifecycle, and runtime entry validation."
+description: 'Use when authoring custom @nmtjs/neem runtimes or package runtime helpers: defineRuntime, createRuntime, defineRuntimeHost, defineRuntimeWorker, defineRuntimePlanner, host/worker ports, planner output, lifecycle, and runtime entry validation.'
 ---
 
 # Build Neem Runtime

--- a/skills/use-neem/SKILL.md
+++ b/skills/use-neem/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-neem
-description: "Use when configuring or running @nmtjs/neem projects: neem.config.ts, runtime discovery, package runtime helpers, CLI build/dev/start lifecycle, artifacts, plugins, metrics, env, proxy, health, and runtime selection."
+description: 'Use when configuring or running @nmtjs/neem projects: neem.config.ts, runtime discovery, package runtime helpers, CLI build/dev/start lifecycle, artifacts, plugins, metrics, env, proxy, health, and runtime selection.'
 ---
 
 # Use Neem

--- a/skills/use-neemata/SKILL.md
+++ b/skills/use-neemata/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-neemata
-description: "Use when answering questions or writing code for Neemata RPC applications: contracts, procedures, routers, applications, DI, metadata, guards, middleware, filters, clients, workflows, pubsub, metrics, streaming, blobs, and Neemata runtime integration."
+description: 'Use when answering questions or writing code for Neemata RPC applications: contracts, procedures, routers, applications, DI, metadata, guards, middleware, filters, clients, workflows, pubsub, metrics, streaming, blobs, and Neemata runtime integration.'
 ---
 
 # Use Neemata


### PR DESCRIPTION
Closes #260.

## What

- **`watch()` rewritten around a `WatchEvent` union** — `{ kind: 'change' }` coarse family wakes (opt-in via `wake: true`) plus `{ kind: 'run', status, error? }` run-row transitions. Terminal delivery stays poll-guaranteed; coarse events are NOTIFY-only best-effort. `family` and `afterEventId` options are gone — wake granularity is the family by construction, and there are no event ids left to cursor on.
- **Native debounce** — `debounceMs` coalesces coarse yields with leading+trailing edges. Wakes inside the window still peek the run row, so status transitions (terminal above all) are yielded without delay; only coarse `change` yields — whose downstream read-model refetches are the load being capped — are coalesced.
- **Persisted event history removed** — `workflow_run_events` table, the per-transition insert CTEs, `listRunEvents`, `StoredRunEvent`, and inspector `RunEventDto` are deleted. Status transitions only `pg_notify` now (one shared `emitStatusChangeNotifySql` CTE). The in-memory adapter fires its wake hub instead of recording events, so the adapter contract asserts identical `watch()` semantics across adapters.
- **Reconnect pulse** — the LISTEN client fires every registered listener once after reconnecting from a connection loss: notifications missed during the gap are unrecoverable without history, and a spurious wake costs one refetch/claim pass, never correctness. Heals watchers and worker dispatch alike.
- **Postgres index tuning** — claim index is now partial (`dead_at IS NULL`), new prune index on `workflow_runs (status, updated_at) WHERE parent_run_id IS NULL`, new dead-command index, and the `input`/`tags` GIN search indexes are opt-in via `createSchema({ searchIndexes: true })` (verified when present, allowed absent).

## Notes

- Schema version intentionally not bumped; the testing installer drops the stale `workflow_run_events` table and converts the old claim-index shape in place.
- Breaking for anything consuming `listRunEvents` / `StoredRunEvent` / `RunEventDto` — scoped in #260 for the same beta window that introduced them.

## Testing

- 431 unit tests (pglite) and 17 integration tests (real Postgres) pass; integration includes NOTIFY-driven coarse+status watch yields with a 20s poll interval proving the wake path.
- New coverage: debounce leading/trailing edges and terminal bypass (fake timers), wake latching during in-flight reads, reconnect pulse (fake LISTEN client), notify-only schema assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow watching now uses status updates and wake signals instead of raw event history, with optional debounce for coalesced changes.
  * Search indexes for workflow run payloads and tags can now be enabled only when needed.

* **Bug Fixes**
  * Improved reconnect handling so notifications are less likely to be missed after a temporary disconnect.
  * Added better pruning and command-handling indexes for faster cleanup and queue processing.
  * Workflow run history storage is no longer required for status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->