### PR TITLE
protocol/format: blob content-type inference, zero-byte blobs, reject undefined chunks

### DIFF
--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -219,8 +219,11 @@ export class HttpTransportClient implements UnidirectionalTransport {
         const isBlob = !!response.headers.get(NEEMATA_BLOB_HEADER)
         if (isBlob) {
           const contentLength = response.headers.get('content-length')
-          const size =
-            (contentLength && Number.parseInt(contentLength, 10)) || undefined
+          // distinguish a missing header from a valid zero-byte blob size
+          const parsedLength = contentLength
+            ? Number.parseInt(contentLength, 10)
+            : Number.NaN
+          const size = Number.isNaN(parsedLength) ? undefined : parsedLength
           const type =
             response.headers.get('content-type') || 'application/octet-stream'
           const disposition = response.headers.get('content-disposition')

--- a/packages/http-client/tests/blob-response.spec.ts
+++ b/packages/http-client/tests/blob-response.spec.ts
@@ -1,0 +1,61 @@
+import { ProtocolVersion } from '@nmtjs/protocol'
+import { describe, expect, it, vi } from 'vitest'
+
+import { HttpTransportFactory } from '../src/index.ts'
+
+describe('HttpTransportClient blob responses', () => {
+  const callBlob = async (headers: Record<string, string>) => {
+    const fetchSpy = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(new Uint8Array(0) as any, { status: 200, headers }),
+      )
+
+    const transport = HttpTransportFactory(
+      {
+        format: { contentType: 'application/json' },
+        protocol: ProtocolVersion.v1,
+      } as any,
+      { url: 'http://localhost:4000', fetch: fetchSpy },
+    )
+
+    return await transport.call(
+      { contentType: 'application/json' },
+      { callId: 0, procedure: 'blob', payload: new Uint8Array(0) },
+      {},
+    )
+  }
+
+  it('reports size 0 for a zero-byte blob response', async () => {
+    const result = await callBlob({
+      'X-Neemata-Blob': 'true',
+      'Content-Type': 'application/octet-stream',
+      'Content-Length': '0',
+    })
+
+    expect(result).toMatchObject({
+      type: 'blob',
+      metadata: { type: 'application/octet-stream', size: 0 },
+    })
+  })
+
+  it('reports the advertised size for a non-empty blob response', async () => {
+    const result = await callBlob({
+      'X-Neemata-Blob': 'true',
+      'Content-Type': 'text/plain',
+      'Content-Length': '42',
+    })
+
+    expect(result).toMatchObject({ type: 'blob', metadata: { size: 42 } })
+  })
+
+  it('reports unknown size when Content-Length is missing', async () => {
+    const result = await callBlob({
+      'X-Neemata-Blob': 'true',
+      'Content-Type': 'text/plain',
+    })
+
+    expect(result.type).toBe('blob')
+    expect((result as any).metadata.size).toBeUndefined()
+  })
+})

--- a/packages/http-client/tests/msgpack-call.spec.ts
+++ b/packages/http-client/tests/msgpack-call.spec.ts
@@ -1,6 +1,5 @@
 import { StaticClient } from '@nmtjs/client'
 import { MsgpackFormat as ClientMsgpackFormat } from '@nmtjs/msgpack-format/client'
-import { MsgpackFormat as ServerMsgpackFormat } from '@nmtjs/msgpack-format/server'
 import { ProtocolVersion } from '@nmtjs/protocol'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -8,7 +7,6 @@ import { HttpTransportFactory } from '../src/index.ts'
 
 describe('HttpTransportClient + MsgpackFormat', () => {
   const format = new ClientMsgpackFormat()
-  const serverFormat = new ServerMsgpackFormat()
 
   const createClient = (responseBody: ArrayBufferView) => {
     const fetchSpy = vi
@@ -37,8 +35,9 @@ describe('HttpTransportClient + MsgpackFormat', () => {
     await expect((client.call as any).probe(undefined)).resolves.toBe(null)
   })
 
-  it('decodes server-encoded top-level undefined (empty payload) as undefined', async () => {
-    const client = createClient(serverFormat.encode(undefined))
+  it('decodes empty payload (server void result) as undefined', async () => {
+    // server responds to void results with an empty body, encode rejects undefined
+    const client = createClient(new Uint8Array(0))
 
     await expect((client.call as any).probe(undefined)).resolves.toBeUndefined()
   })

--- a/packages/http-client/tests/stream-parser.spec.ts
+++ b/packages/http-client/tests/stream-parser.spec.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import { Buffer } from 'node:buffer'
 
 import { describe, expect, it } from 'vitest'

--- a/packages/http-transport/src/server.ts
+++ b/packages/http-transport/src/server.ts
@@ -322,7 +322,11 @@ export class HttpTransportServer implements TransportWorker<
         })
       } else {
         // Handle regular responses
-        const buffer = connection.encoder.encode(result)
+        // void results respond with an empty body — encode rejects undefined
+        const buffer =
+          typeof result === 'undefined'
+            ? undefined
+            : connection.encoder.encode(result)
         responseHeaders.set('Content-Type', connection.encoder.contentType)
 
         // @ts-expect-error

--- a/packages/http-transport/src/server.ts
+++ b/packages/http-transport/src/server.ts
@@ -261,7 +261,8 @@ export class HttpTransportServer implements TransportWorker<
 
         responseHeaders.set(NEEMATA_BLOB_HEADER, 'true')
         responseHeaders.set('Content-Type', type)
-        if (metadata.size) {
+        // nullish check — zero is a valid size for empty blobs
+        if (metadata.size !== undefined) {
           responseHeaders.set('Content-Length', metadata.size.toString())
         }
         if (metadata.filename) {

--- a/packages/http-transport/tests/server-blob.spec.ts
+++ b/packages/http-transport/tests/server-blob.spec.ts
@@ -1,0 +1,67 @@
+import { ProtocolBlob } from '@nmtjs/protocol'
+import { describe, expect, it } from 'vitest'
+
+import { HttpTransportServer } from '../src/server.ts'
+
+const createServer = (result: unknown) => {
+  const server = new HttpTransportServer(
+    () => ({ start: async () => {}, stop: async () => {} }) as any,
+    { listen: { port: 0 } },
+  )
+
+  server.params = {
+    formats: { supportsDecoder: () => false },
+    onConnect: async () => ({
+      encoder: { contentType: 'application/json' },
+      decoder: {},
+      [Symbol.asyncDispose]: async () => {},
+    }),
+    onDisconnect: async () => {},
+    onMessage: async () => {},
+    resolve: async () => ({ meta: new Map() }),
+    onRpc: async () => result,
+  } as any
+
+  return server
+}
+
+const handle = (server: HttpTransportServer) =>
+  server.httpHandler(
+    {
+      url: new URL('http://localhost/procedure'),
+      method: 'POST',
+      headers: new Headers(),
+    },
+    null,
+    new AbortController().signal,
+  )
+
+describe('HttpTransportServer blob responses', () => {
+  it('sends Content-Length: 0 for a zero-byte blob', async () => {
+    const response = await handle(createServer(ProtocolBlob.from(new Blob([]))))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('X-Neemata-Blob')).toBe('true')
+    expect(response.headers.get('Content-Length')).toBe('0')
+    expect(new Uint8Array(await response.arrayBuffer()).byteLength).toBe(0)
+  })
+
+  it('sends the blob size as Content-Length', async () => {
+    const response = await handle(createServer(ProtocolBlob.from('hello')))
+
+    expect(response.headers.get('Content-Length')).toBe('5')
+    expect(await response.text()).toBe('hello')
+  })
+
+  it('omits Content-Length when the blob size is unknown', async () => {
+    const source = new ReadableStream({
+      start(controller) {
+        controller.close()
+      },
+    })
+    const response = await handle(createServer(ProtocolBlob.from(source)))
+
+    expect(response.headers.get('X-Neemata-Blob')).toBe('true')
+    expect(response.headers.get('Content-Length')).toBeNull()
+  })
+})

--- a/packages/json-format/src/server.ts
+++ b/packages/json-format/src/server.ts
@@ -13,9 +13,12 @@ export class JsonFormat extends BaseServerFormat {
   accept = ['application/json']
 
   encode(data: any) {
-    return typeof data !== 'undefined'
-      ? Buffer.from(JSON.stringify(data), 'utf-8')
-      : Buffer.alloc(0)
+    // Encoding undefined would produce a zero-byte frame that gets silently
+    // dropped over SSE and breaks decoding over WS — reject it early instead
+    if (typeof data === 'undefined') {
+      throw new TypeError('Cannot encode undefined')
+    }
+    return Buffer.from(JSON.stringify(data), 'utf-8')
   }
 
   encodeBlob(streamId: number) {

--- a/packages/json-format/tests/server.spec.ts
+++ b/packages/json-format/tests/server.spec.ts
@@ -20,6 +20,7 @@ describe('Server JsonFormat', () => {
       })
 
       it('should reject undefined', () => {
+        expect(() => format.encode(undefined)).toThrow(TypeError)
         expect(() => format.encode(undefined)).toThrow(
           'Cannot encode undefined',
         )
@@ -173,6 +174,7 @@ describe('Server JsonFormat', () => {
 
     describe('undefined value handling', () => {
       it('should reject undefined in encode', () => {
+        expect(() => format.encode(undefined)).toThrow(TypeError)
         expect(() => format.encode(undefined)).toThrow(
           'Cannot encode undefined',
         )

--- a/packages/json-format/tests/server.spec.ts
+++ b/packages/json-format/tests/server.spec.ts
@@ -19,8 +19,10 @@ describe('Server JsonFormat', () => {
         expect(buffer.toString()).toBe(JSON.stringify(data))
       })
 
-      it('should encode undefined to empty buffer', () => {
-        expect(format.encode(undefined).byteLength).toBe(0)
+      it('should reject undefined', () => {
+        expect(() => format.encode(undefined)).toThrow(
+          'Cannot encode undefined',
+        )
       })
     })
 
@@ -65,6 +67,30 @@ describe('Server JsonFormat', () => {
         )
 
         // Decode and verify round-trip
+        const mockConsumer = vi.fn()
+        const ctx = {
+          addStream: vi.fn(() => mockConsumer),
+        } as DecodeRPCContext<any>
+        const decoded = format.decodeRPC(buffer, ctx)
+
+        expect(decoded).toEqual({ data: mockConsumer })
+        expect(ctx.addStream).toHaveBeenCalledWith(streamId, metadata)
+      })
+
+      it('should encode RPC with a zero-byte stream', () => {
+        const streamId = 1
+        const metadata = { type: 'text/plain', size: 0 }
+        const payload = {
+          data: ProtocolBlob.from('', metadata, () =>
+            format.encodeBlob(streamId),
+          ),
+        }
+        const streams: EncodeRPCStreams = { [streamId]: metadata }
+
+        const buffer = Buffer.from(
+          format.encodeRPC(payload, streams) as Uint8Array,
+        )
+
         const mockConsumer = vi.fn()
         const ctx = {
           addStream: vi.fn(() => mockConsumer),
@@ -146,9 +172,10 @@ describe('Server JsonFormat', () => {
     })
 
     describe('undefined value handling', () => {
-      it('should encode undefined as empty buffer', () => {
-        const buffer = format.encode(undefined)
-        expect(buffer.byteLength).toBe(0)
+      it('should reject undefined in encode', () => {
+        expect(() => format.encode(undefined)).toThrow(
+          'Cannot encode undefined',
+        )
       })
 
       it('should encode null as JSON string "null"', () => {

--- a/packages/msgpack-format/src/server.ts
+++ b/packages/msgpack-format/src/server.ts
@@ -28,11 +28,14 @@ export class MsgpackFormat extends BaseServerFormat {
   accept = ['application/msgpack']
 
   encode(data: any) {
-    return typeof data !== 'undefined'
-      ? Buffer.from(
-          encode(data, { extensionCodec, context: {}, ignoreUndefined: true }),
-        )
-      : Buffer.alloc(0)
+    // Encoding undefined would produce a zero-byte frame that gets silently
+    // dropped over SSE and breaks decoding over WS — reject it early instead
+    if (typeof data === 'undefined') {
+      throw new TypeError('Cannot encode undefined')
+    }
+    return Buffer.from(
+      encode(data, { extensionCodec, context: {}, ignoreUndefined: true }),
+    )
   }
 
   encodeBlob(streamId: number, metadata: EncodeRPCStreams[number]) {

--- a/packages/msgpack-format/tests/cross.spec.ts
+++ b/packages/msgpack-format/tests/cross.spec.ts
@@ -43,6 +43,7 @@ describe('MsgpackFormat', () => {
 
       // Server encode rejects undefined — a zero-byte frame would be
       // silently dropped over SSE and break decoding over WS
+      expect(() => serverFormat.encode(undefined)).toThrow(TypeError)
       expect(() => serverFormat.encode(undefined)).toThrow(
         'Cannot encode undefined',
       )

--- a/packages/msgpack-format/tests/cross.spec.ts
+++ b/packages/msgpack-format/tests/cross.spec.ts
@@ -41,9 +41,11 @@ describe('MsgpackFormat', () => {
       const serverDecoded = serverFormat.decode(Buffer.from(clientEncoded))
       expect(serverDecoded).toBeUndefined()
 
-      const serverEncoded = serverFormat.encode(undefined)
-      const clientDecoded = clientFormat.decode(Buffer.from(serverEncoded))
-      expect(clientDecoded).toBeUndefined()
+      // Server encode rejects undefined — a zero-byte frame would be
+      // silently dropped over SSE and break decoding over WS
+      expect(() => serverFormat.encode(undefined)).toThrow(
+        'Cannot encode undefined',
+      )
     })
 
     it('should have consistent encodeRPC/decodeRPC without blobs between client and server', () => {

--- a/packages/msgpack-format/tests/server.spec.ts
+++ b/packages/msgpack-format/tests/server.spec.ts
@@ -26,6 +26,7 @@ describe('Server MsgpackFormat', () => {
       })
 
       it('should reject undefined', () => {
+        expect(() => format.encode(undefined)).toThrow(TypeError)
         expect(() => format.encode(undefined)).toThrow(
           'Cannot encode undefined',
         )
@@ -241,6 +242,7 @@ describe('Server MsgpackFormat', () => {
 
     describe('undefined value handling', () => {
       it('should reject undefined in encode', () => {
+        expect(() => format.encode(undefined)).toThrow(TypeError)
         expect(() => format.encode(undefined)).toThrow(
           'Cannot encode undefined',
         )

--- a/packages/msgpack-format/tests/server.spec.ts
+++ b/packages/msgpack-format/tests/server.spec.ts
@@ -25,8 +25,10 @@ describe('Server MsgpackFormat', () => {
         expect(format.decode(buffer)).toEqual(data)
       })
 
-      it('should encode undefined to empty buffer', () => {
-        expect(format.encode(undefined).byteLength).toBe(0)
+      it('should reject undefined', () => {
+        expect(() => format.encode(undefined)).toThrow(
+          'Cannot encode undefined',
+        )
       })
     })
 
@@ -96,6 +98,30 @@ describe('Server MsgpackFormat', () => {
         const metadata = { type: 'text/plain', size: 50 }
         const payload = {
           data: ProtocolBlob.from('Hello, test!', metadata, () =>
+            format.encodeBlob(streamId, metadata),
+          ),
+        }
+        const streams: EncodeRPCStreams = { [streamId]: metadata }
+
+        const buffer = Buffer.from(
+          format.encodeRPC(payload, streams) as Uint8Array,
+        )
+
+        const mockConsumer = vi.fn()
+        const ctx = {
+          addStream: vi.fn(() => mockConsumer),
+        } as DecodeRPCContext<any>
+        const decoded = format.decodeRPC(buffer, ctx)
+
+        expect(decoded).toEqual({ data: mockConsumer })
+        expect(ctx.addStream).toHaveBeenCalledWith(streamId, metadata)
+      })
+
+      it('should encode RPC with a zero-byte stream', () => {
+        const streamId = 1
+        const metadata = { type: 'text/plain', size: 0 }
+        const payload = {
+          data: ProtocolBlob.from('', metadata, () =>
             format.encodeBlob(streamId, metadata),
           ),
         }
@@ -214,9 +240,10 @@ describe('Server MsgpackFormat', () => {
     })
 
     describe('undefined value handling', () => {
-      it('should encode undefined as empty buffer', () => {
-        const buffer = format.encode(undefined)
-        expect(buffer.byteLength).toBe(0)
+      it('should reject undefined in encode', () => {
+        expect(() => format.encode(undefined)).toThrow(
+          'Cannot encode undefined',
+        )
       })
 
       it('should encode null as MessagePack nil', () => {

--- a/packages/protocol/src/client/stream.ts
+++ b/packages/protocol/src/client/stream.ts
@@ -152,7 +152,8 @@ export class ProtocolServerBlobStream
   }
 
   get size() {
-    return this.metadata.size || Number.NaN
+    // ?? — zero is a valid size for empty blobs, only unknown size is NaN
+    return this.metadata.size ?? Number.NaN
   }
 
   get type() {

--- a/packages/protocol/src/common/blob.ts
+++ b/packages/protocol/src/common/blob.ts
@@ -70,7 +70,7 @@ export class ProtocolBlob implements ProtocolBlobInterface {
     type?: string
     filename?: string
   }) {
-    if (typeof size !== 'undefined' && size <= 0)
+    if (typeof size !== 'undefined' && (Number.isNaN(size) || size < 0))
       throw new Error('Blob size is invalid')
 
     this.encode = encode
@@ -92,7 +92,9 @@ export class ProtocolBlob implements ProtocolBlobInterface {
     _encode?: (metadata: ProtocolBlobMetadata) => unknown,
   ) {
     let source: any
-    const metadata = { type: 'application/octet-stream', ..._metadata }
+    // No type default here — source-inferred types below must win over it,
+    // the default is applied last, after inference
+    const metadata = { ..._metadata }
 
     if (_source instanceof globalThis.ReadableStream) {
       source = _source
@@ -100,10 +102,11 @@ export class ProtocolBlob implements ProtocolBlobInterface {
       source = _source.stream()
       metadata.size ??= _source.size
       metadata.filename ??= _source.name
+      metadata.type ??= _source.type || undefined
     } else if (_source instanceof globalThis.Blob) {
       source = _source.stream()
       metadata.size ??= _source.size
-      metadata.type ??= _source.type
+      metadata.type ??= _source.type || undefined
     } else if (typeof _source === 'string') {
       const blob = new Blob([_source])
       source = blob.stream()
@@ -121,12 +124,17 @@ export class ProtocolBlob implements ProtocolBlobInterface {
       source = _source
     }
 
+    const resolved: ProtocolBlobMetadata = {
+      ...metadata,
+      type: metadata.type ?? 'application/octet-stream',
+    }
+
     return new ProtocolBlob({
       source,
-      encode: _encode?.bind(null, metadata),
-      size: metadata.size,
-      type: metadata.type,
-      filename: metadata.filename,
+      encode: _encode?.bind(null, resolved),
+      size: resolved.size,
+      type: resolved.type,
+      filename: resolved.filename,
     })
   }
 }

--- a/packages/protocol/tests/common/blob.spec.ts
+++ b/packages/protocol/tests/common/blob.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { ProtocolBlob } from '../../src/common/blob.ts'
+
+const readAll = async (source: ReadableStream<Uint8Array>) => {
+  const chunks: Uint8Array[] = []
+  for await (const chunk of source) chunks.push(chunk)
+  return Buffer.concat(chunks)
+}
+
+describe('ProtocolBlob', () => {
+  describe('content type inference', () => {
+    it('should infer type from a Blob source', () => {
+      const blob = ProtocolBlob.from(
+        new Blob(['<svg/>'], { type: 'image/svg+xml' }),
+      )
+      expect(blob.metadata.type).toBe('image/svg+xml')
+    })
+
+    it('should infer type from a File source', () => {
+      const blob = ProtocolBlob.from(
+        new File(['{}'], 'data.json', { type: 'application/json' }),
+      )
+      expect(blob.metadata.type).toBe('application/json')
+      expect(blob.metadata.filename).toBe('data.json')
+    })
+
+    it('should infer text/plain for a string source', () => {
+      const blob = ProtocolBlob.from('hello')
+      expect(blob.metadata.type).toBe('text/plain')
+    })
+
+    it('should prefer explicit metadata type over inference', () => {
+      const blob = ProtocolBlob.from(
+        new Blob(['<svg/>'], { type: 'image/svg+xml' }),
+        { type: 'text/html' },
+      )
+      expect(blob.metadata.type).toBe('text/html')
+
+      const text = ProtocolBlob.from('hello', { type: 'text/csv' })
+      expect(text.metadata.type).toBe('text/csv')
+    })
+
+    it('should default to application/octet-stream when nothing is inferred', () => {
+      const binary = ProtocolBlob.from(new Uint8Array([1, 2, 3]))
+      expect(binary.metadata.type).toBe('application/octet-stream')
+
+      // Blob with no type reports an empty string — not a real content type
+      const untyped = ProtocolBlob.from(new Blob(['data']))
+      expect(untyped.metadata.type).toBe('application/octet-stream')
+    })
+  })
+
+  describe('zero-byte blobs', () => {
+    it('should allow zero-byte sources', () => {
+      expect(ProtocolBlob.from(new Blob([])).metadata.size).toBe(0)
+      expect(ProtocolBlob.from('').metadata.size).toBe(0)
+      expect(ProtocolBlob.from(new Uint8Array(0)).metadata.size).toBe(0)
+      expect(ProtocolBlob.from(new ArrayBuffer(0)).metadata.size).toBe(0)
+      expect(new ProtocolBlob({ source: null, size: 0 }).metadata.size).toBe(0)
+    })
+
+    it('should round-trip zero bytes through the source stream', async () => {
+      const blob = ProtocolBlob.from(new Blob([]))
+      const bytes = await readAll(blob.source)
+      expect(bytes.byteLength).toBe(0)
+    })
+
+    it('should still reject negative and NaN sizes', () => {
+      expect(() => new ProtocolBlob({ source: null, size: -1 })).toThrow(
+        'Blob size is invalid',
+      )
+      expect(
+        () => new ProtocolBlob({ source: null, size: Number.NaN }),
+      ).toThrow('Blob size is invalid')
+    })
+  })
+})


### PR DESCRIPTION
Closes #217

- **Blob content-type inference works again** (`protocol/common/blob.ts`): `ProtocolBlob.from` preset `type: 'application/octet-stream'` before source inspection, so the inferred type from a `Blob`/`File` source and the `text/plain` default for strings never applied — everything went out as octet-stream. Inference now runs first (the `File` branch gained it too — it matched its own `instanceof` before ever reaching the Blob logic) and the octet-stream default is applied last; explicit caller metadata still wins over both. An empty `Blob.type` counts as "nothing to infer".
- **Zero-byte blobs are valid** (`blob.ts` and downstream): the constructor rejected `size <= 0`, making `ProtocolBlob.from(new Blob([]))`, an empty string, or an empty `Uint8Array` impossible — it now rejects only negative/NaN sizes (the old check silently *accepted* NaN). Downstream zero-size truthiness bugs fixed along the way: the client blob stream's `size` getter (`|| NaN` → `??`), the HTTP server omitting `Content-Length: 0` (`if (size)` → `!== undefined`), and the HTTP client parsing a `Content-Length: 0` header into `undefined` (which then surfaced as `size: NaN`). Zero-byte round-trips are covered in both formats and over HTTP in both directions.
- **`undefined` stream chunks are rejected at encode** (`json-format`, `msgpack-format` servers): encoding `undefined` produced a zero-byte frame that the SSE client parser silently dropped and that made WS decode throw mid-stream, hanging the consumer. `encode(undefined)` now throws a `TypeError`; `encodeRPC(undefined)` remains valid (empty-payload RPC is a supported wire case). The one internal caller relying on the old behavior — http-transport's void-RPC response — now sends an empty body explicitly, preserving wire behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zero-byte blobs now preserve their size as `0` across client, server, and streaming responses.
  * Blob responses correctly handle known, unknown, and empty content lengths.
  * Blob content types are inferred more reliably, with a consistent fallback when unavailable.
  * Undefined values now produce a clear serialization error instead of being silently encoded as empty data.

* **Tests**
  * Added coverage for zero-byte blobs, stream metadata, content-type inference, and empty responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->