### PR TITLE
gateway: single-flight closeConnection, exception-safe teardown, pending-open TTL

### DIFF
--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -96,6 +96,8 @@ export class Gateway<
       nonce: number
     }
   >()
+  // In-flight teardowns keyed by connection id, see closeConnection
+  private readonly closingConnections = new Map<string, Promise<void>>()
   public options: Required<
     Omit<GatewayOptions<ResolvedProcedure>, 'streamTimeouts'> & {
       streamTimeouts: Required<
@@ -208,14 +210,12 @@ export class Gateway<
           )
         } catch {
           state.pending.delete(nonce)
-          try {
-            await transportWorker.close?.(connection.id, {
-              code: 1001,
-              reason: 'heartbeat_timeout',
-            })
-          } finally {
-            await this.closeConnection(connection.id)
-          }
+          // Route through the single claimed teardown so the transport is
+          // closed exactly once even when a disconnect races in
+          await this.closeConnection(connection.id, {
+            code: 1001,
+            reason: 'heartbeat_timeout',
+          })
           break
         }
       }
@@ -242,6 +242,10 @@ export class Gateway<
     for (const connection of this.connections.getAll()) {
       await this.closeConnection(connection.id)
     }
+
+    // Also wait for teardowns already claimed by concurrent callers
+    // (e.g. transport disconnect) — they are no longer in the map
+    await Promise.all(this.closingConnections.values())
 
     for (const key in this.options.transports) {
       const { transport } = this.options.transports[key]
@@ -765,13 +769,33 @@ export class Gateway<
     }
   }
 
