### PR TITLE
http-transport: cork backpressure, x-forwarded-proto precedence, payload 400, GET Accept

### DIFF
--- a/packages/http-transport/src/runtimes/node.ts
+++ b/packages/http-transport/src/runtimes/node.ts
@@ -209,7 +209,9 @@ async function handleFixedLengthStream(
   }
 }
 
-async function handleChunkedStream(
+// exported for tests: the waiter dispatch is timing-sensitive and needs
+// deterministic coverage against a controlled response double
+export async function handleChunkedStream(
   res: UwsResponse,
   body: ReadableStream<Uint8Array>,
 ): Promise<void> {

--- a/packages/http-transport/src/runtimes/node.ts
+++ b/packages/http-transport/src/runtimes/node.ts
@@ -23,7 +23,7 @@ const statusResponseBuffer = await statusResponse.arrayBuffer()
 
 type UwsResponse = Parameters<
   Parameters<ReturnType<typeof App>['any']>[1]
->[0] & { aborted?: boolean }
+>[0] & { aborted?: boolean; wakeWritable?: () => void }
 
 function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
   const server = params.tls
@@ -51,6 +51,7 @@ function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
       res.onAborted(() => {
         aborted = true
         uwsRes.aborted = true
+        uwsRes.wakeWritable?.()
         requestController.abort()
 
         try {
@@ -65,8 +66,14 @@ function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
       req.forEach((k, v) => headers.append(k, v))
 
       const host = headers.get('host') || 'localhost'
-      const proto =
-        headers.get('x-forwarded-proto') || params.tls ? 'https' : 'http'
+      const forwardedProto = headers.get('x-forwarded-proto')
+      const proto = forwardedProto
+        ? forwardedProto === 'https'
+          ? 'https'
+          : 'http'
+        : params.tls
+          ? 'https'
+          : 'http'
       const url = new URL(req.getUrl(), `${proto}://${host}`)
       url.search = req.getQuery() ? `?${req.getQuery()}` : ''
       try {
@@ -207,14 +214,36 @@ async function handleChunkedStream(
   body: ReadableStream<Uint8Array>,
 ): Promise<void> {
   const reader = body.getReader()
+  // uWS honors only the first onWritable registration per response, so a
+  // single handler dispatches drain (and abort) events to the pending waiter
+  let writableHandlerRegistered = false
+  const waitWritable = () =>
+    new Promise<void>((resolve, reject) => {
+      if (!writableHandlerRegistered) {
+        writableHandlerRegistered = true
+        res.onWritable(() => {
+          res.wakeWritable?.()
+          return true
+        })
+      }
+      res.wakeWritable = () => {
+        res.wakeWritable = undefined
+        if (res.aborted) reject(new Error('Response aborted'))
+        else resolve()
+      }
+    })
   try {
     while (!res.aborted) {
       const { done, value } = await reader.read()
       if (done) break
       if (value.byteLength === 0) continue
 
-      const ok = res.cork(() => res.write(value))
-      if (!ok) await waitWritable(res)
+      // cork() returns the response object, not write()'s backpressure flag
+      let ok = true
+      res.cork(() => {
+        ok = res.write(value)
+      })
+      if (!ok) await waitWritable()
     }
 
     if (!res.aborted) res.cork(() => res.end())
@@ -257,20 +286,6 @@ function handleFixedChunk(
     }
 
     write(chunkOffset)
-  })
-}
-
-function waitWritable(res: UwsResponse): Promise<void> {
-  return new Promise((resolve, reject) => {
-    res.onWritable(() => {
-      if (res.aborted) {
-        reject(new Error('Response aborted'))
-        return false
-      }
-
-      resolve()
-      return true
-    })
   })
 }
 

--- a/packages/http-transport/src/runtimes/node.ts
+++ b/packages/http-transport/src/runtimes/node.ts
@@ -23,7 +23,11 @@ const statusResponseBuffer = await statusResponse.arrayBuffer()
 
 type UwsResponse = Parameters<
   Parameters<ReturnType<typeof App>['any']>[1]
->[0] & { aborted?: boolean; wakeWritable?: () => void }
+>[0] & {
+  aborted?: boolean
+  wakeWritable?: () => void
+  cancelBody?: () => void
+}
 
 function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
   const server = params.tls
@@ -52,6 +56,7 @@ function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
         aborted = true
         uwsRes.aborted = true
         uwsRes.wakeWritable?.()
+        uwsRes.cancelBody?.()
         requestController.abort()
 
         try {
@@ -216,6 +221,11 @@ export async function handleChunkedStream(
   body: ReadableStream<Uint8Array>,
 ): Promise<void> {
   const reader = body.getReader()
+  // abort must also cancel a pending read(): a stalled source would otherwise
+  // keep the pump and the reader lock alive forever
+  res.cancelBody = () => {
+    reader.cancel().catch(() => {})
+  }
   // uWS honors only the first onWritable registration per response, so a
   // single handler dispatches drain (and abort) events to the pending waiter
   let writableHandlerRegistered = false
@@ -250,6 +260,7 @@ export async function handleChunkedStream(
 
     if (!res.aborted) res.cork(() => res.end())
   } finally {
+    res.cancelBody = undefined
     reader.releaseLock()
   }
 }

--- a/packages/http-transport/src/server.ts
+++ b/packages/http-transport/src/server.ts
@@ -136,9 +136,16 @@ export class HttpTransportServer implements TransportWorker<
     const isBlob = request.headers.get(NEEMATA_BLOB_HEADER) === 'true'
     const contentType = request.headers.get('content-type')
     const accept = request.headers.get('accept') || '*/*'
+    // GET endpoints are reachable via browser navigation, which sends HTML
+    // Accept headers; fall back to the default format only when the client's
+    // Accept can't be negotiated
+    const negotiableAccept =
+      canHaveBody || this.params.formats.supportsEncoder(accept)
+        ? accept
+        : '*/*'
 
     await using connection = await this.params.onConnect({
-      accept: canHaveBody ? accept : '*/*',
+      accept: negotiableAccept,
       contentType: isBlob || !contentType ? '*/*' : contentType,
       data: request,
       protocolVersion: ProtocolVersion.v1,
@@ -178,7 +185,11 @@ export class HttpTransportServer implements TransportWorker<
       } else {
         const querystring = url.searchParams.get('payload')
         if (querystring) {
-          payload = JSON.parse(querystring)
+          try {
+            payload = JSON.parse(querystring)
+          } catch {
+            throw new ProtocolError(ErrorCode.BadRequest, 'Invalid payload')
+          }
         }
       }
 

--- a/packages/http-transport/tests/node-runtime.spec.ts
+++ b/packages/http-transport/tests/node-runtime.spec.ts
@@ -1,0 +1,146 @@
+import { setTimeout as delay } from 'node:timers/promises'
+
+import { BaseServerFormat, ProtocolFormats } from '@nmtjs/protocol/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { HttpTransportServerRequest } from '../src/types.ts'
+import { HttpTransport } from '../src/runtimes/node.ts'
+
+class TestJsonFormat extends BaseServerFormat {
+  accept = ['application/json']
+  contentType = 'application/json'
+
+  encode(data: unknown): ArrayBufferView {
+    return new TextEncoder().encode(JSON.stringify(data))
+  }
+
+  encodeRPC(data: unknown): ArrayBufferView {
+    return this.encode(data)
+  }
+
+  encodeBlob(): unknown {
+    return null
+  }
+
+  decode(buffer: ArrayBufferView): any {
+    return JSON.parse(
+      new TextDecoder().decode(
+        new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength),
+      ),
+    )
+  }
+
+  decodeRPC(buffer: ArrayBufferView): any {
+    return this.decode(buffer)
+  }
+}
+
+async function startServer(onRpc?: (...args: any[]) => Promise<unknown>) {
+  const format = new TestJsonFormat()
+  const connection = {
+    encoder: format,
+    decoder: format,
+    [Symbol.asyncDispose]: () => Promise.resolve(),
+  }
+  const requests: HttpTransportServerRequest[] = []
+  const params = {
+    formats: new ProtocolFormats([format]),
+    onConnect: vi.fn(async (options: { data: unknown }) => {
+      requests.push(options.data as HttpTransportServerRequest)
+      return connection
+    }),
+    resolve: async () => ({ meta: { get: () => ['get', 'post'] } }),
+    onRpc: onRpc ?? (async () => ({ ok: true })),
+    onDisconnect: async () => {},
+    onMessage: async () => {},
+  }
+
+  const worker = await HttpTransport.factory({
+    listen: { port: 0, hostname: '127.0.0.1' },
+  })
+  const url = await worker.start(params as any)
+
+  return {
+    url,
+    requests,
+    stop: () => worker.stop(params as any),
+  }
+}
+
+describe('node runtime adapter', () => {
+  describe('x-forwarded-proto', () => {
+    it('uses http when the header says http', async () => {
+      const { url, requests, stop } = await startServer()
+      try {
+        const response = await fetch(`${url}/test`, {
+          headers: { 'x-forwarded-proto': 'http' },
+        })
+        expect(response.status).toBe(200)
+        expect(requests[0]?.url.protocol).toBe('http:')
+      } finally {
+        await stop()
+      }
+    })
+
+    it('uses https when the header says https', async () => {
+      const { url, requests, stop } = await startServer()
+      try {
+        const response = await fetch(`${url}/test`, {
+          headers: { 'x-forwarded-proto': 'https' },
+        })
+        expect(response.status).toBe(200)
+        expect(requests[0]?.url.protocol).toBe('https:')
+      } finally {
+        await stop()
+      }
+    })
+
+    it('falls back to the listener protocol without the header', async () => {
+      const { url, requests, stop } = await startServer()
+      try {
+        const response = await fetch(`${url}/test`)
+        expect(response.status).toBe(200)
+        expect(requests[0]?.url.protocol).toBe('http:')
+      } finally {
+        await stop()
+      }
+    })
+  })
+
+  describe('chunked stream backpressure', () => {
+    it('pauses reading the source stream when the client does not consume', async () => {
+      const chunkSize = 256 * 1024
+      const totalChunks = 100
+      const chunk = new Uint8Array(chunkSize).fill(97)
+      let pulled = 0
+
+      const { url, stop } = await startServer(async () => {
+        // no content-length header -> exercises the chunked write path
+        const stream = new ReadableStream<Uint8Array>({
+          pull(controller) {
+            pulled++
+            controller.enqueue(chunk)
+            if (pulled >= totalChunks) controller.close()
+          },
+        })
+        return new Response(stream)
+      })
+
+      try {
+        const response = await fetch(`${url}/test`)
+        expect(response.status).toBe(200)
+
+        // give the server time to push as much as buffers allow while the
+        // client is not reading the body yet
+        await delay(500)
+        expect(pulled).toBeLessThan(totalChunks)
+
+        const body = new Uint8Array(await response.arrayBuffer())
+        expect(pulled).toBe(totalChunks)
+        expect(body.byteLength).toBe(chunkSize * totalChunks)
+      } finally {
+        await stop()
+      }
+    })
+  })
+})

--- a/packages/http-transport/tests/node-runtime.spec.ts
+++ b/packages/http-transport/tests/node-runtime.spec.ts
@@ -178,9 +178,11 @@ describe('node runtime adapter', () => {
         res,
         fireWritable: () => handler!(0),
         counts: () => ({ writes, ends, registrations }),
+        // mirrors what the route's onAborted handler does
         abort: () => {
           res.aborted = true
           res.wakeWritable?.()
+          res.cancelBody?.()
         },
       }
     }
@@ -258,6 +260,29 @@ describe('node runtime adapter', () => {
       double.abort()
       await expect(pump).rejects.toThrow('Response aborted')
       expect(double.counts()).toEqual({ writes: 2, ends: 0, registrations: 1 })
+    })
+
+    it('abort while read() is stalled cancels the reader and exits the pump', async () => {
+      const double = createResDouble([])
+      let cancelled = false
+      const body = new ReadableStream<Uint8Array>({
+        // source never produces: the pump parks inside reader.read()
+        pull: () => new Promise<never>(() => {}),
+        cancel() {
+          cancelled = true
+        },
+      })
+      const pump = handleChunkedStream(double.res, body)
+
+      await tick()
+      expect(double.counts().writes).toBe(0)
+
+      double.abort()
+      // reader.cancel() resolves the pending read as done and the pump exits
+      // without writing or ending the aborted response
+      await pump
+      expect(cancelled).toBe(true)
+      expect(double.counts()).toEqual({ writes: 0, ends: 0, registrations: 0 })
     })
   })
 })

--- a/packages/http-transport/tests/node-runtime.spec.ts
+++ b/packages/http-transport/tests/node-runtime.spec.ts
@@ -4,7 +4,7 @@ import { BaseServerFormat, ProtocolFormats } from '@nmtjs/protocol/server'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { HttpTransportServerRequest } from '../src/types.ts'
-import { HttpTransport } from '../src/runtimes/node.ts'
+import { handleChunkedStream, HttpTransport } from '../src/runtimes/node.ts'
 
 class TestJsonFormat extends BaseServerFormat {
   accept = ['application/json']
@@ -141,6 +141,123 @@ describe('node runtime adapter', () => {
       } finally {
         await stop()
       }
+    })
+  })
+
+  describe('handleChunkedStream writable dispatcher', () => {
+    // scripted stand-in for uWS HttpResponse: only the first onWritable
+    // registration takes effect, matching real uWS behavior
+    function createResDouble(writeResults: boolean[]) {
+      const results = [...writeResults]
+      let writes = 0
+      let ends = 0
+      let registrations = 0
+      let handler: ((offset: number) => boolean) | undefined
+      const res: any = {
+        aborted: false,
+        wakeWritable: undefined,
+        cork(cb: () => void) {
+          cb()
+          return res
+        },
+        write() {
+          writes++
+          return results.length > 0 ? (results.shift() as boolean) : true
+        },
+        end() {
+          ends++
+          return res
+        },
+        onWritable(h: (offset: number) => boolean) {
+          registrations++
+          handler ??= h
+          return res
+        },
+      }
+      return {
+        res,
+        fireWritable: () => handler!(0),
+        counts: () => ({ writes, ends, registrations }),
+        abort: () => {
+          res.aborted = true
+          res.wakeWritable?.()
+        },
+      }
+    }
+
+    const chunks = (n: number) =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (let i = 0; i < n; i++) controller.enqueue(new Uint8Array(8))
+          controller.close()
+        },
+      })
+
+    const tick = () => new Promise((resolve) => setImmediate(resolve))
+
+    it('resumes exactly one pending waiter per drain across cycles', async () => {
+      const double = createResDouble([false, true, false, true])
+      const pump = handleChunkedStream(double.res, chunks(4))
+
+      await tick()
+      expect(double.counts()).toEqual({ writes: 1, ends: 0, registrations: 1 })
+
+      double.fireWritable()
+      await tick()
+      // resumed once: write 2 succeeded, write 3 hit backpressure again and
+      // parked a second waiter without re-registering the handler
+      expect(double.counts()).toEqual({ writes: 3, ends: 0, registrations: 1 })
+
+      double.fireWritable()
+      await tick()
+      await pump
+      expect(double.counts()).toEqual({ writes: 4, ends: 1, registrations: 1 })
+    })
+
+    it('writable callback without a pending waiter is a no-op returning true', async () => {
+      const double = createResDouble([false])
+      const pump = handleChunkedStream(double.res, chunks(1))
+
+      await tick()
+      expect(double.fireWritable()).toBe(true)
+      await tick()
+      await pump
+
+      // stream is finished; a late drain event finds no waiter
+      expect(() => double.fireWritable()).not.toThrow()
+      expect(double.fireWritable()).toBe(true)
+    })
+
+    it('abort while a waiter is pending settles the wait and exits the pump', async () => {
+      const double = createResDouble([false])
+      const body = chunks(2)
+      const pump = handleChunkedStream(double.res, body)
+
+      await tick()
+      expect(double.counts().writes).toBe(1)
+
+      double.abort()
+      await expect(pump).rejects.toThrow('Response aborted')
+      expect(double.counts()).toEqual({ writes: 1, ends: 0, registrations: 1 })
+      // reader lock is released on exit
+      expect(() => body.getReader()).not.toThrow()
+    })
+
+    it('handles a drain cycle followed by an abort', async () => {
+      const double = createResDouble([false, false])
+      const pump = handleChunkedStream(double.res, chunks(3))
+
+      await tick()
+      expect(double.counts().writes).toBe(1)
+
+      double.fireWritable()
+      await tick()
+      // resumed and immediately backpressured again
+      expect(double.counts().writes).toBe(2)
+
+      double.abort()
+      await expect(pump).rejects.toThrow('Response aborted')
+      expect(double.counts()).toEqual({ writes: 2, ends: 0, registrations: 1 })
     })
   })
 })

