### PR TITLE
protocol/ws-transport: frame bounds checks, error code prefix, per-runtime send status mapping

### DIFF
--- a/packages/protocol/src/client/protocol.ts
+++ b/packages/protocol/src/client/protocol.ts
@@ -97,10 +97,8 @@ export class ProtocolError extends Error implements BaseProtocolError {
     this.data = data
   }
 
-  get message() {
-    return `${this.code} ${super.message}`
-  }
-
+  // code stays out of `message` so serialization round-trips don't
+  // accumulate "CODE CODE message" prefixes
   toString() {
     return `${this.code} ${this.message}`
   }

--- a/packages/protocol/src/common/binary.ts
+++ b/packages/protocol/src/common/binary.ts
@@ -35,10 +35,13 @@ export const decodeNumber = <T extends keyof BinaryTypes>(
   offset = 0,
   littleEndian = true,
 ): BinaryTypes[T] => {
-  const ab = buffer instanceof ArrayBuffer ? buffer : buffer.buffer
-  const baseOffset = buffer instanceof ArrayBuffer ? 0 : buffer.byteOffset
-  const view = new DataView(ab)
-  return view[`get${type}`](baseOffset + offset, littleEndian) as BinaryTypes[T]
+  // bound the DataView to the passed view, so out-of-range reads throw
+  // instead of silently reading neighboring bytes of the backing buffer
+  const view =
+    buffer instanceof ArrayBuffer
+      ? new DataView(buffer)
+      : new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+  return view[`get${type}`](offset, littleEndian) as BinaryTypes[T]
 }
 
 export const encodeText = (text: string) => utf8encoder.encode(text)

--- a/packages/protocol/src/server/protocol.ts
+++ b/packages/protocol/src/server/protocol.ts
@@ -17,10 +17,8 @@ export class ProtocolError extends Error implements BaseProtocolError {
     this.data = data
   }
 
-  get message() {
-    return `${this.code} ${super.message}`
-  }
-
+  // code stays out of `message` so serialization round-trips don't
+  // accumulate "CODE CODE message" prefixes
   toString() {
     return `${this.code} ${this.message}`
   }

--- a/packages/protocol/src/server/versions/v1.ts
+++ b/packages/protocol/src/server/versions/v1.ts
@@ -24,6 +24,13 @@ export class ProtocolVersion1 extends ProtocolVersionInterface {
         )
         const procedureOffset =
           MessageByteLength.CallId + MessageByteLength.ProcedureLength