-  protected async closeConnection(connectionId: string) {
-    // Single-flight: remove from the map before any await so concurrent
-    // callers (e.g. heartbeat timeout racing transport disconnect) no-op
-    // instead of double-closing the transport and container.
-    if (!this.connections.has(connectionId)) return
+  protected closeConnection(
+    connectionId: string,
+    close: { code: number; reason: string } = { code: 1001, reason: 'closed' },
+  ): Promise<void> {
+    // Single-flight: the first caller claims the connection by removing it
+    // from the map before any await; concurrent callers (e.g. heartbeat
+    // timeout racing transport disconnect) await the same in-flight teardown
+    // instead of tearing down twice.
+    const inFlight = this.closingConnections.get(connectionId)
+    if (inFlight) return inFlight
+    if (!this.connections.has(connectionId)) return Promise.resolve()
+
     const connection = this.connections.get(connectionId)
     this.connections.remove(connectionId)
+
+    const teardown = this.teardownConnection(connection, close).finally(() => {
+      this.closingConnections.delete(connectionId)
+    })
+    this.closingConnections.set(connectionId, teardown)
+    return teardown
+  }
+
+  private async teardownConnection(
+    connection: GatewayConnection,
+    close: { code: number; reason: string },
+  ) {
+    const connectionId = connection.id
 
     // Guard each teardown step so one failure can't skip the rest.
     const guard = async (step: () => unknown) => {
@@ -789,12 +813,7 @@ export class Gateway<
     if (connection.type === ConnectionType.Bidirectional) {
       const transportWorker =
         this.options.transports[connection.transport]?.transport
-      await guard(() =>
-        transportWorker?.close?.(connectionId, {
-          code: 1001,
-          reason: 'closed',
-        }),
-      )
+      await guard(() => transportWorker?.close?.(connectionId, close))
     }
     await guard(() => connection.abortController.abort())
     await guard(() => this.rpcs.close(connectionId))

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -80,6 +80,11 @@ export interface GatewayOptions<
 
 const DEFAULT_GATEWAY_HEARTBEAT_INTERVAL = 15000
 const DEFAULT_GATEWAY_HEARTBEAT_TIMEOUT = 5000
+/**
+ * Upper bound per connection teardown step so a never-settling transport
+ * close or container disposal can't hang closeConnection() and stop().
+ */
+export const GATEWAY_TEARDOWN_STEP_TIMEOUT = 10_000
 
 export class Gateway<
   ResolvedProcedure extends GatewayResolvedProcedure = GatewayResolvedProcedure,
@@ -797,10 +802,15 @@ export class Gateway<
   ) {
     const connectionId = connection.id
 
-    // Guard each teardown step so one failure can't skip the rest.
+    // Guard and time-bound each teardown step so one failure or a
+    // never-settling promise can't skip or hang the rest.
     const guard = async (step: () => unknown) => {
       try {
-        await step()
+        await withTimeout(
+          Promise.resolve(step()),
+          GATEWAY_TEARDOWN_STEP_TIMEOUT,
+          new Error('Connection teardown step timed out'),
+        )
       } catch (error) {
         this.logger.error(
           { error, connectionId },

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -766,25 +766,40 @@ export class Gateway<
   }
 
   protected async closeConnection(connectionId: string) {
-    if (this.connections.has(connectionId)) {
-      const connection = this.connections.get(connectionId)
-      this.stopHeartbeat(connectionId, 'close')
+    // Single-flight: remove from the map before any await so concurrent
+    // callers (e.g. heartbeat timeout racing transport disconnect) no-op
+    // instead of double-closing the transport and container.
+    if (!this.connections.has(connectionId)) return
+    const connection = this.connections.get(connectionId)
+    this.connections.remove(connectionId)
 
-      const transportWorker =
-        this.options.transports[connection.transport]?.transport
-      if (connection.type === ConnectionType.Bidirectional) {
-        await transportWorker?.close?.(connectionId, {
-          code: 1001,
-          reason: 'closed',
-        })
+    // Guard each teardown step so one failure can't skip the rest.
+    const guard = async (step: () => unknown) => {
+      try {
+        await step()
+      } catch (error) {
+        this.logger.error(
+          { error, connectionId },
+          'Error during connection teardown',
+        )
       }
-      connection.abortController.abort()
-      await connection.container.dispose()
     }
 
-    this.rpcs.close(connectionId)
-    this.blobStreams.cleanupConnection(connectionId)
-    this.connections.remove(connectionId)
+    await guard(() => this.stopHeartbeat(connectionId, 'close'))
+    if (connection.type === ConnectionType.Bidirectional) {
+      const transportWorker =
+        this.options.transports[connection.transport]?.transport
+      await guard(() =>
+        transportWorker?.close?.(connectionId, {
+          code: 1001,
+          reason: 'closed',
+        }),
+      )
+    }
+    await guard(() => connection.abortController.abort())
+    await guard(() => this.rpcs.close(connectionId))
+    await guard(() => this.blobStreams.cleanupConnection(connectionId))
+    await guard(() => connection.container.dispose())
   }
 
   protected createBlobFunction(

--- a/packages/gateway/tests/close-connection.spec.ts
+++ b/packages/gateway/tests/close-connection.spec.ts
@@ -1,0 +1,105 @@
+import { Hooks } from '@nmtjs/core'
+import { ConnectionType, ProtocolVersion } from '@nmtjs/protocol'
+import { ProtocolFormats } from '@nmtjs/protocol/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { GatewayApi } from '../src/api.ts'
+import { Gateway } from '../src/gateway.ts'
+import {
+  createTestContainer,
+  createTestLogger,
+  createTestServerFormat,
+} from './_helpers/test-utils.ts'
+
+const createGateway = (transportOverrides: Record<string, any> = {}) => {
+  const logger = createTestLogger()
+  const container = createTestContainer({ logger })
+  const serverFormat = createTestServerFormat()
+
+  const api: GatewayApi = {
+    resolve: vi.fn(async () => ({ name: 'close/test', stream: false })),
+    call: vi.fn(async () => undefined),
+  }
+
+  let params: any
+
+  const transport = {
+    start: vi.fn(async (_params) => {
+      params = _params
+      return 'test://'
+    }),
+    stop: vi.fn(async () => {}),
+    send: vi.fn((_connectionId: string, _buffer: ArrayBufferView) => true),
+    close: vi.fn((_connectionId: string) => {}),
+    ...transportOverrides,
+  }
+
+  const gateway = new Gateway({
+    logger,
+    container,
+    hooks: new Hooks(),
+    formats: new ProtocolFormats([serverFormat]),
+    transports: { test: { transport } },
+    api,
+    heartbeat: false,
+  })
+
+  const connect = async () => {
+    await gateway.start()
+    return params.onConnect({
+      type: ConnectionType.Bidirectional,
+      protocolVersion: ProtocolVersion.v1,
+      accept: serverFormat.contentType,
+      contentType: serverFormat.contentType,
+      data: {},
+    })
+  }
+
+  return { gateway, transport, connect, getParams: () => params }
+}
+
+describe('Gateway closeConnection', () => {
+  it('disposes exactly once for concurrent close calls', async () => {
+    const { gateway, transport, connect, getParams } = createGateway({
+      // Suspend teardown across an await point so both callers overlap
+      close: vi.fn(
+        () => new Promise<void>((resolve) => setTimeout(resolve, 10)),
+      ),
+    })
+
+    const connection = await connect()
+    const disposeSpy = vi.spyOn(connection.container, 'dispose')
+
+    await Promise.all([
+      getParams().onDisconnect(connection.id),
+      getParams().onDisconnect(connection.id),
+    ])
+
+    expect(transport.close).toHaveBeenCalledTimes(1)
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+    expect(gateway.connections.has(connection.id)).toBe(false)
+  })
+
+  it('still disposes container and aborts RPCs when transport.close throws', async () => {
+    const { gateway, connect, getParams } = createGateway({
+      close: vi.fn(async () => {
+        throw new Error('close failed')
+      }),
+    })
+
+    const connection = await connect()
+    const disposeSpy = vi.spyOn(connection.container, 'dispose')
+
+    const rpcController = new AbortController()
+    gateway.rpcs.set(connection.id, 1, rpcController)
+
+    await expect(
+      getParams().onDisconnect(connection.id),
+    ).resolves.toBeUndefined()
+
+    expect(connection.abortController.signal.aborted).toBe(true)
+    expect(rpcController.signal.aborted).toBe(true)
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+    expect(gateway.connections.has(connection.id)).toBe(false)
+  })
+})

--- a/packages/gateway/tests/close-connection.spec.ts
+++ b/packages/gateway/tests/close-connection.spec.ts
@@ -4,7 +4,7 @@ import { ProtocolFormats } from '@nmtjs/protocol/server'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { GatewayApi } from '../src/api.ts'
-import { Gateway } from '../src/gateway.ts'
+import { GATEWAY_TEARDOWN_STEP_TIMEOUT, Gateway } from '../src/gateway.ts'
 import {
   createTestContainer,
   createTestLogger,
@@ -135,6 +135,32 @@ describe('Gateway closeConnection', () => {
 
     expect(stopped).toBe(true)
     expect(disposeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('completes teardown and stop() when transport.close never settles', async () => {
+    vi.useFakeTimers()
+
+    const { gateway, connect, getParams } = createGateway({
+      close: vi.fn(() => new Promise<void>(() => {})),
+    })
+
+    const connection = await connect()
+    const disposeSpy = vi.spyOn(connection.container, 'dispose')
+
+    const disconnect = getParams().onDisconnect(connection.id)
+    let stopped = false
+    const stop = gateway.stop().then(() => {
+      stopped = true
+    })
+
+    // The step timeout abandons the hung close and teardown moves on
+    await vi.advanceTimersByTimeAsync(GATEWAY_TEARDOWN_STEP_TIMEOUT)
+    await Promise.all([disconnect, stop])
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+    expect(stopped).toBe(true)
+
+    vi.useRealTimers()
   })
 
   it('heartbeat timeout racing disconnect closes and disposes exactly once', async () => {

--- a/packages/gateway/tests/close-connection.spec.ts
+++ b/packages/gateway/tests/close-connection.spec.ts
@@ -11,7 +11,10 @@ import {
   createTestServerFormat,
 } from './_helpers/test-utils.ts'
 
-const createGateway = (transportOverrides: Record<string, any> = {}) => {
+const createGateway = (
+  transportOverrides: Record<string, any> = {},
+  gatewayOverrides: Record<string, any> = {},
+) => {
   const logger = createTestLogger()
   const container = createTestContainer({ logger })
   const serverFormat = createTestServerFormat()
@@ -42,6 +45,7 @@ const createGateway = (transportOverrides: Record<string, any> = {}) => {
     transports: { test: { transport } },
     api,
     heartbeat: false,
+    ...gatewayOverrides,
   })
 
   const connect = async () => {
@@ -101,5 +105,61 @@ describe('Gateway closeConnection', () => {
     expect(rpcController.signal.aborted).toBe(true)
     expect(disposeSpy).toHaveBeenCalledTimes(1)
     expect(gateway.connections.has(connection.id)).toBe(false)
+  })
+
+  it('stop() waits for a teardown claimed by a concurrent caller', async () => {
+    let resolveClose!: () => void
+    const { gateway, connect, getParams } = createGateway({
+      close: vi.fn(
+        () => new Promise<void>((resolve) => (resolveClose = resolve)),
+      ),
+    })
+
+    const connection = await connect()
+    const disposeSpy = vi.spyOn(connection.container, 'dispose')
+
+    // Disconnect claims the teardown and parks on transport.close
+    const disconnect = getParams().onDisconnect(connection.id)
+
+    let stopped = false
+    const stop = gateway.stop().then(() => {
+      stopped = true
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(stopped).toBe(false)
+    expect(disposeSpy).not.toHaveBeenCalled()
+
+    resolveClose()
+    await Promise.all([disconnect, stop])
+
+    expect(stopped).toBe(true)
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('heartbeat timeout racing disconnect closes and disposes exactly once', async () => {
+    vi.useFakeTimers()
+
+    const { gateway, transport, connect, getParams } = createGateway(
+      {},
+      { heartbeat: { interval: 1000, timeout: 500 } },
+    )
+
+    const connection = await connect()
+    const disposeSpy = vi.spyOn(connection.container, 'dispose')
+
+    // Ping goes out, then a transport disconnect races the pending heartbeat:
+    // stopping the heartbeat rejects the pending Pong future, sending the
+    // heartbeat loop into its timeout path against the claimed teardown
+    await vi.advanceTimersByTimeAsync(1000)
+    const disconnect = getParams().onDisconnect(connection.id)
+    await vi.advanceTimersByTimeAsync(500)
+    await disconnect
+
+    expect(transport.close).toHaveBeenCalledTimes(1)
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+    expect(gateway.connections.has(connection.id)).toBe(false)
+
+    vi.useRealTimers()
   })
 })

--- a/packages/ws-transport/src/server.ts
+++ b/packages/ws-transport/src/server.ts
@@ -16,6 +16,13 @@ import {
   NotFoundHttpResponse,
 } from './utils.ts'
 
+/**
+ * How long an upgraded connection may stay without its `open` hook firing
+ * before it is reaped. Sockets that die between upgrade and open never get a
+ * `close` hook, which would leak the gateway connection and its container.
+ */
+export const WS_PENDING_OPEN_TTL = 10_000
+
 export function createWSTransportWorker(
   adapterFactory: WsAdapterServerFactory<any>,
   options: WsTransportOptions,
@@ -33,6 +40,8 @@ export class WsTransportServer implements TransportWorker<
     ApplicationResolvedProcedure
   >
   clients = new Map<string, Peer>()
+  // Reap timers for upgraded-but-not-opened connections, see WS_PENDING_OPEN_TTL
+  pendingOpen = new Map<string, ReturnType<typeof setTimeout>>()
 
   constructor(
     protected readonly adapterFactory: WsAdapterServerFactory<any>,
@@ -52,6 +61,8 @@ export class WsTransportServer implements TransportWorker<
   }
 
   async stop(): Promise<void> {
+    for (const timer of this.pendingOpen.values()) clearTimeout(timer)
+    this.pendingOpen.clear()
     for (const peer of this.clients.values()) {
       try {
         peer.close(1001, 'Transport stopped')
@@ -132,6 +143,8 @@ export class WsTransportServer implements TransportWorker<
             data: request,
           })
 
+          this.schedulePendingOpenReap(connection.id)
+
           return { context: { connectionId: connection.id } }
         } catch (error) {
           console.error('Failed to upgrade WebSocket connection', error)
@@ -140,6 +153,7 @@ export class WsTransportServer implements TransportWorker<
       },
       open: (peer) => {
         const { connectionId } = peer.context
+        this.clearPendingOpenReap(connectionId)
         this.clients.set(connectionId, peer)
       },
       message: async (peer, message) => {
@@ -165,6 +179,7 @@ export class WsTransportServer implements TransportWorker<
         )
       },
       close: async (peer) => {
+        this.clearPendingOpenReap(peer.context.connectionId)
         this.clients.delete(peer.context.connectionId)
         try {
           await this.params.onDisconnect(peer.context.connectionId)
@@ -176,6 +191,26 @@ export class WsTransportServer implements TransportWorker<
         }
       },
     }) as Hooks
+  }
+
+  private schedulePendingOpenReap(connectionId: string) {
+    const timer = setTimeout(() => {
+      this.pendingOpen.delete(connectionId)
+      Promise.resolve(this.params.onDisconnect(connectionId)).catch((error) => {
+        console.error(
+          `Failed to reap never-opened WebSocket connection ${connectionId}`,
+          error,
+        )
+      })
+    }, WS_PENDING_OPEN_TTL)
+    this.pendingOpen.set(connectionId, timer)
+  }
+
+  private clearPendingOpenReap(connectionId: string) {
+    const timer = this.pendingOpen.get(connectionId)
+    if (timer === undefined) return
+    this.pendingOpen.delete(connectionId)
+    clearTimeout(timer)
   }
 
   private createServer() {

--- a/packages/ws-transport/src/server.ts
+++ b/packages/ws-transport/src/server.ts
@@ -153,7 +153,19 @@ export class WsTransportServer implements TransportWorker<
       },
       open: (peer) => {
         const { connectionId } = peer.context
-        this.clearPendingOpenReap(connectionId)
+        // If the reap already claimed this connection, the gateway side is
+        // gone — close the late peer instead of registering a zombie
+        if (!this.clearPendingOpenReap(connectionId)) {
+          try {
+            peer.close(1001, 'Closed')
+          } catch (error) {
+            console.error(
+              `Failed to close late WebSocket connection ${connectionId}`,
+              error,
+            )
+          }
+          return
+        }
         this.clients.set(connectionId, peer)
       },
       message: async (peer, message) => {
@@ -206,11 +218,14 @@ export class WsTransportServer implements TransportWorker<
     this.pendingOpen.set(connectionId, timer)
   }
 
+  // Returns whether the pending entry was claimed by this caller; false
+  // means the reap timer already fired (or there was no pending entry)
   private clearPendingOpenReap(connectionId: string) {
     const timer = this.pendingOpen.get(connectionId)
-    if (timer === undefined) return
+    if (timer === undefined) return false
     this.pendingOpen.delete(connectionId)
     clearTimeout(timer)
+    return true
   }
 
   private createServer() {

--- a/packages/ws-transport/src/server.ts
+++ b/packages/ws-transport/src/server.ts
@@ -100,6 +100,9 @@ export class WsTransportServer implements TransportWorker<
     connectionId: string,
     options: { code?: number; reason?: string } = {},
   ) {
+    // A gateway-initiated close may land before `open` (e.g. heartbeat
+    // timeout); claim the reap timer so it can't fire a redundant disconnect
+    this.clearPendingOpenReap(connectionId)
     const peer = this.clients.get(connectionId)
     if (!peer) return
     this.clients.delete(connectionId)

--- a/packages/ws-transport/tests/pending-open.spec.ts
+++ b/packages/ws-transport/tests/pending-open.spec.ts
@@ -70,6 +70,28 @@ describe('WsTransportServer pending-open TTL', () => {
     expect(onDisconnect).not.toHaveBeenCalled()
   })
 
+  it('closes a peer whose open arrives after the reap', async () => {
+    const { server, getHooks } = createServer()
+    const onConnect = vi.fn(async () => ({ id: 'conn-1' }))
+    const onDisconnect = vi.fn(async () => {})
+
+    await server.start({ onConnect, onDisconnect } as any)
+    await getHooks().upgrade!(upgradeRequest)
+
+    await vi.advanceTimersByTimeAsync(WS_PENDING_OPEN_TTL)
+    expect(onDisconnect).toHaveBeenCalledTimes(1)
+
+    const peer = {
+      context: { connectionId: 'conn-1' },
+      close: vi.fn(),
+      send: vi.fn(),
+    } as any
+    getHooks().open!(peer)
+
+    expect(peer.close).toHaveBeenCalledWith(1001, 'Closed')
+    expect(server.clients.has('conn-1')).toBe(false)
+  })
+
   it('cancels the reap timer when close fires before open', async () => {
     const { server, getHooks } = createServer()
     const onConnect = vi.fn(async () => ({ id: 'conn-1' }))

--- a/packages/ws-transport/tests/pending-open.spec.ts
+++ b/packages/ws-transport/tests/pending-open.spec.ts
@@ -1,0 +1,88 @@
+import type { Hooks } from 'crossws'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { WS_PENDING_OPEN_TTL, WsTransportServer } from '../src/server.ts'
+
+const createServer = () => {
+  let hooks: Hooks
+  const adapterFactory = vi.fn((params: any) => {
+    hooks = params.wsHooks
+    return {
+      start: vi.fn(async () => 'ws://test'),
+      stop: vi.fn(async () => {}),
+    }
+  })
+
+  const server = new WsTransportServer(adapterFactory, {
+    listen: { port: 0 },
+  })
+
+  return { server, getHooks: () => hooks! }
+}
+
+const upgradeRequest = {
+  url: 'http://localhost/',
+  headers: new Headers(),
+  method: 'GET',
+} as any
+
+describe('WsTransportServer pending-open TTL', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reaps a connection whose open hook never fires', async () => {
+    const { server, getHooks } = createServer()
+    const onConnect = vi.fn(async () => ({ id: 'conn-1' }))
+    const onDisconnect = vi.fn(async () => {})
+
+    await server.start({ onConnect, onDisconnect } as any)
+    await getHooks().upgrade!(upgradeRequest)
+
+    expect(onConnect).toHaveBeenCalledTimes(1)
+    expect(onDisconnect).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(WS_PENDING_OPEN_TTL)
+
+    expect(onDisconnect).toHaveBeenCalledTimes(1)
+    expect(onDisconnect).toHaveBeenCalledWith('conn-1')
+  })
+
+  it('does not reap a connection once open fires', async () => {
+    const { server, getHooks } = createServer()
+    const onConnect = vi.fn(async () => ({ id: 'conn-1' }))
+    const onDisconnect = vi.fn(async () => {})
+
+    await server.start({ onConnect, onDisconnect } as any)
+    await getHooks().upgrade!(upgradeRequest)
+
+    getHooks().open!({
+      context: { connectionId: 'conn-1' },
+      send: vi.fn(),
+    } as any)
+
+    await vi.advanceTimersByTimeAsync(WS_PENDING_OPEN_TTL * 2)
+
+    expect(onDisconnect).not.toHaveBeenCalled()
+  })
+
+  it('cancels the reap timer when close fires before open', async () => {
+    const { server, getHooks } = createServer()
+    const onConnect = vi.fn(async () => ({ id: 'conn-1' }))
+    const onDisconnect = vi.fn(async () => {})
+
+    await server.start({ onConnect, onDisconnect } as any)
+    await getHooks().upgrade!(upgradeRequest)
+
+    await getHooks().close!({ context: { connectionId: 'conn-1' } } as any, {})
+
+    await vi.advanceTimersByTimeAsync(WS_PENDING_OPEN_TTL * 2)
+
+    // Only the close hook itself disconnects; the timer must not fire again
+    expect(onDisconnect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/ws-transport/tests/pending-open.spec.ts
+++ b/packages/ws-transport/tests/pending-open.spec.ts
@@ -70,6 +70,22 @@ describe('WsTransportServer pending-open TTL', () => {
     expect(onDisconnect).not.toHaveBeenCalled()
   })
 
+  it('clears the reap timer when the gateway closes a pending-open connection', async () => {
+    const { server, getHooks } = createServer()
+    const onConnect = vi.fn(async () => ({ id: 'conn-1' }))
+    const onDisconnect = vi.fn(async () => {})
+
+    await server.start({ onConnect, onDisconnect } as any)
+    await getHooks().upgrade!(upgradeRequest)
+
+    // Gateway-initiated close (e.g. heartbeat timeout) before `open` fires
+    server.close('conn-1', { code: 1001, reason: 'heartbeat_timeout' })
+
+    await vi.advanceTimersByTimeAsync(WS_PENDING_OPEN_TTL * 2)
+
+    expect(onDisconnect).not.toHaveBeenCalled()
+  })
+
   it('closes a peer whose open arrives after the reap', async () => {
     const { server, getHooks } = createServer()
     const onConnect = vi.fn(async () => ({ id: 'conn-1' }))


### PR DESCRIPTION
Closes #212

- **Single-flight, awaitable teardown** (`gateway.ts`): heartbeat timeout and transport `onDisconnect` could both pass the `connections.has()` check before removal, double-running `transport.close()` and container disposal. `closeConnection` now claims the connection by removing it from the map before any await; losing concurrent callers — and `Gateway.stop()` — receive the winner's in-flight teardown promise instead of returning early, so stop() can't resolve while a claimed connection's disposal is still running.
- **Exception-safe teardown steps**: a rejecting `transport.close()` previously exited the method, leaving RPC abort controllers, blob stream state, and the DI container alive. Every step (heartbeat stop, transport close, abort, RPC cleanup, blob cleanup, container dispose) now runs through a guard that logs failures and continues, so one failing step can't skip the rest.
- **Heartbeat timeout rides the same teardown**: the heartbeat path called `transportWorker.close(..., 'heartbeat_timeout')` directly and *then* `closeConnection`, closing the transport twice. `closeConnection` now takes an optional close code/reason it passes to the transport step, and the heartbeat path only calls that.
- **Pending-open TTL for upgraded-but-never-opened WS connections** (`ws-transport`): `onConnect` runs full DI/identity setup during the WS upgrade; if the socket died before `open`, the gateway held a peerless connection reaped only by heartbeat (or never, if disabled). A 10s reap timer set at upgrade and cleared on open/close now disconnects such connections. Claiming the pending entry is atomic (map delete), so a late crossws `open` arriving after the reap can't register a zombie peer — it's closed immediately.

Regression tests: concurrent close disposing exactly once, throwing transport.close still disposing everything, stop() pending until a concurrently-claimed teardown finishes, heartbeat-timeout racing disconnect (one close, one disposal), TTL reap of a never-opened connection, open/close canceling the reap, and late open after reap being rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection shutdown handling during simultaneous disconnects, heartbeat timeouts, and gateway stops.
  * Ensured failed transport closures do not prevent cleanup of connection resources.
  * Automatically removes WebSocket connections that never complete the opening process within 10 seconds.
  * Prevented late-opening or already-closed sockets from being registered as active connections.

* **Tests**
  * Added coverage for concurrent shutdowns, cleanup failures, gateway stopping, heartbeat races, and pending WebSocket connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->