### PR TITLE
application/gateway: filter error handling, timeout abort, duplicate callId, route collisions

### DIFF
--- a/packages/application/src/api/api.ts
+++ b/packages/application/src/api/api.ts
@@ -31,6 +31,7 @@ import {
   createGatewayStaticMetaView,
   isAsyncIterable,
   rpcStreamAbortSignal,
+  rpcTimeoutSignal,
 } from '@nmtjs/gateway'
 import { ErrorCode } from '@nmtjs/protocol'
 import { ProtocolError } from '@nmtjs/protocol/server'
@@ -166,6 +167,10 @@ export class ApplicationApi implements GatewayApi<ApplicationResolvedProcedure> 
     })
 
     const timeout = procedure.contract.timeout ?? this.options.timeout
+    // paired with the timeout so a timed out handler is actually aborted,
+    // not just raced away
+    const timeoutController =
+      timeout && timeout > 0 ? new AbortController() : undefined
     const streamTimeoutSignal = procedure.streamTimeout
       ? AbortSignal.timeout(procedure.streamTimeout)
       : undefined
@@ -174,18 +179,24 @@ export class ApplicationApi implements GatewayApi<ApplicationResolvedProcedure> 
       container.provide(rpcStreamAbortSignal, streamTimeoutSignal)
     }
 