+        // toString/subarray silently clamp to the buffer end, so a truncated
+        // frame would decode into a wrong procedure/payload instead of failing
+        if (procedureOffset + procedureLength > messagePayload.byteLength) {
+          throw new Error(
+            `Malformed RPC message: procedure length ${procedureLength} exceeds frame size`,
+          )
+        }
         const procedure = messagePayload.toString(
           'utf-8',
           procedureOffset,

--- a/packages/protocol/tests/common/binary.spec.ts
+++ b/packages/protocol/tests/common/binary.spec.ts
@@ -1,0 +1,26 @@
+import { Buffer } from 'node:buffer'
+
+import { describe, expect, it } from 'vitest'
+
+import { decodeNumber, encodeNumber } from '../../src/common/binary.ts'
+
+describe('decodeNumber', () => {
+  it('decodes values encoded by encodeNumber', () => {
+    expect(decodeNumber(encodeNumber(42, 'Uint32'), 'Uint32')).toBe(42)
+    expect(decodeNumber(encodeNumber(-7, 'Int16'), 'Int16')).toBe(-7)
+  })
+
+  it('reads a subarray view relative to its own offset', () => {
+    const backing = Buffer.from([0xff, 0xff, 0x2a, 0x00, 0x00, 0x00, 0xff])
+    const view = backing.subarray(2, 6)
+    expect(decodeNumber(view, 'Uint32')).toBe(42)
+  })
+
+  it('throws instead of reading neighboring bytes past the view bounds', () => {
+    const backing = Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+    // the backing buffer has enough bytes, but the view does not
+    const view = backing.subarray(0, 2)
+    expect(() => decodeNumber(view, 'Uint32')).toThrow(RangeError)
+    expect(() => decodeNumber(view, 'Uint8', 2)).toThrow(RangeError)
+  })
+})

--- a/packages/protocol/tests/protocol-error.spec.ts
+++ b/packages/protocol/tests/protocol-error.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { ProtocolError as ClientProtocolError } from '../src/client/protocol.ts'
+import { ProtocolError as ServerProtocolError } from '../src/server/protocol.ts'
+
+describe.each([
+  ['server', ServerProtocolError],
+  ['client', ClientProtocolError],
+])('ProtocolError (%s)', (_, ProtocolError) => {
+  it('keeps the code out of message and toJSON', () => {
+    const error = new ProtocolError('BadRequest', 'boom', { field: 'a' })
+    expect(error.message).toBe('boom')
+    expect(error.toString()).toBe('BadRequest boom')
+    expect(error.toJSON()).toEqual({
+      name: 'BadRequest',
+      message: 'boom',
+      data: { field: 'a' },
+      code: 'BadRequest',
+    })
+  })
+
+  it('does not accumulate code prefixes across serialization round trips', () => {
+    let error = new ProtocolError('Forbidden', 'nope')
+    for (let i = 0; i < 3; i++) {
+      const wire = JSON.parse(JSON.stringify(error))
+      error = new ProtocolError(wire.code, wire.message, wire.data)
+    }
+    expect(error.message).toBe('nope')
+    expect(error.toJSON().message).toBe('nope')
+    expect(error.toString()).toBe('Forbidden nope')
+  })
+})

--- a/packages/protocol/tests/server/protocol-v1.spec.ts
+++ b/packages/protocol/tests/server/protocol-v1.spec.ts
@@ -93,6 +93,23 @@ describe('ProtocolVersion1 - decodeMessage', () => {
     expect(rpcContext!).toMatchObject({ addStream: expect.any(Function) })
   })
 
+  it('rejects RPC frame whose declared procedure length exceeds frame size', () => {
+    const decoder = context.decoder as unknown as {
+      decodeRPC: ReturnType<typeof vi.fn>
+    }
+    const buffer = Buffer.concat([
+      Buffer.from([ClientMessageType.Rpc]),
+      encodeUInt32(1),
+      encodeUInt16(100),
+      Buffer.from('short'),
+    ])
+
+    expect(() => version.decodeMessage(context, buffer)).toThrow(
+      /Malformed RPC message/,
+    )
+    expect(decoder.decodeRPC).not.toHaveBeenCalled()
+  })
+
   it('decodes RpcAbort payload', () => {
     const callId = 99
     const buffer = Buffer.concat([

--- a/packages/ws-transport/src/runtimes/bun.ts
+++ b/packages/ws-transport/src/runtimes/bun.ts
@@ -65,6 +65,9 @@ function adapterFactory(params: WsAdapterParams<'bun'>): WsAdapterServer {
         server = null
       }
     },
+    // Bun send status: >0 = bytes sent, -1 = backpressure applied (will
+    // drain), 0 = dropped — only a drop is a failed delivery
+    isSendSuccess: (status) => status !== 0,
   }
 }
 

--- a/packages/ws-transport/src/runtimes/node.ts
+++ b/packages/ws-transport/src/runtimes/node.ts
@@ -65,6 +65,9 @@ function adapterFactory(params: WsAdapterParams<'node'>): WsAdapterServer {
     stop: () => {
       server.close()
     },
+    // uWS send status: 1 = sent, 0 = buffered (will drain), 2 = dropped
+    // due to backpressure limit — only a drop is a failed delivery
+    isSendSuccess: (status) => status !== 2,
   }
 }
 

--- a/packages/ws-transport/src/server.ts
+++ b/packages/ws-transport/src/server.ts
@@ -73,9 +73,9 @@ export class WsTransportServer implements TransportWorker<
     try {
       const result = peer.send(buffer)
       if (typeof result === 'boolean') return result
-      // uWS send codes: 1 = sent, 0 = buffered (will drain), 2 = dropped
-      // due to backpressure limit — only a drop is a failed delivery
-      if (typeof result === 'number') return result !== 2
+      if (typeof result === 'number') {
+        return this.#server.isSendSuccess?.(result) ?? true
+      }
       return true
     } catch (error) {
       console.error(

--- a/packages/ws-transport/src/server.ts
+++ b/packages/ws-transport/src/server.ts
@@ -73,7 +73,9 @@ export class WsTransportServer implements TransportWorker<
     try {
       const result = peer.send(buffer)
       if (typeof result === 'boolean') return result
-      if (typeof result === 'number') return result > 0
+      // uWS send codes: 1 = sent, 0 = buffered (will drain), 2 = dropped
+      // due to backpressure limit — only a drop is a failed delivery
+      if (typeof result === 'number') return result !== 2
       return true
     } catch (error) {
       console.error(

--- a/packages/ws-transport/src/types.ts
+++ b/packages/ws-transport/src/types.ts
@@ -116,6 +116,9 @@ export type WsAdapterParams<
 export interface WsAdapterServer {
   stop: () => MaybePromise<any>
   start: () => MaybePromise<string>
+  // numeric Peer.send() statuses are runtime-specific (uWS vs Bun), so only
+  // the adapter that knows its runtime can interpret them as delivery success
+  isSendSuccess?: (status: number) => boolean
 }
 
 export type WsAdapterServerFactory<

--- a/packages/ws-transport/tests/server.spec.ts
+++ b/packages/ws-transport/tests/server.spec.ts
@@ -1,0 +1,56 @@
+import type { Peer } from 'crossws'
+import { describe, expect, it, vi } from 'vitest'
+
+import type {
+  WsAdapterServerFactory,
+  WsTransportOptions,
+} from '../src/types.ts'
+import { WsTransportServer } from '../src/server.ts'
+
+const adapterFactory: WsAdapterServerFactory<any> = () => ({
+  start: vi.fn(async () => 'ws://localhost'),
+  stop: vi.fn(async () => {}),
+})
+
+const options = { listen: { port: 0 } } as WsTransportOptions
+
+const withPeer = (send: () => unknown) => {
+  const server = new WsTransportServer(adapterFactory, options)
+  const peer = {
+    send: vi.fn(send),
+    close: vi.fn(),
+    context: { connectionId: 'c1' },
+  } as unknown as Peer
+  server.clients.set('c1', peer)
+  return server
+}
+
+describe('WsTransportServer.send', () => {
+  const buffer = new Uint8Array([0x01])
+
+  it('maps uWS send codes truthfully: sent(1)/buffered(0) succeed, dropped(2) fails', () => {
+    expect(withPeer(() => 1).send('c1', buffer)).toBe(true)
+    expect(withPeer(() => 0).send('c1', buffer)).toBe(true)
+    expect(withPeer(() => 2).send('c1', buffer)).toBe(false)
+  })
+
+  it('passes boolean results through', () => {
+    expect(withPeer(() => true).send('c1', buffer)).toBe(true)
+    expect(withPeer(() => false).send('c1', buffer)).toBe(false)
+  })
+
+  it('returns false for unknown connections', () => {
+    const server = new WsTransportServer(adapterFactory, options)
+    expect(server.send('missing', buffer)).toBe(false)
+  })
+
+  it('returns false and drops the peer when send throws', () => {
+    const server = withPeer(() => {
+      throw new Error('boom')
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(server.send('c1', buffer)).toBe(false)
+    expect(server.clients.has('c1')).toBe(false)
+    consoleError.mockRestore()
+  })
+})

--- a/packages/ws-transport/tests/server.spec.ts
+++ b/packages/ws-transport/tests/server.spec.ts
@@ -5,6 +5,8 @@ import type {
   WsAdapterServerFactory,
   WsTransportOptions,
 } from '../src/types.ts'
+import { WsTransport as BunWsTransport } from '../src/runtimes/bun.ts'
+import { WsTransport as NodeWsTransport } from '../src/runtimes/node.ts'
 import { WsTransportServer } from '../src/server.ts'
 
 const adapterFactory: WsAdapterServerFactory<any> = () => ({
@@ -14,8 +16,7 @@ const adapterFactory: WsAdapterServerFactory<any> = () => ({
 
 const options = { listen: { port: 0 } } as WsTransportOptions
 
-const withPeer = (send: () => unknown) => {
-  const server = new WsTransportServer(adapterFactory, options)
+const setPeer = (server: WsTransportServer, send: () => unknown) => {
   const peer = {
     send: vi.fn(send),
     close: vi.fn(),
@@ -28,15 +29,37 @@ const withPeer = (send: () => unknown) => {
 describe('WsTransportServer.send', () => {
   const buffer = new Uint8Array([0x01])
 
-  it('maps uWS send codes truthfully: sent(1)/buffered(0) succeed, dropped(2) fails', () => {
-    expect(withPeer(() => 1).send('c1', buffer)).toBe(true)
-    expect(withPeer(() => 0).send('c1', buffer)).toBe(true)
-    expect(withPeer(() => 2).send('c1', buffer)).toBe(false)
+  it('maps uWS (node runtime) statuses truthfully: sent(1)/buffered(0) succeed, dropped(2) fails', () => {
+    const create = () =>
+      NodeWsTransport.factory(options as any) as WsTransportServer
+    expect(setPeer(create(), () => 1).send('c1', buffer)).toBe(true)
+    expect(setPeer(create(), () => 0).send('c1', buffer)).toBe(true)
+    expect(setPeer(create(), () => 2).send('c1', buffer)).toBe(false)
+  })
+
+  it('maps Bun statuses truthfully: bytes sent(>0)/backpressure(-1) succeed, dropped(0) fails', () => {
+    // crossws refuses to create its Bun adapter unless a Bun global exists
+    vi.stubGlobal('Bun', {})
+    try {
+      const create = () =>
+        BunWsTransport.factory(options as any) as WsTransportServer
+      expect(setPeer(create(), () => 2).send('c1', buffer)).toBe(true)
+      expect(setPeer(create(), () => -1).send('c1', buffer)).toBe(true)
+      expect(setPeer(create(), () => 0).send('c1', buffer)).toBe(false)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('treats numeric statuses as success when the adapter has no interpreter', () => {
+    const server = new WsTransportServer(adapterFactory, options)
+    expect(setPeer(server, () => 0).send('c1', buffer)).toBe(true)
   })
 
   it('passes boolean results through', () => {
-    expect(withPeer(() => true).send('c1', buffer)).toBe(true)
-    expect(withPeer(() => false).send('c1', buffer)).toBe(false)
+    const server = new WsTransportServer(adapterFactory, options)
+    expect(setPeer(server, () => true).send('c1', buffer)).toBe(true)
+    expect(setPeer(server, () => false).send('c1', buffer)).toBe(false)
   })
 
   it('returns false for unknown connections', () => {
@@ -45,9 +68,12 @@ describe('WsTransportServer.send', () => {
   })
 
   it('returns false and drops the peer when send throws', () => {
-    const server = withPeer(() => {
-      throw new Error('boom')
-    })
+    const server = setPeer(
+      new WsTransportServer(adapterFactory, options),
+      () => {
+        throw new Error('boom')
+      },
+    )
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     expect(server.send('c1', buffer)).toBe(false)
     expect(server.clients.has('c1')).toBe(false)

--- a/packages/ws-transport/vitest.config.ts
+++ b/packages/ws-transport/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: { environment: 'node', include: ['tests/**/*.spec.ts'] },
+})


### PR DESCRIPTION
Tactical fixes cherry-picked from #211 and #208 — the isolated, factual defects that no future redesign could want. The structural work (centralized frame validation, unified error model, stream-ref escaping, credit-based flow control) stays in those issues.

- **v1 RPC frame bounds check** (`protocol/src/server/versions/v1.ts`): frames whose declared `procedureLength` exceeds the remaining bytes are now rejected with a malformed-message error instead of parsing a truncated frame into a wrong procedure/payload.
- **`decodeNumber` view bounds** (`protocol/src/common/binary.ts`): the DataView is now constructed with the view's `byteOffset`/`byteLength` instead of over the entire backing `ArrayBuffer`, so out-of-range reads on subarray views throw `RangeError` instead of silently reading neighboring bytes.
- **`ProtocolError` code prefix out of `message`** (server + client `protocol.ts`): the `get message()` override prepended the code, so `toString()` yielded `"CODE CODE message"` and the prefix leaked into `toJSON().message`, compounding across round trips. `message`/`toJSON().message` are now the raw message; `toString()` still formats as `"CODE message"`. The client-side re-wrap no longer accumulates prefixes.
- **Truthful WS send-status mapping** (`ws-transport`): the shared server treated any numeric send result `> 0` as success, which read uWS's `2 = dropped due to backpressure` as success and `0 = buffered, will drain` as failure — a slow client silently lost frames. Since Bun's semantics differ and collide by value (uWS: 1 sent / 0 buffered / 2 dropped; Bun: >0 bytes sent / -1 buffered / 0 dropped — both verified against installed typings and crossws adapters, which forward raw statuses), the interpretation moved into each runtime adapter via an optional `isSendSuccess` hook: uWS `status !== 2`, Bun `status !== 0`. Callers of `send` largely ignore the result today — making them react to it is #208's scope; this only makes the returned boolean truthful.

Regression tests: truncated v1 frame rejection, subarray `decodeNumber` bounds, error message/`toJSON`/round-trip shape (both classes), and send-status mapping through the real node/bun runtime factories.

Refs #211, #208 (partial — redesign items remain open)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented protocol error messages from accumulating duplicate error-code prefixes during serialization.
  - Added validation to reject truncated RPC messages instead of decoding incomplete data.
  - Improved WebSocket send-status handling across Node and Bun runtimes, including dropped-message detection.
  - Ensured binary decoding respects provided view boundaries and reports insufficient data.

- **Tests**
  - Added coverage for protocol errors, binary decoding boundaries, malformed RPC frames, and WebSocket delivery outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->