### PR TITLE
pubsub: subscription pump backpressure and re-entry guard

### DIFF
--- a/packages/pubsub/src/manager.ts
+++ b/packages/pubsub/src/manager.ts
@@ -212,7 +212,12 @@ export class PubSubManager {
         controller.abort()
         // Best-effort release of the adapter subscription; don't block
         // destruction on the iterator settling.
-        iterator.return?.()?.catch(() => {})
+        iterator.return?.()?.catch((error) => {
+          logger.error(
+            { error },
+            'Failed to release pubsub subscription iterator',
+          )
+        })
         callback(error)
       },
     })

--- a/packages/pubsub/src/manager.ts
+++ b/packages/pubsub/src/manager.ts
@@ -148,27 +148,46 @@ export class PubSubManager {
     events: Map<string, TAnySubscriptionEventContract>,
   ): Readable {
     const logger = this.logger
+    const iterator = stream[Symbol.asyncIterator]()
+    // Node clears `reading` on every push and may re-invoke `read` while the
+    // previous pump is still awaiting; a second concurrent pump would race
+    // over the shared iterator and double-push null at end of stream.
+    let pumping = false
     return new Readable({
       objectMode: true,
       async read() {
+        if (pumping) return
+        pumping = true
         try {
-          for await (const { channel, data } of stream) {
+          while (!this.destroyed) {
+            const { done, value } = await iterator.next()
+            if (done) break
+            if (this.destroyed) break
+            const { channel, data } = value
             const { event, payload } = data
             const contract = events.get(event)
             if (!contract) {
               logger.warn({ channel, event }, 'Unknown subscription event')
               continue
             }
+            let decoded: unknown
             try {
-              this.push({ event, payload: contract.payload.decode(payload) })
+              decoded = { event, payload: contract.payload.decode(payload) }
             } catch (error) {
               logger.error({ error }, 'Unable to decode event payload')
+              continue
+            }
+            if (!this.push(decoded)) {
+              // Backpressure: pause until the consumer drains and Node
+              // invokes `read` again.
+              pumping = false
+              return
             }
           }
-          this.push(null)
+          if (!this.destroyed) this.push(null)
         } catch (error) {
           if (isAbortError(error)) {
-            this.push(null)
+            if (!this.destroyed) this.push(null)
           } else {
             this.destroy(
               Error.isError(error)
@@ -177,6 +196,12 @@ export class PubSubManager {
             )
           }
         }
+      },
+      destroy(error, callback) {
+        // Best-effort release of the adapter subscription; don't block
+        // destruction on an iterator that only settles on the next message.
+        iterator.return?.()?.catch(() => {})
+        callback(error)
       },
     })
   }

--- a/packages/pubsub/src/manager.ts
+++ b/packages/pubsub/src/manager.ts
@@ -101,9 +101,17 @@ export class PubSubManager {
 
     const { adapter } = this.options
 
+    // Owned controller lets destroy() release an adapter iterator that is
+    // blocked waiting for the next message, even without a caller signal.
+    const controller = new AbortController()
+    const finalSignal = signal
+      ? AbortSignal.any([signal, controller.signal])
+      : controller.signal
+
     const stream = this.createMessageStream(
-      adapter.subscribe(channel, signal),
+      adapter.subscribe(channel, finalSignal),
       events,
+      controller,
     )
 
     stream.on('close', () => {
@@ -146,6 +154,7 @@ export class PubSubManager {
   private createMessageStream(
     stream: AsyncIterable<PubSubMessage>,
     events: Map<string, TAnySubscriptionEventContract>,
+    controller: AbortController,
   ): Readable {
     const logger = this.logger
     const iterator = stream[Symbol.asyncIterator]()
@@ -198,8 +207,11 @@ export class PubSubManager {
         }
       },
       destroy(error, callback) {
+        // Abort first: return() alone queues behind a next() that is blocked
+        // waiting for the next message and would never let cleanup run.
+        controller.abort()
         // Best-effort release of the adapter subscription; don't block
-        // destruction on an iterator that only settles on the next message.
+        // destruction on the iterator settling.
         iterator.return?.()?.catch(() => {})
         callback(error)
       },

--- a/packages/pubsub/tests/manager.spec.ts
+++ b/packages/pubsub/tests/manager.spec.ts
@@ -1,0 +1,169 @@
+import type { Readable } from 'node:stream'
+import { setImmediate as tick } from 'node:timers/promises'
+
+import { EventContract, SubscriptionContract } from '@nmtjs/contract'
+import { createLogger } from '@nmtjs/core'
+import { t } from '@nmtjs/type'
+import { describe, expect, it } from 'vitest'
+
+import type { PubSubAdapter, PubSubMessage } from '../src/adapter.ts'
+import { PubSubManager } from '../src/manager.ts'
+
+const channel = SubscriptionContract({
+  namespace: 'chat',
+  params: t.object({ roomId: t.string() }),
+  key: ({ roomId }) => roomId,
+  events: {
+    message: EventContract({ payload: t.object({ text: t.string() }) }),
+  },
+})
+
+function createManager(subscribe: PubSubAdapter['subscribe']) {
+  return new PubSubManager({
+    logger: createLogger({ pinoOptions: { enabled: false } }, 'test'),
+    adapter: { publish: async () => true, subscribe },
+  })
+}
+
+async function subscribeStream(manager: PubSubManager, signal?: AbortSignal) {
+  const stream = await manager.subscribe(
+    channel,
+    { roomId: 'general' },
+    undefined,
+    signal,
+  )
+  return stream as unknown as Readable
+}
+
+function message(text: string): PubSubMessage {
+  return {
+    channel: 'chat:general',
+    data: { event: 'message', payload: { text } },
+  }
+}
+
+describe('PubSubManager subscription stream', () => {
+  it('pauses the pump instead of buffering unboundedly for a slow consumer', async () => {
+    const total = 100
+    let pulled = 0
+    const manager = createManager(async function* () {
+      for (let i = 0; i < total; i++) {
+        pulled++
+        yield message(`msg-${i}`)
+      }
+    })
+    const stream = await subscribeStream(manager)
+
+    // Kick the pump without consuming anything
+    expect(stream.read()).toBeNull()
+    await tick()
+    await tick()
+
+    // push() returned false at the high water mark and the pump paused
+    expect(pulled).toBeLessThan(total)
+    expect(pulled).toBeLessThanOrEqual(stream.readableHighWaterMark + 1)
+
+    const received: unknown[] = []
+    for await (const item of stream) received.push(item)
+
+    expect(received).toHaveLength(total)
+    expect(pulled).toBe(total)
+  })
+
+  it('does not double-push end of stream when read is re-entered', async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const manager = createManager(async function* () {
+      yield message('only')
+      await gate
+    })
+    const stream = await subscribeStream(manager)
+
+    const errors: unknown[] = []
+    const received: unknown[] = []
+    stream.on('error', (error) => errors.push(error))
+    stream.on('data', (item) => {
+      received.push(item)
+      // Flowing mode re-invokes read() while the pump is still awaiting;
+      // ending the iterator now overlaps both paths to end of stream
+      release()
+    })
+    await new Promise((resolve) => stream.once('end', resolve))
+    await tick()
+
+    expect(errors).toEqual([])
+    expect(received).toEqual([{ event: 'message', payload: { text: 'only' } }])
+  })
+
+  it('destroys the stream when the adapter iterator fails', async () => {
+    const failure = new Error('adapter failed')
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const manager = createManager(async function* () {
+      yield message('first')
+      // Let the consumer drain the first message before failing, since
+      // destroy discards anything still buffered
+      await gate
+      throw failure
+    })
+    const stream = await subscribeStream(manager)
+
+    const received: unknown[] = []
+    await expect(async () => {
+      for await (const item of stream) {
+        received.push(item)
+        release()
+      }
+    }).rejects.toBe(failure)
+
+    expect(received).toEqual([{ event: 'message', payload: { text: 'first' } }])
+    expect(stream.destroyed).toBe(true)
+  })
+
+  it('ends the stream gracefully when the adapter iterator aborts', async () => {
+    const abortError = Object.assign(new Error('aborted'), {
+      name: 'AbortError',
+      code: 'ABORT_ERR',
+    })
+    const manager = createManager(async function* () {
+      yield message('first')
+      throw abortError
+    })
+    const stream = await subscribeStream(manager)
+
+    const received: unknown[] = []
+    for await (const item of stream) received.push(item)
+
+    expect(received).toEqual([{ event: 'message', payload: { text: 'first' } }])
+  })
+
+  it('stops the pump and releases the adapter iterator on destroy', async () => {
+    let finalized = false
+    let pulled = 0
+    const manager = createManager(async function* () {
+      try {
+        while (true) {
+          pulled++
+          yield message(`msg-${pulled}`)
+        }
+      } finally {
+        finalized = true
+      }
+    })
+    const stream = await subscribeStream(manager)
+
+    stream.read()
+    await tick()
+    stream.destroy()
+    await tick()
+
+    expect(finalized).toBe(true)
+    const pulledAtDestroy = pulled
+    await tick()
+    expect(pulled).toBe(pulledAtDestroy)
+  })
+})

--- a/packages/pubsub/tests/manager.spec.ts
+++ b/packages/pubsub/tests/manager.spec.ts
@@ -141,6 +141,32 @@ describe('PubSubManager subscription stream', () => {
     expect(received).toEqual([{ event: 'message', payload: { text: 'first' } }])
   })
 
+  it('aborts an adapter iterator blocked on the next message when destroyed', async () => {
+    let finalized = false
+    const manager = createManager(async function* (_channel, signal) {
+      try {
+        yield message('first')
+        // Blocked mid-next() like an adapter waiting for the broker; only
+        // the abort signal can release it — return() alone queues forever
+        await new Promise<never>((_, reject) => {
+          signal?.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          })
+        })
+      } finally {
+        finalized = true
+      }
+    })
+    const stream = await subscribeStream(manager)
+
+    stream.read()
+    await tick()
+    stream.destroy()
+    await tick()
+
+    expect(finalized).toBe(true)
+  })
+
   it('stops the pump and releases the adapter iterator on destroy', async () => {
     let finalized = false
     let pulled = 0

--- a/packages/pubsub/tests/manager.spec.ts
+++ b/packages/pubsub/tests/manager.spec.ts
@@ -141,6 +141,30 @@ describe('PubSubManager subscription stream', () => {
     expect(received).toEqual([{ event: 'message', payload: { text: 'first' } }])
   })
 
+  it('ends the stream gracefully when a caller signal aborts', async () => {
+    const controller = new AbortController()
+    const manager = createManager(async function* (_channel, signal) {
+      yield message('first')
+      // Blocked until the combined signal (caller + manager-owned) aborts
+      await new Promise<never>((_, reject) => {
+        signal?.addEventListener('abort', () => reject(signal.reason), {
+          once: true,
+        })
+      })
+    })
+    const stream = await subscribeStream(manager, controller.signal)
+
+    const received: unknown[] = []
+    const consumed = (async () => {
+      for await (const item of stream) received.push(item)
+    })()
+    await tick()
+    controller.abort()
+    await consumed
+
+    expect(received).toEqual([{ event: 'message', payload: { text: 'first' } }])
+  })
+
   it('aborts an adapter iterator blocked on the next message when destroyed', async () => {
     let finalized = false
     const manager = createManager(async function* (_channel, signal) {


### PR DESCRIPTION
Closes #205

The subscription `Readable`'s `read()` ran an unbounded `for await` loop over the shared adapter iterator: it ignored `push()`'s return value (a fast publisher with a slow consumer grew the buffer without bound) and had no re-entry guard (Node can re-invoke `_read` while the first loop is still awaiting, so two loops could both `push(null)` at end → `ERR_STREAM_PUSH_AFTER_EOF`).

`createMessageStream()` is now a single guarded pump:

- a `pumping` flag makes re-entrant `_read` a no-op; the pump pauses when `push()` returns `false` and resumes on the next `_read`, bounding the buffer by the stream's `highWaterMark`
- end-of-iterator pushes `null` exactly once; `AbortError` still ends gracefully; other iterator errors still `destroy(error)`
- `_subscribe()` creates a manager-owned `AbortController` per subscription (combined with the optional caller signal via `AbortSignal.any`), and the stream's `destroy()` aborts it before fire-and-forgetting `iterator.return?.()` — `return()` alone queues behind a `next()` blocked on the next message (e.g. the Redis adapter parked at `for await`), so without the abort the adapter's `finally` cleanup (listener refcount/unsubscribe) would never run. `return()` is deliberately not awaited: awaiting it could hang destruction behind that same pending `next()`

Regression tests cover: pump pausing at `highWaterMark` and draining fully, overlapping `_read` at end-of-stream (no double `push(null)`), iterator error propagation, graceful abort, destroy stopping the pump, and destroy releasing an adapter iterator blocked awaiting the next message. The backpressure and re-entry specs crash/fail against the previous implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription stream cleanup when streams are destroyed or aborted.
  * Prevented duplicate stream completion and concurrent message reads.
  * Added backpressure-aware handling so slow consumers no longer cause unbounded buffering.
  * Improved handling of adapter iterator failures, including graceful termination on abort-style errors.
  * Added additional coverage for stream ending behavior when caller aborts or destroy happens while waiting for the next message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->