+    if (timeoutController) {
+      container.provide(rpcTimeoutSignal, timeoutController.signal)
+    }
+
     try {
       const handle = await this.createProcedureHandler(
         callOptions,
         metaBindings,
       )
-      return timeout
-        ? await this.withTimeout(handle(payload), timeout)
+      return timeoutController
+        ? await this.withTimeout(handle(payload), timeout!, timeoutController)
         : await handle(payload)
     } catch (error) {
       const handled = await this.handleFilters(callOptions, error)
-      if (handled === error && error instanceof ProtocolError === false) {
-        const logError = new Error('Unhandled error', { cause: error })
+      // plain Errors are not wire-safe: log them and respond with a generic
+      // server error instead of leaking internals
+      if (handled instanceof ProtocolError === false) {
+        const logError = new Error('Unhandled error', { cause: handled })
         this.options.logger.error(logError)
         throw new ApiError(
           ErrorCode.InternalServerError,
@@ -327,13 +338,18 @@ export class ApplicationApi implements GatewayApi<ApplicationResolvedProcedure> 
     return result[Symbol.iterator]()
   }
 
-  private withTimeout(response: any, timeout: number): unknown {
+  private withTimeout(
+    response: any,
+    timeout: number,
+    controller: AbortController,
+  ): unknown {
     const applyTimeout = response instanceof Promise && timeout > 0
     if (!applyTimeout) return response
     return withTimeout(
       response,
       timeout,
       new ApiError(ErrorCode.RequestTimeout, 'Request Timeout'),
+      controller,
     )
   }
 
@@ -363,9 +379,10 @@ export class ApplicationApi implements GatewayApi<ApplicationResolvedProcedure> 
       for (const filter of this.options.filters) {
         if (error instanceof filter.errorClass) {
           const ctx = await container.createContext(filter.dependencies)
+          // accept any Error, as the Filter type promises; non-ProtocolError
+          // results are sanitized on the way out by call()
           const handledError = await filter.handler(ctx, error)
-          if (!handledError || handledError instanceof ApiError === false)
-            continue
+          if (!handledError || handledError instanceof Error === false) continue
           return handledError
         }
       }
@@ -396,7 +413,7 @@ export class ApplicationApi implements GatewayApi<ApplicationResolvedProcedure> 
     runtimeConfig: Required<RuntimeConfig>,
   ) {
     if (!isAsyncIterable(response))
-      throw new Error('Response is an async iterable')
+      throw new Error('Response is not an async iterable')
     const chunkType = procedure.contract.output
     if (chunkType instanceof type.NeverType)
       throw new Error('Stream procedure must have a defined output type')

--- a/packages/application/src/api/router.ts
+++ b/packages/application/src/api/router.ts
@@ -118,7 +118,14 @@ export function createRootRouter<Routers extends readonly AnyRouter[]>(
   >
 > {
   const routes: Record<string, any> = {}
-  for (const router of routers) Object.assign(routes, router.routes)
+  for (const router of routers) {
+    for (const [name, route] of Object.entries(router.routes)) {
+      // Object.assign would silently drop the earlier route
+      if (name in routes)
+        throw new Error(`Root router route collision: "${name}"`)
+      routes[name] = route
+    }
+  }
   const router = createRouter({ routes })
   return Object.freeze({
     ...router,

--- a/packages/application/src/api/router.ts
+++ b/packages/application/src/api/router.ts
@@ -117,7 +117,9 @@ export function createRootRouter<Routers extends readonly AnyRouter[]>(
     undefined
   >
 > {
-  const routes: Record<string, any> = {}
+  // null prototype so a route literally named "__proto__" is stored as an
+  // own property instead of going through the legacy prototype setter
+  const routes: Record<string, any> = Object.create(null)
   for (const router of routers) {
     for (const [name, route] of Object.entries(router.routes)) {
       // Object.assign would silently drop the earlier route; hasOwn so that
@@ -185,7 +187,9 @@ export function createRouter<const Routes extends AnyRouterRoutes>(
 ): Router<RouterContractFromRoutes<Routes>> {
   const { routes, guards, middlewares, meta, timeout } = params
 
-  const routesContracts: any = {}
+  // null prototype so a route literally named "__proto__" is stored as an
+  // own property instead of going through the legacy prototype setter
+  const routesContracts: any = Object.create(null)
   for (const [name, route] of Object.entries(routes)) {
     routesContracts[name] = route.contract
   }

--- a/packages/application/src/api/router.ts
+++ b/packages/application/src/api/router.ts
@@ -120,8 +120,9 @@ export function createRootRouter<Routers extends readonly AnyRouter[]>(
   const routes: Record<string, any> = {}
   for (const router of routers) {
     for (const [name, route] of Object.entries(router.routes)) {
-      // Object.assign would silently drop the earlier route
-      if (name in routes)
+      // Object.assign would silently drop the earlier route; hasOwn so that
+      // routes named after Object.prototype members don't false-positive
+      if (Object.hasOwn(routes, name))
         throw new Error(`Root router route collision: "${name}"`)
       routes[name] = route
     }

--- a/packages/application/tests/api.spec.ts
+++ b/packages/application/tests/api.spec.ts
@@ -147,19 +147,28 @@ describe('ApplicationApi timeout', () => {
   })
 
   it('does not abort the handler signal when the call completes in time', async () => {
-    let observed: AbortSignal | undefined
-    const procedure = createProcedure({
-      timeout: 1000,
-      dependencies: { signal: GatewayInjectables.rpcAbortSignal },
-      handler: async (ctx) => {
-        observed = ctx.signal
-        return 'done'
-      },
-    })
-    const { call } = createTestApi({ procedure })
+    vi.useFakeTimers()
+    try {
+      let observed: AbortSignal | undefined
+      const procedure = createProcedure({
+        timeout: 1000,
+        dependencies: { signal: GatewayInjectables.rpcAbortSignal },
+        handler: async (ctx) => {
+          observed = ctx.signal
+          return 'done'
+        },
+      })
+      const { call } = createTestApi({ procedure })
 
-    await call()
+      await call()
+      expect(observed?.aborted).toBe(false)
 
-    expect(observed?.aborted).toBe(false)
+      // the timeout timer must be cleared on completion, a late firing
+      // would abort the still-referenced call signal
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(observed?.aborted).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/application/tests/api.spec.ts
+++ b/packages/application/tests/api.spec.ts
@@ -1,0 +1,165 @@
+import { onceAborted } from '@nmtjs/common'
+import { Container, createLogger, Scope } from '@nmtjs/core'
+import { GatewayInjectables } from '@nmtjs/gateway'
+import { ErrorCode } from '@nmtjs/protocol'
+import { ProtocolError } from '@nmtjs/protocol/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AnyFilter, AnyProcedure } from '../src/index.ts'
+import {
+  ApiError,
+  ApplicationApi,
+  createFilter,
+  createProcedure,
+} from '../src/index.ts'
+
+class DomainError extends Error {}
+
+function createTestApi(options: {
+  procedure: AnyProcedure
+  filters?: AnyFilter[]
+  timeout?: number
+}) {
+  const logger = createLogger({ pinoOptions: { enabled: false } }, 'test')
+  const container = new Container({ logger })
+
+  const api = new ApplicationApi({
+    timeout: options.timeout,
+    container,
+    logger,
+    procedures: new Map([['test', { procedure: options.procedure, path: [] }]]),
+    meta: [],
+    guards: new Set(),
+    middlewares: new Set(),
+    filters: new Set(options.filters ?? []),
+  })
+
+  const connectionAbort = new AbortController()
+  const clientAbort = new AbortController()
+
+  const connectionContainer = container.fork(Scope.Connection)
+  connectionContainer.provide(
+    GatewayInjectables.connectionAbortSignal,
+    connectionAbort.signal,
+  )
+
+  const callContainer = connectionContainer.fork(Scope.Call)
+  callContainer.provide(
+    GatewayInjectables.rpcClientAbortSignal,
+    clientAbort.signal,
+  )
+
+  const call = (payload?: any) =>
+    api.call({
+      connection: {} as any,
+      procedure: 'test',
+      container: callContainer,
+      payload,
+      signal: clientAbort.signal,
+    })
+
+  return { api, call, logger }
+}
+
+describe('ApplicationApi filters', () => {
+  it('applies a filter returning a ProtocolError', async () => {
+    const filter = createFilter({
+      errorClass: DomainError,
+      handler: () => new ProtocolError(ErrorCode.Forbidden, 'Mapped'),
+    })
+    const procedure = createProcedure({
+      handler: () => {
+        throw new DomainError('boom')
+      },
+    })
+    const { call } = createTestApi({ procedure, filters: [filter] })
+
+    await expect(call()).rejects.toMatchObject({ code: ErrorCode.Forbidden })
+  })
+
+  it('applies a filter returning a plain Error, without leaking it to the wire', async () => {
+    const filter = createFilter({
+      errorClass: DomainError,
+      handler: () => new Error('internal details'),
+    })
+    const procedure = createProcedure({
+      handler: () => {
+        throw new DomainError('boom')
+      },
+    })
+    const { call, logger } = createTestApi({ procedure, filters: [filter] })
+    const logged = vi.spyOn(logger, 'error')
+
+    const error: ApiError = await call().then(
+      () => expect.unreachable(),
+      (error) => error,
+    )
+
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error.code).toBe(ErrorCode.InternalServerError)
+    expect(error.message).not.toContain('internal details')
+    // the filter's error must still be observable in logs
+    expect(logged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cause: expect.objectContaining({ message: 'internal details' }),
+      }),
+    )
+  })
+
+  it('falls through to a generic error when a filter returns nothing', async () => {
+    const filter = createFilter({
+      errorClass: DomainError,
+      handler: () => undefined as any,
+    })
+    const procedure = createProcedure({
+      handler: () => {
+        throw new DomainError('boom')
+      },
+    })
+    const { call } = createTestApi({ procedure, filters: [filter] })
+
+    await expect(call()).rejects.toMatchObject({
+      code: ErrorCode.InternalServerError,
+    })
+  })
+})
+
+describe('ApplicationApi timeout', () => {
+  it('aborts the handler signal when the procedure times out', async () => {
+    let observed: AbortSignal | undefined
+    const procedure = createProcedure({
+      timeout: 20,
+      dependencies: { signal: GatewayInjectables.rpcAbortSignal },
+      handler: async (ctx) => {
+        observed = ctx.signal
+        await onceAborted(ctx.signal)
+        return 'done'
+      },
+    })
+    const { call } = createTestApi({ procedure })
+
+    await expect(call()).rejects.toMatchObject({
+      code: ErrorCode.RequestTimeout,
+    })
+    expect(observed?.aborted).toBe(true)
+    expect(observed?.reason).toBeInstanceOf(ApiError)
+    expect(observed?.reason).toMatchObject({ code: ErrorCode.RequestTimeout })
+  })
+
+  it('does not abort the handler signal when the call completes in time', async () => {
+    let observed: AbortSignal | undefined
+    const procedure = createProcedure({
+      timeout: 1000,
+      dependencies: { signal: GatewayInjectables.rpcAbortSignal },
+      handler: async (ctx) => {
+        observed = ctx.signal
+        return 'done'
+      },
+    })
+    const { call } = createTestApi({ procedure })
+
+    await call()
+
+    expect(observed?.aborted).toBe(false)
+  })
+})

--- a/packages/application/tests/runtime-host.spec.ts
+++ b/packages/application/tests/runtime-host.spec.ts
@@ -88,9 +88,7 @@ describe('application runtime boundary', () => {
     }
   })
 
-  it('warns when root-composed routers duplicate a top-level route', async () => {
-    const logger = createLogger({ pinoOptions: { enabled: false } }, 'test')
-    const warn = vi.spyOn(logger, 'warn')
+  it('throws when root-composed routers duplicate a top-level route', () => {
     const first = createRouter({
       routes: {
         ping: createProcedure({ handler: async () => ({ ok: true }) }),
@@ -101,23 +99,10 @@ describe('application runtime boundary', () => {
         ping: createProcedure({ handler: async () => ({ ok: true }) }),
       },
     })
-    const runtime = new NeemataApplication(
-      defineApplication({ router: createRootRouter([first, second] as const) }),
-      { logger },
-    )
 
-    try {
-      await expect(runtime.initialize()).rejects.toThrow(
-        'Procedure ping already registered',
-      )
-      expect(warn).toHaveBeenCalledWith(
-        { route: 'ping' },
-        'Duplicate root router route',
-      )
-    } finally {
-      await runtime.dispose()
-      warn.mockRestore()
-    }
+    expect(() => createRootRouter([first, second] as const)).toThrow(
+      'Root router route collision: "ping"',
+    )
   })
 
   it('registers each root-composed source router once in procedure paths', async () => {

--- a/packages/application/tests/runtime-host.spec.ts
+++ b/packages/application/tests/runtime-host.spec.ts
@@ -105,6 +105,16 @@ describe('application runtime boundary', () => {
     )
   })
 
+  it('allows routes named after Object.prototype members', () => {
+    const router = createRouter({
+      routes: {
+        toString: createProcedure({ handler: async () => ({ ok: true }) }),
+      },
+    })
+
+    expect(() => createRootRouter([router] as const)).not.toThrow()
+  })
+
   it('registers each root-composed source router once in procedure paths', async () => {
     const logger = createLogger({ pinoOptions: { enabled: false } }, 'test')
     const allowed = createMeta<'get'>()

--- a/packages/application/tests/runtime-host.spec.ts
+++ b/packages/application/tests/runtime-host.spec.ts
@@ -115,6 +115,21 @@ describe('application runtime boundary', () => {
     expect(() => createRootRouter([router] as const)).not.toThrow()
   })
 
+  it('keeps a route literally named "__proto__" as an own route', () => {
+    const procedure = createProcedure({ handler: async () => ({ ok: true }) })
+    const router = createRouter({
+      routes: { ['__proto__']: procedure },
+    })
+
+    const root = createRootRouter([router] as const)
+
+    // a plain accumulator would pass "__proto__" to the legacy prototype
+    // setter, silently dropping the route from own-property enumeration
+    expect(Object.hasOwn(root.routes, '__proto__')).toBe(true)
+    expect(Object.keys(root.routes)).toContain('__proto__')
+    expect(root.routes['__proto__' as string]).toBe(procedure)
+  })
+
   it('registers each root-composed source router once in procedure paths', async () => {
     const logger = createLogger({ pinoOptions: { enabled: false } }, 'test')
     const allowed = createMeta<'get'>()

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -63,11 +63,17 @@ export function withTimeout(
   value: Promise<any>,
   timeout: number,
   timeoutError: Error,
+  abortController?: AbortController,
 ) {
   return Promise.race([
     value,
     new Promise((_, reject) =>
-      globalThis.setTimeout(reject, timeout, timeoutError),
+      globalThis.setTimeout(() => {
+        // fire the paired signal so in-flight work is actually cancelled,
+        // not just raced away
+        abortController?.abort(timeoutError)
+        reject(timeoutError)
+      }, timeout),
     ),
   ])
 }

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -65,17 +65,21 @@ export function withTimeout(
   timeoutError: Error,
   abortController?: AbortController,
 ) {
+  let timer: ReturnType<typeof globalThis.setTimeout>
   return Promise.race([
     value,
-    new Promise((_, reject) =>
-      globalThis.setTimeout(() => {
+    new Promise((_, reject) => {
+      timer = globalThis.setTimeout(() => {
         // fire the paired signal so in-flight work is actually cancelled,
         // not just raced away
         abortController?.abort(timeoutError)
         reject(timeoutError)
-      }, timeout),
-    ),
-  ])
+      }, timeout)
+    }),
+  ]).finally(() => {
+    // otherwise a settled call would still get aborted at the deadline
+    globalThis.clearTimeout(timer)
+  })
 }
 
 export function tryCaptureStackTrace(depth = 0) {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -31,6 +31,7 @@ import {
   ClientMessageType,
   ConnectionType,
   createProtocolBlobReference,
+  ErrorCode,
   getProtocolBlobStreamId,
   isBlobInterface,
   ProtocolBlob,
@@ -522,6 +523,27 @@ export class Gateway<
             break
           }
           case ClientMessageType.Rpc: {
+            // reusing an active callId would hijack the in-flight call's
+            // abort controller and interleave responses — reject it instead
+            if (this.rpcs.get(connectionId, message.rpc.callId)) {
+              messageContext.transport.send!(
+                connectionId,
+                connection.protocol.encodeMessage(
+                  messageContext,
+                  ServerMessageType.RpcResponse,
+                  {
+                    callId: message.rpc.callId,
+                    result: null,
+                    streams: {},
+                    error: new ProtocolError(
+                      ErrorCode.ClientRequestError,
+                      'Duplicate call id',
+                    ),
+                  },
+                ),
+              )
+              break
+            }
             const rpcContext = this.createRpcContext(
               connection,
               messageContext,
@@ -866,7 +888,7 @@ export class Gateway<
   }
 }
 
-const gatewayLoggerOptions: ChildLoggerOptions = {
+export const gatewayLoggerOptions: ChildLoggerOptions = {
   serializers: {
     chunk: (chunk) =>
       isTypedArray(chunk) ? `<Buffer length=${chunk.byteLength}>` : chunk,
@@ -876,14 +898,15 @@ const gatewayLoggerOptions: ChildLoggerOptions = {
           return obj.map(traverseObject)
         } else if (isTypedArray(obj)) {
           return `<${obj.constructor.name} length=${obj.byteLength}>`
+        } else if (isBlobInterface(obj)) {
+          // must run before the generic object branch, blobs are objects too
+          return `<ClientBlobStream metadata=${JSON.stringify(obj.metadata)}>`
         } else if (typeof obj === 'object' && obj !== null) {
           const result: Record<string, any> = {}
           for (const [key, value] of Object.entries(obj)) {
             result[key] = traverseObject(value)
           }
           return result
-        } else if (isBlobInterface(obj)) {
-          return `<ClientBlobStream metadata=${JSON.stringify(obj.metadata)}>`
         }
         return obj
       }

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -31,7 +31,6 @@ import {
   ClientMessageType,
   ConnectionType,
   createProtocolBlobReference,
-  ErrorCode,
   getProtocolBlobStreamId,
   isBlobInterface,
   ProtocolBlob,
@@ -323,7 +322,7 @@ export class Gateway<
         streamAbortReason,
       )
 
-      this.rpcs.delete(connection.id, callId)
+      this.rpcs.delete(connection.id, callId, controller)
 
       await container.dispose()
     }
@@ -524,23 +523,13 @@ export class Gateway<
           }
           case ClientMessageType.Rpc: {
             // reusing an active callId would hijack the in-flight call's
-            // abort controller and interleave responses — reject it instead
+            // abort controller and interleave responses — drop the message
+            // silently, an error response would reject the pending call
+            // on the client side
             if (this.rpcs.get(connectionId, message.rpc.callId)) {
-              messageContext.transport.send!(
-                connectionId,
-                connection.protocol.encodeMessage(
-                  messageContext,
-                  ServerMessageType.RpcResponse,
-                  {
-                    callId: message.rpc.callId,
-                    result: null,
-                    streams: {},
-                    error: new ProtocolError(
-                      ErrorCode.ClientRequestError,
-                      'Duplicate call id',
-                    ),
-                  },
-                ),
+              logger.warn(
+                { callId: message.rpc.callId },
+                'Duplicate RPC call id, dropping message',
               )
               break
             }

--- a/packages/gateway/src/injectables.ts
+++ b/packages/gateway/src/injectables.ts
@@ -75,12 +75,28 @@ export const rpcStreamAbortSignal = createLazyInjectable<
 >(Scope.Call, 'RPC stream abort signal')
 
 /**
+ * Optional procedure timeout signal.
+ *
+ * Scope: Call
+ *
+ * Provided by the runtime when a procedure/api timeout is configured, and
+ * aborted when the call times out, so handlers stop instead of running past
+ * the timed-out response.
+ * Prefer rpcAbortSignal for general handler cancellation.
+ */
+export const rpcTimeoutSignal = createLazyInjectable<AbortSignal, Scope.Call>(
+  Scope.Call,
+  'RPC timeout signal',
+)
+
+/**
  * Unified RPC cancellation signal derived from other call/connection signals.
  *
  * Scope: Call
  *
  * Combines rpcClientAbortSignal, connectionAbortSignal, and (if present)
- * rpcStreamAbortSignal. This is the recommended signal for procedure logic.
+ * rpcStreamAbortSignal and rpcTimeoutSignal. This is the recommended signal
+ * for procedure logic.
  *
  * Gateway/transport code should provide rpcClientAbortSignal, not
  * rpcAbortSignal directly, so this composition remains intact.
@@ -91,12 +107,14 @@ export const rpcAbortSignal = createFactoryInjectable(
       rpcClientAbortSignal,
       connectionAbortSignal,
       rpcStreamAbortSignal: optional(rpcStreamAbortSignal),
+      rpcTimeoutSignal: optional(rpcTimeoutSignal),
     },
     create: (ctx) =>
       anyAbortSignal(
         ctx.rpcClientAbortSignal,
         ctx.connectionAbortSignal,
         ctx.rpcStreamAbortSignal,
+        ctx.rpcTimeoutSignal,
       ),
   },
   'Any RPC abort signal',
@@ -129,6 +147,7 @@ export const GatewayInjectables = {
   connectionAbortSignal,
   rpcClientAbortSignal,
   rpcStreamAbortSignal,
+  rpcTimeoutSignal,
   rpcAbortSignal,
   createBlob,
   consumeBlob,

--- a/packages/gateway/src/rpcs.ts
+++ b/packages/gateway/src/rpcs.ts
@@ -12,18 +12,18 @@ export class RpcManager {
     return this.rpcs.get(key)
   }
 
-  delete(connectionId: string, callId: number) {
+  delete(connectionId: string, callId: number, owner?: AbortController) {
     const key = this.getKey(connectionId, callId)
+    // callId may have been reused since — only remove an entry the caller owns
+    if (owner && this.rpcs.get(key) !== owner) return
     this.rpcs.delete(key)
   }
 
   abort(connectionId: string, callId: number) {
     const key = this.getKey(connectionId, callId)
-    const controller = this.rpcs.get(key)
-    if (controller) {
-      controller.abort()
-      this.rpcs.delete(key)
-    }
+    // keep the reservation until the call's context is disposed, so the id
+    // cannot be reused while an abort-ignoring handler is still running
+    this.rpcs.get(key)?.abort()
   }
 
   close(connectionId: string) {

--- a/packages/gateway/tests/gateway.spec.ts
+++ b/packages/gateway/tests/gateway.spec.ts
@@ -5,7 +5,6 @@ import {
   ClientMessageType,
   ConnectionType,
   createProtocolBlobReference,
-  ErrorCode,
   ProtocolVersion,
   ServerMessageType,
 } from '@nmtjs/protocol'
@@ -29,6 +28,13 @@ const encodeRpcMessage = (callId: number, procedure: string, payload: any) => {
   return Buffer.concat([header, name, Buffer.from(JSON.stringify(payload))])
 }
 
+const encodeRpcAbortMessage = (callId: number) => {
+  const buffer = Buffer.alloc(5)
+  buffer.writeUInt8(ClientMessageType.RpcAbort, 0)
+  buffer.writeUInt32LE(callId, 1)
+  return buffer
+}
+
 const decodeRpcResponse = (buffer: Buffer) => ({
   type: buffer.readUInt8(0),
   callId: buffer.readUInt32LE(1),
@@ -36,93 +42,137 @@ const decodeRpcResponse = (buffer: Buffer) => ({
   payload: JSON.parse(buffer.subarray(6).toString('utf-8')),
 })
 
+async function createTestGateway() {
+  const logger = createTestLogger()
+  const container = createTestContainer({ logger })
+  const serverFormat = createTestServerFormat()
+
+  // each api.call stays in flight until its future is resolved by the test
+  const calls: PromiseWithResolvers<unknown>[] = []
+  const api: GatewayApi = {
+    resolve: vi.fn(async () => ({ name: 'test', stream: false })),
+    call: vi.fn(() => {
+      const future = Promise.withResolvers<unknown>()
+      calls.push(future)
+      return future.promise
+    }),
+  }
+
+  let params: any
+  const sent: Buffer[] = []
+
+  const transport = {
+    start: vi.fn(async (_params) => {
+      params = _params
+      return 'test://'
+    }),
+    stop: vi.fn(async () => {}),
+    send: vi.fn((_connectionId: string, buffer: ArrayBufferView) => {
+      sent.push(Buffer.from(buffer as Uint8Array))
+      return true
+    }),
+    close: vi.fn((_connectionId: string) => {}),
+  }
+
+  const gateway = new Gateway({
+    logger,
+    container,
+    hooks: new Hooks(),
+    formats: new ProtocolFormats([serverFormat]),
+    transports: { test: { transport } },
+    api,
+    heartbeat: false,
+  })
+
+  await gateway.start()
+
+  const connection = await params.onConnect({
+    type: ConnectionType.Bidirectional,
+    protocolVersion: ProtocolVersion.v1,
+    accept: serverFormat.contentType,
+    contentType: serverFormat.contentType,
+    data: {},
+  })
+
+  const send = (data: Buffer) =>
+    params.onMessage({ connectionId: connection.id, data })
+
+  return { gateway, api, calls, sent, connection, send }
+}
+
 describe('Gateway RPC handling', () => {
-  it('rejects a duplicate callId without disturbing the in-flight call', async () => {
-    const logger = createTestLogger()
-    const container = createTestContainer({ logger })
-    const serverFormat = createTestServerFormat()
-
-    const firstCall = Promise.withResolvers<unknown>()
-    const api: GatewayApi = {
-      resolve: vi.fn(async () => ({ name: 'test', stream: false })),
-      call: vi.fn(() => firstCall.promise),
-    }
-
-    let params: any
-    const sent: Buffer[] = []
-
-    const transport = {
-      start: vi.fn(async (_params) => {
-        params = _params
-        return 'test://'
-      }),
-      stop: vi.fn(async () => {}),
-      send: vi.fn((_connectionId: string, buffer: ArrayBufferView) => {
-        sent.push(Buffer.from(buffer as Uint8Array))
-        return true
-      }),
-      close: vi.fn((_connectionId: string) => {}),
-    }
-
-    const gateway = new Gateway({
-      logger,
-      container,
-      hooks: new Hooks(),
-      formats: new ProtocolFormats([serverFormat]),
-      transports: { test: { transport } },
-      api,
-      heartbeat: false,
-    })
-
-    await gateway.start()
-
-    const connection = await params.onConnect({
-      type: ConnectionType.Bidirectional,
-      protocolVersion: ProtocolVersion.v1,
-      accept: serverFormat.contentType,
-      contentType: serverFormat.contentType,
-      data: {},
-    })
+  it('drops a duplicate callId without disturbing the in-flight call', async () => {
+    const { gateway, api, calls, sent, connection, send } =
+      await createTestGateway()
 
     // First call stays in flight (api.call promise unresolved)
-    const inFlight = params.onMessage({
-      connectionId: connection.id,
-      data: encodeRpcMessage(1, 'test', {}),
-    })
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
 
     const controller = gateway.rpcs.get(connection.id, 1)
     expect(controller).toBeDefined()
 
-    // Hostile reuse of the same callId
-    await params.onMessage({
-      connectionId: connection.id,
-      data: encodeRpcMessage(1, 'test', {}),
-    })
+    // Hostile reuse of the same callId must produce NO response: an error
+    // response would reject the pending call on the client side
+    await send(encodeRpcMessage(1, 'test', {}))
 
     expect(api.call).toHaveBeenCalledTimes(1)
-    expect(sent.length).toBe(1)
-
-    const rejection = decodeRpcResponse(sent[0])
-    expect(rejection.type).toBe(ServerMessageType.RpcResponse)
-    expect(rejection.callId).toBe(1)
-    expect(rejection.isError).toBe(true)
-    expect(rejection.payload).toMatchObject({
-      code: ErrorCode.ClientRequestError,
-    })
+    expect(sent.length).toBe(0)
 
     // Original call survives: same controller, not aborted, responds normally
     expect(gateway.rpcs.get(connection.id, 1)).toBe(controller)
     expect(controller!.signal.aborted).toBe(false)
 
-    firstCall.resolve({ ok: true })
+    calls[0].resolve({ ok: true })
     await inFlight
 
-    expect(sent.length).toBe(2)
-    const response = decodeRpcResponse(sent[1])
+    expect(sent.length).toBe(1)
+    const response = decodeRpcResponse(sent[0])
     expect(response.type).toBe(ServerMessageType.RpcResponse)
     expect(response.callId).toBe(1)
     expect(response.isError).toBe(false)
     expect(response.payload).toStrictEqual({ ok: true })
+
+    await gateway.stop()
+  })
+
+  it('keeps an aborted callId reserved until the handler finishes', async () => {
+    const { gateway, api, calls, sent, connection, send } =
+      await createTestGateway()
+
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
+    const controller = gateway.rpcs.get(connection.id, 1)
+
+    // Abort-ignoring handler: the call promise stays pending after abort
+    await send(encodeRpcAbortMessage(1))
+    expect(controller!.signal.aborted).toBe(true)
+
+    // Immediate reuse must still be dropped, or the old context's disposal
+    // would remove the new call's controller
+    await send(encodeRpcMessage(1, 'test', {}))
+    expect(api.call).toHaveBeenCalledTimes(1)
+    expect(gateway.rpcs.get(connection.id, 1)).toBe(controller)
+
+    // Once the original call truly finishes, the id becomes reusable
+    calls[0].resolve(null)
+    await inFlight
+    expect(gateway.rpcs.get(connection.id, 1)).toBeUndefined()
+
+    const inFlight2 = send(encodeRpcMessage(1, 'test', {}))
+    expect(api.call).toHaveBeenCalledTimes(2)
+
+    const controller2 = gateway.rpcs.get(connection.id, 1)
+    expect(controller2).toBeDefined()
+    expect(controller2).not.toBe(controller)
+    expect(controller2!.signal.aborted).toBe(false)
+
+    // ...and the new call is abortable via its own controller
+    await send(encodeRpcAbortMessage(1))
+    expect(controller2!.signal.aborted).toBe(true)
+
+    calls[1].resolve(null)
+    await inFlight2
+
+    expect(sent.length).toBe(2)
 
     await gateway.stop()
   })

--- a/packages/gateway/tests/gateway.spec.ts
+++ b/packages/gateway/tests/gateway.spec.ts
@@ -1,0 +1,147 @@
+import { Buffer } from 'node:buffer'
+
+import { Hooks } from '@nmtjs/core'
+import {
+  ClientMessageType,
+  ConnectionType,
+  createProtocolBlobReference,
+  ErrorCode,
+  ProtocolVersion,
+  ServerMessageType,
+} from '@nmtjs/protocol'
+import { ProtocolFormats } from '@nmtjs/protocol/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { GatewayApi } from '../src/api.ts'
+import { Gateway, gatewayLoggerOptions } from '../src/gateway.ts'
+import {
+  createTestContainer,
+  createTestLogger,
+  createTestServerFormat,
+} from './_helpers/test-utils.ts'
+
+const encodeRpcMessage = (callId: number, procedure: string, payload: any) => {
+  const name = Buffer.from(procedure, 'utf-8')
+  const header = Buffer.alloc(7)
+  header.writeUInt8(ClientMessageType.Rpc, 0)
+  header.writeUInt32LE(callId, 1)
+  header.writeUInt16LE(name.byteLength, 5)
+  return Buffer.concat([header, name, Buffer.from(JSON.stringify(payload))])
+}
+
+const decodeRpcResponse = (buffer: Buffer) => ({
+  type: buffer.readUInt8(0),
+  callId: buffer.readUInt32LE(1),
+  isError: buffer.readUInt8(5) === 1,
+  payload: JSON.parse(buffer.subarray(6).toString('utf-8')),
+})
+
+describe('Gateway RPC handling', () => {
+  it('rejects a duplicate callId without disturbing the in-flight call', async () => {
+    const logger = createTestLogger()
+    const container = createTestContainer({ logger })
+    const serverFormat = createTestServerFormat()
+
+    const firstCall = Promise.withResolvers<unknown>()
+    const api: GatewayApi = {
+      resolve: vi.fn(async () => ({ name: 'test', stream: false })),
+      call: vi.fn(() => firstCall.promise),
+    }
+
+    let params: any
+    const sent: Buffer[] = []
+
+    const transport = {
+      start: vi.fn(async (_params) => {
+        params = _params
+        return 'test://'
+      }),
+      stop: vi.fn(async () => {}),
+      send: vi.fn((_connectionId: string, buffer: ArrayBufferView) => {
+        sent.push(Buffer.from(buffer as Uint8Array))
+        return true
+      }),
+      close: vi.fn((_connectionId: string) => {}),
+    }
+
+    const gateway = new Gateway({
+      logger,
+      container,
+      hooks: new Hooks(),
+      formats: new ProtocolFormats([serverFormat]),
+      transports: { test: { transport } },
+      api,
+      heartbeat: false,
+    })
+
+    await gateway.start()
+
+    const connection = await params.onConnect({
+      type: ConnectionType.Bidirectional,
+      protocolVersion: ProtocolVersion.v1,
+      accept: serverFormat.contentType,
+      contentType: serverFormat.contentType,
+      data: {},
+    })
+
+    // First call stays in flight (api.call promise unresolved)
+    const inFlight = params.onMessage({
+      connectionId: connection.id,
+      data: encodeRpcMessage(1, 'test', {}),
+    })
+
+    const controller = gateway.rpcs.get(connection.id, 1)
+    expect(controller).toBeDefined()
+
+    // Hostile reuse of the same callId
+    await params.onMessage({
+      connectionId: connection.id,
+      data: encodeRpcMessage(1, 'test', {}),
+    })
+
+    expect(api.call).toHaveBeenCalledTimes(1)
+    expect(sent.length).toBe(1)
+
+    const rejection = decodeRpcResponse(sent[0])
+    expect(rejection.type).toBe(ServerMessageType.RpcResponse)
+    expect(rejection.callId).toBe(1)
+    expect(rejection.isError).toBe(true)
+    expect(rejection.payload).toMatchObject({
+      code: ErrorCode.ClientRequestError,
+    })
+
+    // Original call survives: same controller, not aborted, responds normally
+    expect(gateway.rpcs.get(connection.id, 1)).toBe(controller)
+    expect(controller!.signal.aborted).toBe(false)
+
+    firstCall.resolve({ ok: true })
+    await inFlight
+
+    expect(sent.length).toBe(2)
+    const response = decodeRpcResponse(sent[1])
+    expect(response.type).toBe(ServerMessageType.RpcResponse)
+    expect(response.callId).toBe(1)
+    expect(response.isError).toBe(false)
+    expect(response.payload).toStrictEqual({ ok: true })
+
+    await gateway.stop()
+  })
+})
+
+describe('Gateway logger payload serializer', () => {
+  it('renders blob placeholders instead of traversing them as objects', () => {
+    const serialize = gatewayLoggerOptions.serializers!.payload
+    const blob = createProtocolBlobReference(1, { size: 3, type: 'text/plain' })
+
+    const result = serialize({
+      file: blob,
+      list: [blob],
+      nested: { value: 42 },
+    })
+
+    const placeholder = `<ClientBlobStream metadata=${JSON.stringify(blob.metadata)}>`
+    expect(result.file).toBe(placeholder)
+    expect(result.list).toStrictEqual([placeholder])
+    expect(result.nested).toStrictEqual({ value: 42 })
+  })
+})

--- a/packages/gateway/tests/rpcs.spec.ts
+++ b/packages/gateway/tests/rpcs.spec.ts
@@ -79,6 +79,28 @@ describe('RpcManager', () => {
       expect(manager.get('conn-1', 1)).toBeUndefined()
       expect(manager.get('conn-1', 2)).toBe(controller2)
     })
+
+    it('should delete when the caller owns the entry', () => {
+      const controller = new AbortController()
+      manager.set('conn-1', 1, controller)
+
+      manager.delete('conn-1', 1, controller)
+
+      expect(manager.get('conn-1', 1)).toBeUndefined()
+    })
+
+    it('should not delete an entry owned by another controller', () => {
+      const controller1 = new AbortController()
+      const controller2 = new AbortController()
+
+      // callId was reused: deleting on behalf of the old controller
+      // must not remove the new call's entry
+      manager.set('conn-1', 1, controller2)
+
+      manager.delete('conn-1', 1, controller1)
+
+      expect(manager.get('conn-1', 1)).toBe(controller2)
+    })
   })
 
   describe('abort', () => {
@@ -101,13 +123,15 @@ describe('RpcManager', () => {
       expect(controller.signal.reason).toBeInstanceOf(DOMException)
     })
 
-    it('should remove the RPC after aborting', () => {
+    it('should keep the reservation after aborting', () => {
       const controller = new AbortController()
       manager.set('conn-1', 1, controller)
 
       manager.abort('conn-1', 1)
 
-      expect(manager.get('conn-1', 1)).toBeUndefined()
+      // an abort-ignoring handler may still be running: the callId must
+      // stay reserved until the call's context is disposed
+      expect(manager.get('conn-1', 1)).toBe(controller)
     })
 
     it('should do nothing for non-existent RPC', () => {


### PR DESCRIPTION
Closes #215

- **Filters honor their declared type** (`application/api`): `handleFilters` accepted only `ApiError` and silently ignored everything else, despite the `Filter` type promising `Error`. It now accepts any `Error`; on the response path a `ProtocolError` result goes to the wire as-is (filters can now return those too), while any other `Error` is logged with its cause and sanitized to `InternalServerError` — plain Errors aren't wire-safe (they'd encode as `{}`), and nothing internal should leak.
- **Procedure timeout aborts the handler** (`application`, `gateway`, `common`): `withTimeout` was a bare `Promise.race`, so the client got `RequestTimeout` while the handler kept running past call-container disposal. The timeout now aborts a per-call controller (reason: the `RequestTimeout` error) exposed as a `rpcTimeoutSignal` injectable composed into the handler-facing `rpcAbortSignal`; the timer is cleared when the call settles in time, so successful calls no longer get a stray late abort.
- **Duplicate `callId` frames are dropped** (`gateway`): a WS client reusing an active callId could make aborts target the wrong call and interleave responses. Duplicates are now logged and dropped without a response (responding on the reused id would reject the *legitimate* pending call client-side). `RpcManager.abort` keeps the id reserved until the original call's context disposes — an abort-ignoring handler can't be displaced by immediate id reuse — and disposal only removes an entry its own controller owns.
- **`createRootRouter` throws on route collision** (`application/api`): merging routers silently overwrote same-named routes; now throws at composition time, using `Object.hasOwn` so routes named `toString`/`constructor` don't false-positive.
- **Inverted error message** fixed (`'Response is not an async iterable'`).
- **Payload log serializer** (`gateway`): the blob-placeholder branch was unreachable behind the generic object branch; reordered so blob placeholders render in logs.

Regression tests cover each fix, including duplicate-frame drop with the original call surviving, abort-then-reuse with an abort-ignoring handler, late-abort absence after in-time completion, and the `toString` route name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added request timeout cancellation, allowing in-progress operations to stop promptly when a timeout occurs.
  - Added protection against duplicate in-flight requests, preventing conflicting calls from replacing active operations.
  - Added clear detection for duplicate route names when combining routers.

- **Bug Fixes**
  - Improved error handling to prevent unexpected internal error details from being exposed.
  - Corrected response validation messages.
  - Improved serialization of streamed blob references in gateway logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->