--- a/packages/http-transport/tests/server.spec.ts
+++ b/packages/http-transport/tests/server.spec.ts
@@ -1,0 +1,166 @@
+import { BaseServerFormat, ProtocolFormats } from '@nmtjs/protocol/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import type {
+  HttpAdapterServer,
+  HttpTransportServerRequest,
+} from '../src/types.ts'
+import { HttpTransportServer } from '../src/server.ts'
+
+class TestJsonFormat extends BaseServerFormat {
+  accept = ['application/json']
+  contentType = 'application/json'
+
+  encode(data: unknown): ArrayBufferView {
+    return new TextEncoder().encode(JSON.stringify(data))
+  }
+
+  encodeRPC(data: unknown): ArrayBufferView {
+    return this.encode(data)
+  }
+
+  encodeBlob(): unknown {
+    return null
+  }
+
+  decode(buffer: ArrayBufferView): any {
+    return JSON.parse(
+      new TextDecoder().decode(
+        new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength),
+      ),
+    )
+  }
+
+  decodeRPC(buffer: ArrayBufferView): any {
+    return this.decode(buffer)
+  }
+}
+
+const adapterFactory = (): HttpAdapterServer => ({
+  runtime: {},
+  start: () => 'http://127.0.0.1:0',
+  stop: () => {},
+})
+
+async function createServer() {
+  const format = new TestJsonFormat()
+  const connection = {
+    encoder: format,
+    decoder: format,
+    [Symbol.asyncDispose]: () => Promise.resolve(),
+  }
+  const onConnect = vi.fn(async () => connection)
+  const resolve = vi.fn(async () => ({
+    meta: { get: () => ['get', 'post'] },
+  }))
+  const onRpc = vi.fn(async () => ({ ok: true }))
+  const params = {
+    formats: new ProtocolFormats([format]),
+    onConnect,
+    resolve,
+    onRpc,
+    onDisconnect: async () => {},
+    onMessage: async () => {},
+  }
+
+  const server = new HttpTransportServer(adapterFactory, {
+    listen: { port: 0 },
+  })
+  await server.start(params as any)
+
+  return { server, onConnect, resolve, onRpc }
+}
+
+const makeRequest = (
+  url: string,
+  headers: Record<string, string> = {},
+  method = 'GET',
+): HttpTransportServerRequest => ({
+  url: new URL(url),
+  method,
+  headers: new Headers(headers),
+})
+
+describe('HttpTransportServer.httpHandler', () => {
+  describe('GET ?payload parsing', () => {
+    it('responds 400 to malformed payload JSON', async () => {
+      const { server, onRpc } = await createServer()
+
+      const response = await server.httpHandler(
+        makeRequest('http://localhost/test?payload={bad', {
+          accept: 'application/json',
+        }),
+        null,
+        new AbortController().signal,
+      )
+
+      expect(response.status).toBe(400)
+      expect(onRpc).not.toHaveBeenCalled()
+    })
+
+    it('passes valid payload JSON to rpc handler', async () => {
+      const { server, onRpc } = await createServer()
+
+      const response = await server.httpHandler(
+        makeRequest(
+          `http://localhost/test?payload=${encodeURIComponent('{"a":1}')}`,
+          { accept: 'application/json' },
+        ),
+        null,
+        new AbortController().signal,
+      )
+
+      expect(response.status).toBe(200)
+      expect(onRpc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ payload: { a: 1 } }),
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+  })
+
+  describe('GET Accept negotiation', () => {
+    it('keeps a supported Accept header', async () => {
+      const { server, onConnect } = await createServer()
+
+      await server.httpHandler(
+        makeRequest('http://localhost/test', { accept: 'application/json' }),
+        null,
+        new AbortController().signal,
+      )
+
+      expect(onConnect).toHaveBeenCalledWith(
+        expect.objectContaining({ accept: 'application/json' }),
+      )
+    })
+
+    it('falls back to */* when Accept is not negotiable', async () => {
+      const { server, onConnect } = await createServer()
+
+      await server.httpHandler(
+        makeRequest('http://localhost/test', { accept: 'text/html' }),
+        null,
+        new AbortController().signal,
+      )
+
+      expect(onConnect).toHaveBeenCalledWith(
+        expect.objectContaining({ accept: '*/*' }),
+      )
+    })
+
+    it('keeps non-negotiable Accept for non-GET requests', async () => {
+      const { server, onConnect } = await createServer()
+
+      await server.httpHandler(
+        makeRequest('http://localhost/test', { accept: 'text/html' }, 'POST'),
+        null,
+        new AbortController().signal,
+      )
+
+      expect(onConnect).toHaveBeenCalledWith(
+        expect.objectContaining({ accept: 'text/html' }),
+      )
+    })
+  })
+})


### PR DESCRIPTION
Closes #204, closes #213

- **Chunked-stream backpressure actually engages** (`runtimes/node.ts`): `res.cork(cb)` returns the response object (always truthy), not `write()`'s boolean, so the backpressure wait was dead code and uWS buffered every un-drained byte of a streamed response in memory. Beyond the issue's sketch, uWS turned out to honor only the *first* `onWritable` registration per response — the old per-wait re-registration could never have worked, and the naive capture-only fix would deadlock on the second backpressure event. The pump now uses a single lazily-registered `onWritable` handler dispatching drain events to the current waiter, and `onAborted` wakes a pending waiter so a client disconnect mid-backpressure exits the pump instead of leaking it. Verified against a live uWS server (slow client pauses the source at ~11/100 chunks, resumes to full delivery) plus deterministic unit tests over a scripted response double (two wait/drain cycles, drain with no waiter, abort-while-waiting, drain-then-abort).
- **`x-forwarded-proto` precedence** (`runtimes/node.ts`): `header || tls ? 'https' : 'http'` parsed as `(header || tls) ? …`, so any header value — including `http` — produced `https`. The header value now decides when present, falling back to the TLS param.
- **Malformed `?payload=` returns 400** (`server.ts`): the `JSON.parse` `SyntaxError` fell into the unknown-error branch and surfaced as 500 `InternalServerError`; it now maps to `BadRequest`.
- **GET honors `Accept`** (`server.ts`): GET responses unconditionally forced the default format; the client's Accept header is now negotiated, falling back to `*/*` only when negotiation fails (tolerating browser-navigation Accept headers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chunked streaming to better handle backpressure, aborts, and client disconnects without hanging.
  * Correctly derives the request URL protocol when behind proxies by honoring `x-forwarded-proto` (fallback to listener protocol when missing).
  * Improved `Accept` negotiation for `GET` requests, using the client’s `Accept` when appropriate and safely falling back when unsupported.
  * Invalid JSON in `GET` `payload` query parameters now returns HTTP 400 with a clear “Invalid payload” error.
* **Tests**
  * Added new Node runtime and server HTTP handler test coverage for protocol selection, streaming backpressure, and chunked write/abort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->