### PR TITLE
client: duplex half for stream bodies, keepalive opt-in, send race, jitter, decode guard, abort reasons

### DIFF
--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -5,7 +5,7 @@ import type {
   ProtocolVersionInterface,
 } from '@nmtjs/protocol/client'
 import { noopFn } from '@nmtjs/common'
-import { ConnectionType } from '@nmtjs/protocol'
+import { ConnectionType, ErrorCode } from '@nmtjs/protocol'
 import { ProtocolError, versions } from '@nmtjs/protocol/client'
 
 import type {
@@ -70,12 +70,9 @@ const sleep = (ms: number, signal?: AbortSignal) => {
 }
 
 const computeReconnectDelay = (ms: number) => {
-  if (globalThis.window) {
-    const jitter = Math.floor(ms * 0.2 * Math.random())
-    return ms + jitter
-  }
-
-  return ms
+  // jitter unconditionally: Node fleets would otherwise reconnect in lockstep
+  const jitter = Math.floor(ms * 0.2 * Math.random())
+  return ms + jitter
 }
 
 export class ClientCore extends EventEmitter<{
@@ -84,6 +81,7 @@ export class ClientCore extends EventEmitter<{
   disconnected: [reason: ClientDisconnectReason]
   state_changed: [state: ConnectionState, previous: ConnectionState]
   pong: [nonce: number]
+  error: [error: ClientError]
 }> {
   readonly protocol: ProtocolVersionInterface
   readonly format: BaseClientFormat
@@ -371,7 +369,21 @@ export class ClientCore extends EventEmitter<{
   async #onMessage(buffer: ArrayBufferView) {
     if (!this.messageContext) return
 
-    const message = this.protocol.decodeMessage(this.messageContext, buffer)
+    let message: ReturnType<ProtocolVersionInterface['decodeMessage']>
+    try {
+      message = this.protocol.decodeMessage(this.messageContext, buffer)
+    } catch (cause) {
+      // a malformed server frame must not become an unhandled rejection
+      this.emit(
+        'error',
+        new ClientError(
+          ErrorCode.ClientRequestError,
+          'Unable to decode server message',
+          cause,
+        ),
+      )
+      return
+    }
 
     for (const plugin of this.#plugins) {
       plugin.onServerMessage?.(message, buffer)

--- a/packages/client/src/layers/rpc.ts
+++ b/packages/client/src/layers/rpc.ts
@@ -16,6 +16,7 @@ import type { BaseClientTransformer } from '../transformers.ts'
 import type { ClientCallOptions } from '../types.ts'
 import type { StreamLayerApi } from './streams.ts'
 import { ServerStreams } from '../streams.ts'
+import { toReasonString } from './streams.ts'
 
 export type ProtocolClientCall = Future<any> & {
   procedure: string
@@ -31,24 +32,6 @@ export interface RpcLayerApi {
   ): Promise<any>
   readonly pendingCallCount: number
   readonly activeStreamCount: number
-}
-
-const toReasonString = (reason: unknown) => {
-  if (typeof reason === 'string') return reason
-  if (reason === undefined || reason === null) return undefined
-  if (reason instanceof Error) return reason.message
-  try {
-    return JSON.stringify(reason)
-  } catch {}
-  if (
-    typeof reason === 'number' ||
-    typeof reason === 'boolean' ||
-    typeof reason === 'bigint' ||
-    typeof reason === 'symbol'
-  ) {
-    return reason.toString()
-  }
-  return Object.prototype.toString.call(reason)
 }
 
 const toAbortError = (signal: AbortSignal) => {
@@ -576,7 +559,7 @@ export const createRpcLayer = (
           callId: message.callId,
           reason: message.reason,
         })
-        void rpcStreams.abort(message.callId)
+        void rpcStreams.abort(message.callId, message.reason)
         calls.delete(message.callId)
         break
     }
@@ -698,7 +681,11 @@ export const createRpcLayer = (
               contentType: core.format.contentType,
             },
             { callId: currentCallId, procedure, payload: encodedPayload, blob },
-            { signal, streamResponse: callOptions._stream_response },
+            {
+              signal,
+              streamResponse: callOptions._stream_response,
+              keepalive: callOptions.keepalive,
+            },
           )
 
           handleCallResponse(currentCallId, response)

--- a/packages/client/src/layers/streams.ts
+++ b/packages/client/src/layers/streams.ts
@@ -18,12 +18,14 @@ import { ClientStreams, ServerStreams } from '../streams.ts'
 
 const DEFAULT_PULL_SIZE = 65535
 
-const toReasonString = (reason: unknown) => {
+export const toReasonString = (reason: unknown) => {
   if (typeof reason === 'string') return reason
   if (reason === undefined || reason === null) return undefined
   if (reason instanceof Error) return reason.message
   try {
-    return JSON.stringify(reason)
+    // JSON.stringify returns undefined (does not throw) for symbols/functions
+    const json = JSON.stringify(reason)
+    if (json !== undefined) return json
   } catch {}
   if (
     typeof reason === 'number' ||
@@ -260,7 +262,7 @@ export const createStreamLayer = (core: ClientCore): StreamLayerApi => {
           streamId: message.streamId,
           reason: message.reason,
         })
-        void serverStreams.abort(message.streamId)
+        void serverStreams.abort(message.streamId, message.reason)
         break
       case ServerMessageType.ClientStreamPull:
         core.emitStreamEvent({

--- a/packages/client/src/transport.ts
+++ b/packages/client/src/transport.ts
@@ -35,6 +35,7 @@ export interface TransportRpcParams {
 export interface TransportCallOptions {
   signal?: AbortSignal
   streamResponse?: boolean
+  keepalive?: boolean
 }
 
 export interface TransportRpcResponse {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -6,7 +6,16 @@ import type { BaseTypeAny, t } from '@nmtjs/type'
 export const ResolvedType: unique symbol = Symbol('ResolvedType')
 export type ResolvedType = typeof ResolvedType
 
-export type RpcCallOptions = { timeout?: number; signal?: AbortSignal }
+export type RpcCallOptions = {
+  timeout?: number
+  signal?: AbortSignal
+  /**
+   * HTTP transport only: send with fetch keepalive so the request survives
+   * page unload. Browsers cap total in-flight keepalive bytes at ~64KB,
+   * so it is opt-in per call.
+   */
+  keepalive?: boolean
+}
 
 export type StreamCallOptions = RpcCallOptions & { autoReconnect?: boolean }
 

--- a/packages/client/tests/core.spec.ts
+++ b/packages/client/tests/core.spec.ts
@@ -11,12 +11,13 @@ import type {
 import {
   ConnectionType,
   createProtocolBlobReference,
+  ErrorCode,
   ProtocolVersion,
 } from '@nmtjs/protocol'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { TransportConnectParams } from '../src/transport.ts'
-import { ClientCore } from '../src/core.ts'
+import { ClientCore, ClientError } from '../src/core.ts'
 
 const format: BaseClientFormat = {
   contentType: 'application/json',
@@ -187,6 +188,41 @@ describe('ClientCore', () => {
 
     expect(decodeMessage).toHaveBeenCalledWith(context, raw)
     expect(listener).toHaveBeenCalledWith(decodedMessage, raw)
+  })
+
+  it('emits an error event when a server frame fails to decode', async () => {
+    const transport = createBidirectionalTransportDouble()
+    const core = new ClientCore(
+      { protocol: ProtocolVersion.v1, format },
+      transport.transport,
+    )
+
+    core.setMessageContextFactory(() => createMessageContext())
+
+    const cause = new Error('malformed frame')
+    ;(core.protocol as any).decodeMessage = vi.fn(() => {
+      throw cause
+    })
+
+    const messageListener = vi.fn()
+    const errorListener = vi.fn()
+    core.on('message', messageListener)
+    core.on('error', errorListener)
+
+    const connectPromise = core.connect()
+    transport.open()
+    await connectPromise
+
+    transport.emitMessage(new Uint8Array([1, 2, 3]))
+    await Promise.resolve()
+
+    expect(messageListener).not.toHaveBeenCalled()
+    expect(errorListener).toHaveBeenCalledTimes(1)
+
+    const error = errorListener.mock.calls[0][0] as ClientError
+    expect(error).toBeInstanceOf(ClientError)
+    expect(error.code).toBe(ErrorCode.ClientRequestError)
+    expect(error.data).toBe(cause)
   })
 
   it('reconnects after a server disconnect when reconnect is configured', async () => {

--- a/packages/client/tests/core.spec.ts
+++ b/packages/client/tests/core.spec.ts
@@ -225,6 +225,30 @@ describe('ClientCore', () => {
     expect(error.data).toBe(cause)
   })
 
+  it('survives a decode error emitted without any error listeners', async () => {
+    const transport = createBidirectionalTransportDouble()
+    const core = new ClientCore(
+      { protocol: ProtocolVersion.v1, format },
+      transport.transport,
+    )
+
+    core.setMessageContextFactory(() => createMessageContext())
+    ;(core.protocol as any).decodeMessage = vi.fn(() => {
+      throw new Error('malformed frame')
+    })
+
+    const connectPromise = core.connect()
+    transport.open()
+    await connectPromise
+
+    // pins EventTarget-style emit semantics: an unlistened 'error' event must
+    // not throw (unlike Node's EventEmitter) or surface as unhandled rejection
+    expect(() => transport.emitMessage(new Uint8Array([1, 2, 3]))).not.toThrow()
+    await Promise.resolve()
+
+    expect(core.state).toBe('connected')
+  })
+
   it('reconnects after a server disconnect when reconnect is configured', async () => {
     vi.useFakeTimers()
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)

--- a/packages/client/tests/reconnection-bidirectional.spec.ts
+++ b/packages/client/tests/reconnection-bidirectional.spec.ts
@@ -57,8 +57,8 @@ describe('reconnectPlugin (bidirectional)', () => {
   })
 
   it('applies reconnect jitter outside browser environments', async () => {
-    // max jitter: delay = timeout + floor(timeout * 0.2)
-    vi.spyOn(Math, 'random').mockReturnValue(1)
+    // near-max jitter: delay = timeout + floor(timeout * 0.2 * 0.995) = 1199
+    vi.spyOn(Math, 'random').mockReturnValue(0.995)
 
     const transport = createMockBidirectionalTransport()
     const connectSpy = vi.spyOn(transport.transport, 'connect')
@@ -79,7 +79,7 @@ describe('reconnectPlugin (bidirectional)', () => {
     await vi.advanceTimersByTimeAsync(1000)
     expect(connectSpy).not.toHaveBeenCalled()
 
-    await vi.advanceTimersByTimeAsync(200)
+    await vi.advanceTimersByTimeAsync(199)
     expect(connectSpy).toHaveBeenCalledTimes(1)
   })
 

--- a/packages/client/tests/reconnection-bidirectional.spec.ts
+++ b/packages/client/tests/reconnection-bidirectional.spec.ts
@@ -56,6 +56,33 @@ describe('reconnectPlugin (bidirectional)', () => {
     expect(connectSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('applies reconnect jitter outside browser environments', async () => {
+    // max jitter: delay = timeout + floor(timeout * 0.2)
+    vi.spyOn(Math, 'random').mockReturnValue(1)
+
+    const transport = createMockBidirectionalTransport()
+    const connectSpy = vi.spyOn(transport.transport, 'connect')
+
+    const client = new StaticClient(
+      { ...createBaseOptions(), plugins: [reconnectPlugin()] },
+      transport.factory,
+      {},
+    )
+
+    const connectPromise = client.connect()
+    transport.simulateConnect()
+    await connectPromise
+
+    connectSpy.mockClear()
+    transport.simulateDisconnect('server')
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(connectSpy).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(200)
+    expect(connectSpy).toHaveBeenCalledTimes(1)
+  })
+
   it('does not reconnect after client-initiated disconnect', async () => {
     const transport = createMockBidirectionalTransport()
     const connectSpy = vi.spyOn(transport.transport, 'connect')

--- a/packages/client/tests/rpc-streams.spec.ts
+++ b/packages/client/tests/rpc-streams.spec.ts
@@ -160,4 +160,41 @@ describe('RPC streams', () => {
       value: undefined,
     })
   })
+
+  it('propagates server abort reasons to stream consumers', async () => {
+    const core = new MockCore()
+    const rpcLayer = createRpcLayer(
+      core as any,
+      { addServerBlobStream: vi.fn() } as any,
+      new BaseClientTransformer(),
+    )
+
+    const streamPromise = rpcLayer.call(
+      'users/profile',
+      { userId: '1' },
+      { _stream_response: true },
+    )
+
+    core.emit(
+      'message',
+      { type: ServerMessageType.RpcStreamResponse, callId: 0 },
+      new Uint8Array([1]),
+    )
+
+    const iterable = await streamPromise
+    const iterator = iterable[Symbol.asyncIterator]()
+    const nextPromise = iterator.next()
+
+    core.emit(
+      'message',
+      {
+        type: ServerMessageType.RpcStreamAbort,
+        callId: 0,
+        reason: 'server cancelled',
+      },
+      new Uint8Array([2]),
+    )
+
+    await expect(nextPromise).rejects.toBe('server cancelled')
+  })
 })

--- a/packages/client/tests/streams.spec.ts
+++ b/packages/client/tests/streams.spec.ts
@@ -1,7 +1,10 @@
 import type { ProtocolBlobMetadata } from '@nmtjs/protocol'
+import { ServerMessageType } from '@nmtjs/protocol'
 import { ProtocolServerStream } from '@nmtjs/protocol/client'
 import { describe, expect, it, vi } from 'vitest'
 
+import { EventEmitter } from '../src/events.ts'
+import { createStreamLayer, toReasonString } from '../src/layers/streams.ts'
 import { ClientStreams, ServerStreams } from '../src/streams.ts'
 
 const metadata: ProtocolBlobMetadata = { type: 'application/octet-stream' }
@@ -281,5 +284,49 @@ describe('ServerStreams', () => {
 
       expect(() => streams.get(1)).toThrow('Stream not found')
     })
+  })
+})
+
+describe('createStreamLayer', () => {
+  it('propagates server abort reasons to blob stream consumers', async () => {
+    const core = Object.assign(new EventEmitter(), {
+      messageContext: {},
+      protocol: { encodeMessage: vi.fn(() => new Uint8Array([0])) },
+      send: vi.fn(async () => {}),
+      emitStreamEvent: vi.fn(),
+      emitClientEvent: vi.fn(),
+    })
+
+    const layer = createStreamLayer(core as any)
+    const { blob, streamId } = layer.addServerBlobStream(metadata)
+    const stream = layer.consumeServerBlob(blob)
+
+    const iterator = stream[Symbol.asyncIterator]()
+    const nextPromise = iterator.next()
+
+    core.emit('message', {
+      type: ServerMessageType.ServerStreamAbort,
+      streamId,
+      reason: 'quota exceeded',
+    })
+
+    await expect(nextPromise).rejects.toBe('quota exceeded')
+  })
+})
+
+describe('toReasonString', () => {
+  it('coerces symbol and function reasons instead of dropping them', () => {
+    expect(toReasonString(Symbol('cancelled'))).toBe('Symbol(cancelled)')
+    expect(toReasonString(() => {})).toBe('[object Function]')
+  })
+
+  it('keeps existing coercions intact', () => {
+    expect(toReasonString('stop')).toBe('stop')
+    expect(toReasonString(new Error('boom'))).toBe('boom')
+    expect(toReasonString({ code: 1 })).toBe('{"code":1}')
+    expect(toReasonString(42)).toBe('42')
+    expect(toReasonString(10n)).toBe('10')
+    expect(toReasonString(undefined)).toBeUndefined()
+    expect(toReasonString(null)).toBeUndefined()
   })
 })

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -17,6 +17,9 @@ type DecodeBase64Function = (data: string) => ArrayBufferView
 const createDecodeBase64 = (
   customFn?: DecodeBase64Function,
 ): DecodeBase64Function => {
+  // caller-supplied decoder must win over built-ins
+  if (customFn) return customFn
+
   return (string: string) => {
     if (
       'fromBase64' in Uint8Array &&
@@ -25,8 +28,6 @@ const createDecodeBase64 = (
       return Uint8Array.fromBase64(string)
     } else if (typeof atob === 'function') {
       return Uint8Array.from(atob(string), (c) => c.charCodeAt(0))
-    } else if (customFn) {
-      return customFn(string)
     } else {
       throw new Error('No base64 decoding function available')
     }
@@ -138,15 +139,23 @@ export class HttpTransportClient implements UnidirectionalTransport {
       )
     }
 
+    // duplex is required by fetch for stream bodies but missing from RequestInit typings
+    const requestInit: RequestInit & { duplex?: 'half' } = {
+      body,
+      method: 'POST',
+      headers: requestHeaders,
+      signal: options.signal,
+      credentials: 'include',
+      // keepalive is opt-in: browsers cap total in-flight keepalive bytes at ~64KB
+      ...(options.keepalive && shouldUseKeepalive(body)
+        ? { keepalive: true }
+        : {}),
+      // undici and Chrome throw on stream request bodies without half-duplex
+      ...(rpc.blob ? { duplex: 'half' as const } : {}),
+    }
+
     if (options.streamResponse) {
-      const response = await fetchImpl(url.toString(), {
-        body,
-        method: 'POST',
-        headers: requestHeaders,
-        signal: options.signal,
-        credentials: 'include',
-        ...(shouldUseKeepalive(body) ? { keepalive: true } : {}),
-      })
+      const response = await fetchImpl(url.toString(), requestInit)
 
       if (!response.ok) {
         return {
@@ -204,14 +213,7 @@ export class HttpTransportClient implements UnidirectionalTransport {
 
       return { type: 'rpc_stream' as const, stream }
     } else {
-      const response = await fetchImpl(url.toString(), {
-        body,
-        method: 'POST',
-        headers: requestHeaders,
-        signal: options.signal,
-        credentials: 'include',
-        ...(shouldUseKeepalive(body) ? { keepalive: true } : {}),
-      })
+      const response = await fetchImpl(url.toString(), requestInit)
 
       if (response.ok) {
         const isBlob = !!response.headers.get(NEEMATA_BLOB_HEADER)

--- a/packages/http-client/tests/client-call.spec.ts
+++ b/packages/http-client/tests/client-call.spec.ts
@@ -1,9 +1,9 @@
 import { StaticClient, loggingPlugin } from '@nmtjs/client'
-import { ProtocolVersion } from '@nmtjs/protocol'
+import { ProtocolBlob, ProtocolVersion } from '@nmtjs/protocol'
 import { BaseClientFormat } from '@nmtjs/protocol/client'
 import { describe, expect, it, vi } from 'vitest'
 
-import { HttpTransportFactory } from '../src/index.ts'
+import { HttpTransportClient, HttpTransportFactory } from '../src/index.ts'
 
 class TestJsonFormat extends BaseClientFormat {
   contentType = 'application/json'
@@ -78,7 +78,7 @@ describe('HttpTransportClient + StaticClient', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('uses keepalive for small HTTP request bodies', async () => {
+  it('omits keepalive by default', async () => {
     const format = new TestJsonFormat()
     const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(format.encode({ ok: true }) as any, {
@@ -96,10 +96,10 @@ describe('HttpTransportClient + StaticClient', () => {
     await (client.call as any).ping({ userId: 'u1' })
 
     expect(fetchSpy).toHaveBeenCalledTimes(1)
-    expect(fetchSpy.mock.calls[0]?.[1]?.keepalive).toBe(true)
+    expect(fetchSpy.mock.calls[0]?.[1]?.keepalive).toBeUndefined()
   })
 
-  it('omits keepalive for large HTTP request bodies', async () => {
+  it('uses keepalive for small bodies when opted in per call', async () => {
     const format = new TestJsonFormat()
     const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(format.encode({ ok: true }) as any, {
@@ -114,10 +114,76 @@ describe('HttpTransportClient + StaticClient', () => {
       { url: 'http://localhost:4000', fetch: fetchSpy },
     )
 
-    await (client.call as any).ping({ data: 'x'.repeat(64 * 1024) })
+    await (client.call as any).ping({ userId: 'u1' }, { keepalive: true })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy.mock.calls[0]?.[1]?.keepalive).toBe(true)
+  })
+
+  it('omits keepalive for large bodies even when opted in', async () => {
+    const format = new TestJsonFormat()
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(format.encode({ ok: true }) as any, {
+        status: 200,
+        headers: { 'content-type': format.contentType },
+      }),
+    )
+
+    const client = new StaticClient(
+      { contract: {} as any, protocol: ProtocolVersion.v1, format },
+      HttpTransportFactory,
+      { url: 'http://localhost:4000', fetch: fetchSpy },
+    )
+
+    await (client.call as any).ping(
+      { data: 'x'.repeat(64 * 1024) },
+      { keepalive: true },
+    )
 
     expect(fetchSpy).toHaveBeenCalledTimes(1)
     expect(fetchSpy.mock.calls[0]?.[1]?.keepalive).toBeUndefined()
+  })
+
+  it('sends blob uploads as half-duplex stream bodies', async () => {
+    const format = new TestJsonFormat()
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(format.encode({ ok: true }) as any, {
+        status: 200,
+        headers: { 'content-type': format.contentType },
+      }),
+    )
+
+    const client = new StaticClient(
+      { contract: {} as any, protocol: ProtocolVersion.v1, format },
+      HttpTransportFactory,
+      { url: 'http://localhost:4000', fetch: fetchSpy },
+    )
+
+    await (client.call as any).upload(
+      ProtocolBlob.from(new Uint8Array([1, 2, 3])),
+    )
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const init = fetchSpy.mock.calls[0]?.[1] as
+      | (RequestInit & { duplex?: string })
+      | undefined
+    expect(init?.body).toBeInstanceOf(ReadableStream)
+    expect(init?.duplex).toBe('half')
+    expect(init?.keepalive).toBeUndefined()
+  })
+
+  it('prefers a caller-supplied base64 decoder over built-ins', () => {
+    const decoded = new Uint8Array([42])
+    const customDecode = vi.fn(() => decoded)
+
+    const transport = new HttpTransportClient(
+      new TestJsonFormat(),
+      ProtocolVersion.v1,
+      { url: 'http://localhost:4000', decodeBase64: customDecode },
+    )
+
+    expect(transport.decodeBase64('AAECAw==')).toBe(decoded)
+    expect(customDecode).toHaveBeenCalledWith('AAECAw==')
   })
 
   it('emits decoded rpc_response body in logging plugin', async () => {

--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -7,7 +7,8 @@ import type {
 import type { ProtocolVersion } from '@nmtjs/protocol'
 import type { BaseClientFormat } from '@nmtjs/protocol/client'
 import { once } from '@nmtjs/common'
-import { ConnectionType } from '@nmtjs/protocol'
+import { ConnectionType, ErrorCode } from '@nmtjs/protocol'
+import { ProtocolError } from '@nmtjs/protocol/client'
 
 export type WsClientTransportOptions = {
   /**
@@ -126,9 +127,21 @@ export class WsTransportClient implements BidirectionalTransport {
   }
 
   async send(message: ArrayBufferView, options: TransportSendOptions) {
-    if (this.webSocket === null) throw new Error('WebSocket is not connected')
+    if (this.webSocket === null) {
+      throw new ProtocolError(
+        ErrorCode.ConnectionError,
+        'WebSocket is not connected',
+      )
+    }
     await this.connecting
-    if (!options.signal?.aborted) this.webSocket!.send(message as any)
+    // the close handler may null the socket while awaiting the connect
+    if (this.webSocket === null) {
+      throw new ProtocolError(
+        ErrorCode.ConnectionError,
+        'WebSocket closed while connecting',
+      )
+    }
+    if (!options.signal?.aborted) this.webSocket.send(message as any)
   }
 }
 

--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -10,6 +10,9 @@ import { once } from '@nmtjs/common'
 import { ConnectionType, ErrorCode } from '@nmtjs/protocol'
 import { ProtocolError } from '@nmtjs/protocol/client'
 
+// WebSocket.OPEN without touching the global: a custom implementation may be injected
+const WS_OPEN = 1
+
 export type WsClientTransportOptions = {
   /**
    * The origin of the server
@@ -134,14 +137,16 @@ export class WsTransportClient implements BidirectionalTransport {
       )
     }
     await this.connecting
-    // the close handler may null the socket while awaiting the connect
-    if (this.webSocket === null) {
+    // the close handler may null the socket, or a concurrent disconnect may
+    // start closing it, while this send is suspended on the await
+    const webSocket = this.webSocket
+    if (webSocket === null || webSocket.readyState !== WS_OPEN) {
       throw new ProtocolError(
         ErrorCode.ConnectionError,
-        'WebSocket closed while connecting',
+        'WebSocket is not open',
       )
     }
-    if (!options.signal?.aborted) this.webSocket.send(message as any)
+    if (!options.signal?.aborted) webSocket.send(message as any)
   }
 }
 

--- a/packages/ws-client/tests/client.spec.ts
+++ b/packages/ws-client/tests/client.spec.ts
@@ -31,9 +31,12 @@ class FakeWebSocket {
 
   readonly url: URL
   binaryType = 'blob'
+  readyState = 0 // CONNECTING
   readonly send = vi.fn()
   readonly close = vi.fn((code?: number, reason?: string) => {
-    this.emit('close', { code, reason })
+    this.readyState = 2 // CLOSING
+    // real sockets deliver close asynchronously, leaving a CLOSING window
+    setTimeout(() => this.emit('close', { code, reason }), 0)
   })
 
   #listeners = new Map<string, Set<Listener>>()
@@ -50,6 +53,9 @@ class FakeWebSocket {
   }
 
   emit(type: string, init: Record<string, unknown> = {}) {
+    if (type === 'open') this.readyState = 1 // OPEN
+    if (type === 'close') this.readyState = 3 // CLOSED
+
     const event = Object.assign(new Event(type), init)
     for (const listener of this.#listeners.get(type) ?? []) {
       listener(event)
@@ -161,5 +167,40 @@ describe('WsTransportClient', () => {
         error.code === ErrorCode.ConnectionError,
     )
     expect(socket.send).not.toHaveBeenCalled()
+  })
+
+  it('rejects sends while the socket is still closing', async () => {
+    const transport = new WsTransportClient(
+      new TestFormat(),
+      ProtocolVersion.v1,
+      { url: 'http://localhost:4000', WebSocket: FakeWebSocket as any },
+    )
+
+    const onDisconnect = vi.fn()
+
+    const connectPromise = transport.connect({
+      onConnect: vi.fn(),
+      onMessage: vi.fn(),
+      onDisconnect,
+    })
+
+    const socket = FakeWebSocket.instances.at(-1)!
+    socket.emit('open')
+    await connectPromise
+
+    // socket is CLOSING (close event not yet delivered) when send resumes
+    const closing = transport.disconnect()
+    expect(socket.readyState).toBe(2)
+
+    await expect(transport.send(new Uint8Array([1]), {})).rejects.toSatisfy(
+      (error) =>
+        error instanceof ProtocolError &&
+        error.code === ErrorCode.ConnectionError,
+    )
+    expect(socket.send).not.toHaveBeenCalled()
+
+    await closing
+    expect(socket.readyState).toBe(3)
+    expect(onDisconnect).toHaveBeenCalledWith('client')
   })
 })

--- a/packages/ws-client/tests/client.spec.ts
+++ b/packages/ws-client/tests/client.spec.ts
@@ -1,5 +1,5 @@
-import { ProtocolVersion } from '@nmtjs/protocol'
-import { BaseClientFormat } from '@nmtjs/protocol/client'
+import { ErrorCode, ProtocolVersion } from '@nmtjs/protocol'
+import { BaseClientFormat, ProtocolError } from '@nmtjs/protocol/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { WsTransportClient } from '../src/index.ts'
@@ -132,5 +132,34 @@ describe('WsTransportClient', () => {
 
     expect(socket.close).toHaveBeenCalledWith(1000, 'client')
     expect(onDisconnect).toHaveBeenCalledWith('client')
+  })
+
+  it('rejects sends when the socket closes while awaiting connect', async () => {
+    const transport = new WsTransportClient(
+      new TestFormat(),
+      ProtocolVersion.v1,
+      { url: 'http://localhost:4000', WebSocket: FakeWebSocket as any },
+    )
+
+    const connectPromise = transport.connect({
+      onConnect: vi.fn(),
+      onMessage: vi.fn(),
+      onDisconnect: vi.fn(),
+    })
+
+    const socket = FakeWebSocket.instances.at(-1)!
+
+    // send() awaits the pending connect; the socket closes before it resumes
+    const sendPromise = transport.send(new Uint8Array([1]), {})
+    socket.emit('open')
+    socket.emit('close', { reason: 'server_shutdown' })
+    await connectPromise
+
+    await expect(sendPromise).rejects.toSatisfy(
+      (error) =>
+        error instanceof ProtocolError &&
+        error.code === ErrorCode.ConnectionError,
+    )
+    expect(socket.send).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Closes #216

Small fixes across `client`, `ws-client`, `http-client`:

- **`duplex: 'half'` on stream bodies** (`http-client`): every blob upload sends a `ReadableStream` body, and modern fetch (undici, Chrome) throws `TypeError` without the flag — uploads were a hard failure. Typed via a local `RequestInit` intersection since the lib type lacks `duplex`.
- **`keepalive` becomes per-call opt-in** (`http-client`, `client`): the blanket `keepalive: true` for bodies ≤64KB collided with the browser's ~64KB *total* in-flight keepalive budget, so concurrent RPC bursts started rejecting. Now off by default; `RpcCallOptions.keepalive` opts in per call (for unload/beacon use), still gated by the known-size check.
- **Custom `decodeBase64` override actually used** (`http-client`): built-ins won before the caller-supplied function, making the option dead code.
- **`send()` race on closing sockets** (`ws-client`): the socket was null-checked *before* `await this.connecting`, and only for null — a concurrent close during the await produced a raw `TypeError`, and a socket in CLOSING/CLOSED state could still be written to. `send()` now snapshots the socket after the await and requires `readyState === OPEN`, throwing `ProtocolError(ConnectionError)` otherwise.
- **Reconnect jitter in Node** (`client/core.ts`): jitter was browser-gated, so Node fleets reconnected in lockstep after a server restart. Applied unconditionally.
- **Decode failures no longer unhandled rejections** (`client/core.ts`): `#onMessage` wraps `decodeMessage` and emits a typed `error` event (the core emitter is EventTarget-backed, so an unlistened event is safe — pinned by a test).
- **Server stream abort reasons propagated** (`client/layers`): `message.reason` from the wire now reaches `serverStreams.abort`/`rpcStreams.abort`, so consumers see the actual reason instead of a reasonless error.
- **Symbol/function abort reasons** (`toReasonString`): `JSON.stringify` returns `undefined` for symbols/functions without throwing, which short-circuited the fallbacks; a stringify miss now falls through (symbol → its description string). The two duplicated helper copies were consolidated.

Regression tests cover each fix, including the CLOSING-window send race, the no-listener decode error, and jitter timing in Node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional HTTP request keepalive support for RPC calls, with safeguards for large payloads.
  * Added half-duplex handling for streamed uploads.
  * Added client error events for malformed server messages.
  * Server-provided stream abort reasons are now surfaced to consumers.
  * Custom Base64 decoders are now preferred when supplied.

* **Bug Fixes**
  * Improved reconnect timing jitter across environments.
  * WebSocket sends now fail with clear connection errors when the socket is unavailable or not open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->