### PR TITLE
http-transport: safe cors defaults, request body size cap

### DIFF
--- a/packages/http-transport/src/constants.ts
+++ b/packages/http-transport/src/constants.ts
@@ -2,6 +2,9 @@ import type { MetadataKind } from '@nmtjs/application'
 import { createMeta } from '@nmtjs/application'
 import { ErrorCode } from '@nmtjs/protocol'
 
+// Matches Bun's maxRequestBodySize default so all runtimes behave the same
+export const DEFAULT_MAX_REQUEST_BODY_SIZE = 128 * 1024 * 1024
+
 export enum HttpStatus {
   Continue = 100,
   SwitchingProtocols = 101,

--- a/packages/http-transport/src/runtimes/bun.ts
+++ b/packages/http-transport/src/runtimes/bun.ts
@@ -26,6 +26,9 @@ function adapterFactory(params: HttpAdapterParams<'bun'>): HttpAdapterServer {
 
     return globalThis.Bun.serve({
       ...params.runtime,
+      // Bun's own default (128MiB) applies when neither option is set
+      maxRequestBodySize:
+        params.runtime?.maxRequestBodySize ?? params.maxRequestBodySize,
       unix: params.listen.unix as string,
       port: params.listen.port ?? 0,
       hostname: params.listen.hostname,

--- a/packages/http-transport/src/runtimes/node.ts
+++ b/packages/http-transport/src/runtimes/node.ts
@@ -10,12 +10,14 @@ import type {
   HttpAdapterServer,
   HttpTransportOptions,
 } from '../types.ts'
+import { DEFAULT_MAX_REQUEST_BODY_SIZE } from '../constants.ts'
 import * as injectables from '../injectables.ts'
 import { createHTTPTransportWorker } from '../server.ts'
 import {
   InternalServerErrorHttpResponse,
   NotFoundHttpResponse,
   OkResponse,
+  PayloadTooLargeError,
 } from '../utils.ts'
 
 const statusResponse = OkResponse()
@@ -26,6 +28,7 @@ type UwsResponse = Parameters<
 >[0] & { aborted?: boolean }
 
 function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
+  const maxBodySize = params.maxRequestBodySize ?? DEFAULT_MAX_REQUEST_BODY_SIZE
   const server = params.tls
     ? SSLApp({
         passphrase: params.tls.passphrase,
@@ -70,12 +73,22 @@ function adapterFactory(params: HttpAdapterParams<'node'>): HttpAdapterServer {
       const url = new URL(req.getUrl(), `${proto}://${host}`)
       url.search = req.getQuery() ? `?${req.getQuery()}` : ''
       try {
+        // uWS delivers chunks without backpressure, so cap what gets copied
+        // into memory before the whole body arrives
+        let received = 0
+        let capped = false
         const body = new ReadableStream<Buffer>({
           start(controller) {
             bodyController = controller
             res.onDataV2((chunk, maxRemainingBodyLength) => {
-              if (aborted) return
+              if (aborted || capped) return
               if (chunk) {
+                received += chunk.byteLength
+                if (received > maxBodySize) {
+                  capped = true
+                  controller.error(new PayloadTooLargeError())
+                  return
+                }
                 const copy = Buffer.allocUnsafe(chunk.byteLength)
                 copy.set(new Uint8Array(chunk))
                 controller.enqueue(copy)

--- a/packages/http-transport/src/server.ts
+++ b/packages/http-transport/src/server.ts
@@ -28,16 +28,19 @@ import type {
 } from './types.ts'
 import {
   AllowedHttpMethod,
+  DEFAULT_MAX_REQUEST_BODY_SIZE,
   HttpCodeMap,
   HttpStatus,
   HttpStatusText,
 } from './constants.ts'
 import * as injections from './injectables.ts'
+import { PayloadTooLargeError } from './utils.ts'
 
 const NEEMATA_BLOB_HEADER = 'X-Neemata-Blob'
 const DEFAULT_ALLOWED_METHODS = Object.freeze(['post']) as ('get' | 'post')[]
+// No allowCredentials here: reflecting arbitrary origins with credentials
+// would let any website make cookie-authed requests
 const DEFAULT_CORS_PARAMS = Object.freeze({
-  allowCredentials: 'true',
   allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowHeaders: [
     'Content-Type',
@@ -51,6 +54,11 @@ const DEFAULT_CORS_PARAMS = Object.freeze({
   requestMethod: undefined,
   exposeHeaders: [],
   requestHeaders: [],
+}) satisfies Omit<HttpTransportCorsCustomParams, 'origin'>
+// Credentials are safe to allow when the user explicitly vetted the origin
+const EXPLICIT_ORIGIN_CORS_PARAMS = Object.freeze({
+  ...DEFAULT_CORS_PARAMS,
+  allowCredentials: 'true',
 }) satisfies Omit<HttpTransportCorsCustomParams, 'origin'>
 const CORS_HEADERS_MAP: Record<
   keyof HttpTransportCorsCustomParams | 'origin',
@@ -82,6 +90,7 @@ export class HttpTransportServer implements TransportWorker<
 > {
   #server: HttpAdapterServer
   #corsOptions?: HttpTransportOptions['cors']
+  #maxRequestBodySize: number
 
   params!: TransportWorkerParams<
     ConnectionType.Unidirectional,
@@ -94,6 +103,8 @@ export class HttpTransportServer implements TransportWorker<
   ) {
     this.#server = this.createServer()
     this.#corsOptions = this.options.cors
+    this.#maxRequestBodySize =
+      this.options.maxRequestBodySize ?? DEFAULT_MAX_REQUEST_BODY_SIZE
   }
 
   async start(
@@ -170,7 +181,17 @@ export class HttpTransportServer implements TransportWorker<
           payload = new ProtocolClientStream(-1, { size, type })
           bodyStream.pipe(payload)
         } else {
-          const buffer = Buffer.concat(await bodyStream.toArray())
+          const chunks: Buffer[] = []
+          let received = 0
+          for await (const chunk of bodyStream) {
+            received += chunk.byteLength
+            // Reject mid-stream to avoid buffering unbounded payloads
+            if (received > this.#maxRequestBodySize) {
+              throw new PayloadTooLargeError()
+            }
+            chunks.push(chunk)
+          }
+          const buffer = Buffer.concat(chunks)
           if (buffer.byteLength > 0) {
             payload = connection.decoder.decode(buffer)
           }
@@ -282,6 +303,17 @@ export class HttpTransportServer implements TransportWorker<
         })
       }
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        const status = HttpStatus.PayloadTooLarge
+        const text = HttpStatusText[status]
+
+        return new Response(text, {
+          status,
+          statusText: text,
+          headers: responseHeaders,
+        })
+      }
+
       if (error instanceof UnsupportedFormatError) {
         const status =
           error instanceof UnsupportedContentTypeError
@@ -347,15 +379,19 @@ export class HttpTransportServer implements TransportWorker<
       params = { ...DEFAULT_CORS_PARAMS }
     } else if (Array.isArray(this.#corsOptions)) {
       if (this.#corsOptions.includes(origin)) {
-        params = { ...DEFAULT_CORS_PARAMS }
+        params = { ...EXPLICIT_ORIGIN_CORS_PARAMS }
       }
     } else if (typeof this.#corsOptions === 'object') {
       if (
         this.#corsOptions.origin === true ||
         this.#corsOptions.origin.includes(origin)
       ) {
-        params = { ...DEFAULT_CORS_PARAMS }
-        for (const key in DEFAULT_CORS_PARAMS) {
+        params =
+          this.#corsOptions.origin === true
+            ? { ...DEFAULT_CORS_PARAMS }
+            : { ...EXPLICIT_ORIGIN_CORS_PARAMS }
+        // Iterating base params also drops allowCredentials for origin: true
+        for (const key in params) {
           const value = this.#corsOptions[key]
           if (value !== undefined) {
             params[key] = value
@@ -366,11 +402,14 @@ export class HttpTransportServer implements TransportWorker<
       const result = this.#corsOptions(origin, request)
       if (typeof result === 'boolean') {
         if (result) {
-          params = { ...DEFAULT_CORS_PARAMS }
+          params = { ...EXPLICIT_ORIGIN_CORS_PARAMS }
         }
       } else if (typeof result === 'object') {
-        params = { ...DEFAULT_CORS_PARAMS }
-        for (const key in DEFAULT_CORS_PARAMS) {
+        params =
+          result.origin === true
+            ? { ...DEFAULT_CORS_PARAMS }
+            : { ...EXPLICIT_ORIGIN_CORS_PARAMS }
+        for (const key in params) {
           const value = result[key]
           if (value !== undefined) {
             params[key] = value

--- a/packages/http-transport/src/server.ts
+++ b/packages/http-transport/src/server.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer'
-import { Duplex, Readable } from 'node:stream'
+import { Duplex, Readable, Transform } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
 
 import type { ApplicationResolvedProcedure } from '@nmtjs/application'
 import type { TransportWorker, TransportWorkerParams } from '@nmtjs/gateway'
@@ -131,6 +132,9 @@ export class HttpTransportServer implements TransportWorker<
     const method = request.method.toLowerCase()
     const origin = request.headers.get('origin')
     const responseHeaders = new Headers()
+    // CORS makes responses origin-dependent (even denials), so shared caches
+    // must key on Origin to avoid serving them across origins
+    if (this.#corsOptions) responseHeaders.append('Vary', 'Origin')
     if (origin) this.applyCors(origin, request, responseHeaders)
 
     // Handle preflight requests
@@ -169,7 +173,6 @@ export class HttpTransportServer implements TransportWorker<
       let payload: any
 
       if (canHaveBody && body) {
-        const bodyStream = Readable.fromWeb(body as any)
         const cannotDecode =
           !contentType || !this.params.formats.supportsDecoder(contentType)
         if (isBlob || cannotDecode) {
@@ -178,12 +181,26 @@ export class HttpTransportServer implements TransportWorker<
           const size = contentLength
             ? Number.parseInt(contentLength, 10)
             : undefined
-          payload = new ProtocolClientStream(-1, { size, type })
-          bodyStream.pipe(payload)
+          // Declared size over the cap: reject before reading anything
+          if (size !== undefined && size > this.#maxRequestBodySize) {
+            throw new PayloadTooLargeError()
+          }
+          const clientStream = new ProtocolClientStream(-1, { size, type })
+          // The rpc may never read the payload; without a handler a capped
+          // upload would crash the process with an unhandled 'error'
+          clientStream.on('error', () => {})
+          payload = clientStream
+          // pipeline (unlike pipe) propagates source errors; the cap error is
+          // re-surfaced on the payload stream so its consumer rejects with it
+          pipeline(
+            Readable.fromWeb(body as any),
+            this.createBodySizeGuard(),
+            clientStream,
+          ).catch((error) => clientStream.destroy(error))
         } else {
           const chunks: Buffer[] = []
           let received = 0
-          for await (const chunk of bodyStream) {
+          for await (const chunk of Readable.fromWeb(body as any)) {
             received += chunk.byteLength
             // Reject mid-stream to avoid buffering unbounded payloads
             if (received > this.#maxRequestBodySize) {
@@ -217,7 +234,9 @@ export class HttpTransportServer implements TransportWorker<
       if (result instanceof Response) {
         const { status, statusText, headers, body } = result
         headers.forEach((value, key) => {
-          responseHeaders.set(key, value)
+          // Merge Vary so the cors Origin entry isn't lost to shared caches
+          if (key.toLowerCase() === 'vary') responseHeaders.append(key, value)
+          else responseHeaders.set(key, value)
         })
 
         return new Response(body, {
@@ -366,6 +385,19 @@ export class HttpTransportServer implements TransportWorker<
     }
   }
 
+  private createBodySizeGuard() {
+    const maxSize = this.#maxRequestBodySize
+    let received = 0
+    return new Transform({
+      transform(chunk: Buffer, _encoding, callback) {
+        received += chunk.byteLength
+        // Enforce the cap even when the declared content-length lies
+        if (received > maxSize) callback(new PayloadTooLargeError())
+        else callback(null, chunk)
+      },
+    })
+  }
+
   private applyCors(
     origin: string,
     request: HttpTransportServerRequest,
@@ -405,14 +437,18 @@ export class HttpTransportServer implements TransportWorker<
           params = { ...EXPLICIT_ORIGIN_CORS_PARAMS }
         }
       } else if (typeof result === 'object') {
-        params =
-          result.origin === true
-            ? { ...DEFAULT_CORS_PARAMS }
-            : { ...EXPLICIT_ORIGIN_CORS_PARAMS }
-        for (const key in params) {
-          const value = result[key]
-          if (value !== undefined) {
-            params[key] = value
+        // Returned params must still match the requesting origin, otherwise
+        // any origin would get reflected (with credentials for allowlists)
+        if (result.origin === true || result.origin.includes(origin)) {
+          params =
+            result.origin === true
+              ? { ...DEFAULT_CORS_PARAMS }
+              : { ...EXPLICIT_ORIGIN_CORS_PARAMS }
+          for (const key in params) {
+            const value = result[key]
+            if (value !== undefined) {
+              params[key] = value
+            }
           }
         }
       }

--- a/packages/http-transport/src/types.ts
+++ b/packages/http-transport/src/types.ts
@@ -12,19 +12,41 @@ export type HttpTransportOptions<
   listen: HttpTransportListenOptions
   cors?: HttpTransportCorsOptions
   tls?: HttpTransportTlsOptions
+  /**
+   * Maximum request body size in bytes. Requests exceeding it are rejected
+   * with 413 Payload Too Large. Defaults to 128MiB (Bun's own default, kept
+   * consistent across runtimes).
+   */
+  maxRequestBodySize?: number
   runtime?: HttpTransportRuntimes[R]
 }
 
 export type HttpTransportCorsCustomParams = {
-  origin: true | string[]
   allowMethods?: string[]
   allowHeaders?: string[]
-  allowCredentials?: string
   maxAge?: string
   exposeHeaders?: string[]
   requestHeaders?: string[]
   requestMethod?: string
-}
+} & (
+  | {
+      /**
+       * Reflect any request origin. Credentials are not allowed in this mode:
+       * combining a reflected origin with `Access-Control-Allow-Credentials`
+       * would let any website make credentialed (cookie-authed) requests.
+       */
+      origin: true
+      allowCredentials?: never
+    }
+  | {
+      /**
+       * Explicit origin allowlist. Credentials are enabled by default for
+       * allowlisted origins (set `allowCredentials` to override).
+       */
+      origin: string[]
+      allowCredentials?: string
+    }
+)
 
 export type HttpTransportCorsOptions =
   | true
@@ -83,6 +105,7 @@ export type HttpAdapterParams<
   ) => MaybePromise<Response>
   cors?: HttpTransportCorsOptions
   tls?: HttpTransportTlsOptions
+  maxRequestBodySize?: number
   runtime?: HttpTransportRuntimes[R]
 }
 

--- a/packages/http-transport/src/types.ts
+++ b/packages/http-transport/src/types.ts
@@ -31,17 +31,17 @@ export type HttpTransportCorsCustomParams = {
 } & (
   | {
       /**
-       * Reflect any request origin. Credentials are not allowed in this mode:
-       * combining a reflected origin with `Access-Control-Allow-Credentials`
-       * would let any website make credentialed (cookie-authed) requests.
+       * `true` reflects any request origin, an array is an explicit
+       * allowlist. Credentials default on for allowlisted origins only.
        */
-      origin: true
+      origin: true | string[]
       allowCredentials?: never
     }
   | {
       /**
-       * Explicit origin allowlist. Credentials are enabled by default for
-       * allowlisted origins (set `allowCredentials` to override).
+       * Explicit `allowCredentials` requires an origin allowlist: combining
+       * credentials with a reflected origin (`origin: true`) would let any
+       * website make credentialed (cookie-authed) requests.
        */
       origin: string[]
       allowCredentials?: string

--- a/packages/http-transport/src/utils.ts
+++ b/packages/http-transport/src/utils.ts
@@ -26,3 +26,9 @@ export const InternalServerErrorHttpResponse = () =>
   })
 
 export const OkResponse = () => new Response('OK', { status: 200 })
+
+export class PayloadTooLargeError extends Error {
+  constructor(message = 'Payload Too Large') {
+    super(message)
+  }
+}

--- a/packages/http-transport/tests/_helpers/test-utils.ts
+++ b/packages/http-transport/tests/_helpers/test-utils.ts
@@ -1,0 +1,73 @@
+import type { TransportWorkerParams } from '@nmtjs/gateway'
+import type { ConnectionType } from '@nmtjs/protocol'
+import type { Mock } from 'vitest'
+import { vi } from 'vitest'
+
+import type {
+  HttpAdapterServerFactory,
+  HttpTransportOptions,
+} from '../../src/types.ts'
+import { HttpTransportServer } from '../../src/server.ts'
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
+export type TestParams = TransportWorkerParams<
+  ConnectionType.Unidirectional,
+  any
+>
+
+export function createTestParams(
+  onRpc: Mock = vi.fn(async () => ({ ok: true })),
+) {
+  const connection = {
+    id: 'test-connection',
+    encoder: {
+      contentType: 'application/json',
+      encode: (data: unknown) =>
+        textEncoder.encode(JSON.stringify(data ?? null)),
+    },
+    decoder: {
+      decode: (buffer: Uint8Array) => JSON.parse(textDecoder.decode(buffer)),
+    },
+    [Symbol.asyncDispose]: async () => {},
+  }
+  const params = {
+    formats: {
+      supportsDecoder: (contentType: string) =>
+        contentType.startsWith('application/json'),
+    },
+    onConnect: vi.fn(async () => connection),
+    onDisconnect: vi.fn(async () => {}),
+    onMessage: vi.fn(async () => {}),
+    resolve: vi.fn(async () => ({ meta: new Map() })),
+    onRpc,
+  } as unknown as TestParams
+  return { params, onRpc, connection }
+}
+
+const stubAdapterFactory: HttpAdapterServerFactory<any> = () => ({
+  runtime: {},
+  start: () => 'http://127.0.0.1:0',
+  stop: () => {},
+})
+
+export async function createTestServer(
+  options: Partial<HttpTransportOptions>,
+  params: TestParams,
+) {
+  const server = new HttpTransportServer(stubAdapterFactory, {
+    listen: { port: 0 },
+    ...options,
+  })
+  await server.start(params)
+  return server
+}
+
+export function createTestRequest(
+  headers: Record<string, string>,
+  method = 'POST',
+  url = 'http://localhost/testProcedure',
+) {
+  return { url: new URL(url), method, headers: new Headers(headers) }
+}

--- a/packages/http-transport/tests/body-limit.spec.ts
+++ b/packages/http-transport/tests/body-limit.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { HttpTransport } from '../src/runtimes/node.ts'
 import {
@@ -8,6 +8,32 @@ import {
 } from './_helpers/test-utils.ts'
 
 const JSON_HEADERS = { 'content-type': 'application/json' }
+const BLOB_HEADERS = {
+  'content-type': 'application/octet-stream',
+  'x-neemata-blob': 'true',
+}
+
+// Mimics a real procedure consuming an uploaded blob stream
+const consumingRpc = () =>
+  vi.fn(async (_connection: any, rpc: any) => {
+    if (rpc.payload && typeof rpc.payload.toArray === 'function') {
+      await rpc.payload.toArray()
+    }
+    return { ok: true }
+  })
+
+function createCountingBody(chunkSize: number, totalChunks: number) {
+  const chunk = new Uint8Array(chunkSize).fill(97) // 'a'
+  let pulls = 0
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      pulls++
+      if (pulls > totalChunks) controller.close()
+      else controller.enqueue(chunk)
+    },
+  })
+  return { body, getPulls: () => pulls }
+}
 
 describe('request body size limit', () => {
   it('rejects oversized body with 413 without buffering the whole payload', async () => {
@@ -17,16 +43,7 @@ describe('request body size limit', () => {
       params,
     )
 
-    const chunk = new Uint8Array(64 * 1024).fill(97) // 'a'
-    const totalChunks = 100
-    let pulls = 0
-    const body = new ReadableStream<Uint8Array>({
-      pull(controller) {
-        pulls++
-        if (pulls > totalChunks) controller.close()
-        else controller.enqueue(chunk)
-      },
-    })
+    const { body, getPulls } = createCountingBody(64 * 1024, 100)
 
     const response = await server.httpHandler(
       createTestRequest(JSON_HEADERS),
@@ -38,7 +55,70 @@ describe('request body size limit', () => {
     expect(onRpc).not.toHaveBeenCalled()
     // Buffering must stop as soon as the cap is exceeded (3 chunks), not
     // consume the whole stream; a few extra pulls are read-ahead buffering
-    expect(pulls).toBeLessThan(20)
+    expect(getPulls()).toBeLessThan(20)
+  })
+
+  it('rejects oversized blob body with 413 and keeps the server alive', async () => {
+    const onRpc = consumingRpc()
+    const { params } = createTestParams(onRpc)
+    const server = await createTestServer(
+      { maxRequestBodySize: 128 * 1024 },
+      params,
+    )
+
+    // No content-length: forces enforcement while streaming, not up-front
+    const { body, getPulls } = createCountingBody(64 * 1024, 100)
+    const response = await server.httpHandler(
+      createTestRequest(BLOB_HEADERS),
+      body,
+      new AbortController().signal,
+    )
+
+    expect(response.status).toBe(413)
+    expect(getPulls()).toBeLessThan(20)
+
+    // Same server instance must still serve subsequent requests
+    const ok = await server.httpHandler(
+      createTestRequest(JSON_HEADERS),
+      new Response(JSON.stringify({ hello: 'world' })).body!,
+      new AbortController().signal,
+    )
+    expect(ok.status).toBe(200)
+  })
+
+  it('rejects oversized undecodable body with 413', async () => {
+    const onRpc = consumingRpc()
+    const { params } = createTestParams(onRpc)
+    const server = await createTestServer(
+      { maxRequestBodySize: 128 * 1024 },
+      params,
+    )
+
+    const { body } = createCountingBody(64 * 1024, 100)
+    const response = await server.httpHandler(
+      createTestRequest({ 'content-type': 'text/unsupported' }),
+      body,
+      new AbortController().signal,
+    )
+
+    expect(response.status).toBe(413)
+  })
+
+  it('rejects blob body with declared content-length over the limit up-front', async () => {
+    const { params, onRpc } = createTestParams()
+    const server = await createTestServer({ maxRequestBodySize: 1024 }, params)
+
+    const { body, getPulls } = createCountingBody(64 * 1024, 1)
+    const response = await server.httpHandler(
+      createTestRequest({ ...BLOB_HEADERS, 'content-length': '65536' }),
+      body,
+      new AbortController().signal,
+    )
+
+    expect(response.status).toBe(413)
+    expect(onRpc).not.toHaveBeenCalled()
+    // A single pull is the stream pre-filling its own queue, not the handler
+    expect(getPulls()).toBeLessThanOrEqual(1)
   })
 
   it('accepts body within the limit', async () => {
@@ -95,6 +175,34 @@ describe('request body size limit (node runtime)', () => {
       })
       expect(ok.status).toBe(200)
       expect(onRpc).toHaveBeenCalledTimes(1)
+    } finally {
+      await worker.stop(params as any)
+    }
+  })
+
+  it('caps blob bodies on the node adapter and survives', async () => {
+    const onRpc = consumingRpc()
+    const { params } = createTestParams(onRpc)
+    const worker = await HttpTransport.factory({
+      listen: { port: 0 },
+      maxRequestBodySize: 1024,
+    })
+    const url = await worker.start(params as any)
+
+    try {
+      const oversized = await fetch(`${url}/testProcedure`, {
+        method: 'POST',
+        headers: BLOB_HEADERS,
+        body: new Uint8Array(64 * 1024),
+      })
+      expect(oversized.status).toBe(413)
+
+      const ok = await fetch(`${url}/testProcedure`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ hello: 'world' }),
+      })
+      expect(ok.status).toBe(200)
     } finally {
       await worker.stop(params as any)
     }

--- a/packages/http-transport/tests/body-limit.spec.ts
+++ b/packages/http-transport/tests/body-limit.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import { HttpTransport } from '../src/runtimes/node.ts'
+import {
+  createTestParams,
+  createTestRequest,
+  createTestServer,
+} from './_helpers/test-utils.ts'
+
+const JSON_HEADERS = { 'content-type': 'application/json' }
+
+describe('request body size limit', () => {
+  it('rejects oversized body with 413 without buffering the whole payload', async () => {
+    const { params, onRpc } = createTestParams()
+    const server = await createTestServer(
+      { maxRequestBodySize: 128 * 1024 },
+      params,
+    )
+
+    const chunk = new Uint8Array(64 * 1024).fill(97) // 'a'
+    const totalChunks = 100
+    let pulls = 0
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls++
+        if (pulls > totalChunks) controller.close()
+        else controller.enqueue(chunk)
+      },
+    })
+
+    const response = await server.httpHandler(
+      createTestRequest(JSON_HEADERS),
+      body,
+      new AbortController().signal,
+    )
+
+    expect(response.status).toBe(413)
+    expect(onRpc).not.toHaveBeenCalled()
+    // Buffering must stop as soon as the cap is exceeded (3 chunks), not
+    // consume the whole stream; a few extra pulls are read-ahead buffering
+    expect(pulls).toBeLessThan(20)
+  })
+
+  it('accepts body within the limit', async () => {
+    const { params, onRpc } = createTestParams()
+    const server = await createTestServer(
+      { maxRequestBodySize: 128 * 1024 },
+      params,
+    )
+
+    const payload = JSON.stringify({ hello: 'world' })
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(payload))
+        controller.close()
+      },
+    })
+
+    const response = await server.httpHandler(
+      createTestRequest(JSON_HEADERS),
+      body,
+      new AbortController().signal,
+    )
+
+    expect(response.status).toBe(200)
+    expect(onRpc).toHaveBeenCalledTimes(1)
+    expect(onRpc.mock.calls[0][1]).toMatchObject({
+      payload: { hello: 'world' },
+    })
+  })
+})
+
+describe('request body size limit (node runtime)', () => {
+  it('caps request bodies on the node adapter', async () => {
+    const { params, onRpc } = createTestParams()
+    const worker = await HttpTransport.factory({
+      listen: { port: 0 },
+      maxRequestBodySize: 1024,
+    })
+    const url = await worker.start(params as any)
+
+    try {
+      const oversized = await fetch(`${url}/testProcedure`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ data: 'x'.repeat(64 * 1024) }),
+      })
+      expect(oversized.status).toBe(413)
+      expect(onRpc).not.toHaveBeenCalled()
+
+      const ok = await fetch(`${url}/testProcedure`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ hello: 'world' }),
+      })
+      expect(ok.status).toBe(200)
+      expect(onRpc).toHaveBeenCalledTimes(1)
+    } finally {
+      await worker.stop(params as any)
+    }
+  })
+})

--- a/packages/http-transport/tests/cors.spec.ts
+++ b/packages/http-transport/tests/cors.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import type { HttpTransportCorsOptions } from '../src/types.ts'
 import {
   createTestParams,
   createTestRequest,
@@ -10,11 +11,14 @@ const ORIGIN = 'https://app.example.com'
 const ALLOW_ORIGIN = 'Access-Control-Allow-Origin'
 const ALLOW_CREDENTIALS = 'Access-Control-Allow-Credentials'
 
-async function preflight(cors: any) {
+async function preflight(
+  cors: HttpTransportCorsOptions,
+  origin: string | null = ORIGIN,
+) {
   const { params } = createTestParams()
   const server = await createTestServer({ cors }, params)
   return await server.httpHandler(
-    createTestRequest({ origin: ORIGIN }, 'OPTIONS'),
+    createTestRequest(origin === null ? {} : { origin }, 'OPTIONS'),
     null,
     new AbortController().signal,
   )
@@ -57,7 +61,7 @@ describe('CORS credentials defaults', () => {
   })
 
   it('enables credentials when a custom function vets the origin', async () => {
-    const response = await preflight((origin: string) => origin === ORIGIN)
+    const response = await preflight((origin) => origin === ORIGIN)
 
     expect(response.headers.get(ALLOW_ORIGIN)).toBe(ORIGIN)
     expect(response.headers.get(ALLOW_CREDENTIALS)).toBe('true')
@@ -68,5 +72,93 @@ describe('CORS credentials defaults', () => {
 
     expect(response.headers.get(ALLOW_ORIGIN)).toBe(ORIGIN)
     expect(response.headers.get(ALLOW_CREDENTIALS)).toBeNull()
+  })
+
+  it('enables credentials for function params listing the requesting origin', async () => {
+    const response = await preflight(() => ({ origin: [ORIGIN] }))
+
+    expect(response.headers.get(ALLOW_ORIGIN)).toBe(ORIGIN)
+    expect(response.headers.get(ALLOW_CREDENTIALS)).toBe('true')
+  })
+
+  it('skips CORS headers when function params do not list the requesting origin', async () => {
+    const response = await preflight(() => ({
+      origin: ['https://trusted.example.com'],
+    }))
+
+    expect(response.headers.get(ALLOW_ORIGIN)).toBeNull()
+    expect(response.headers.get(ALLOW_CREDENTIALS)).toBeNull()
+  })
+})
+
+describe('CORS Vary header', () => {
+  it('adds Vary: Origin for allowed origins', async () => {
+    const response = await preflight(true)
+
+    expect(response.headers.get('Vary')).toBe('Origin')
+  })
+
+  it('adds Vary: Origin for disallowed origins', async () => {
+    const response = await preflight(['https://other.example.com'])
+
+    expect(response.headers.get('Vary')).toBe('Origin')
+    expect(response.headers.get(ALLOW_ORIGIN)).toBeNull()
+  })
+
+  it('adds Vary: Origin when the request has no Origin header', async () => {
+    const response = await preflight(true, null)
+
+    expect(response.headers.get('Vary')).toBe('Origin')
+  })
+
+  it('omits Vary: Origin when cors is not configured', async () => {
+    const { params } = createTestParams()
+    const server = await createTestServer({}, params)
+    const response = await server.httpHandler(
+      createTestRequest({ origin: ORIGIN }, 'OPTIONS'),
+      null,
+      new AbortController().signal,
+    )
+
+    expect(response.headers.get('Vary')).toBeNull()
+  })
+
+  it('merges Vary from custom rpc responses instead of overwriting', async () => {
+    const { params } = createTestParams()
+    params.onRpc = async () =>
+      new Response(null, { headers: { Vary: 'Accept-Encoding' } })
+    const server = await createTestServer({ cors: true }, params)
+    const response = await server.httpHandler(
+      createTestRequest({ origin: ORIGIN }),
+      null,
+      new AbortController().signal,
+    )
+
+    expect(response.headers.get('Vary')).toBe('Origin, Accept-Encoding')
+  })
+})
+
+describe('CORS config type surface', () => {
+  it('accepts safe configs and rejects credentials with reflected origin', () => {
+    const allowAll = Math.random() >= 0
+    const allowedOrigins = [ORIGIN]
+
+    // Composing origin as `true | string[]` without credentials must be valid
+    const composed: HttpTransportCorsOptions = {
+      origin: allowAll ? true : allowedOrigins,
+    }
+    const credentialed: HttpTransportCorsOptions = {
+      origin: allowedOrigins,
+      allowCredentials: 'true',
+    }
+    // @ts-expect-error credentials cannot be combined with origin reflection
+    const unsafe: HttpTransportCorsOptions = {
+      origin: true,
+      allowCredentials: 'true',
+    }
+
+    expect(composed).toBeDefined()
+    expect(credentialed).toBeDefined()
+    expect(unsafe).toBeDefined()
   })
 })

--- a/packages/http-transport/tests/cors.spec.ts
+++ b/packages/http-transport/tests/cors.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createTestParams,
+  createTestRequest,
+  createTestServer,
+} from './_helpers/test-utils.ts'
+
+const ORIGIN = 'https://app.example.com'
+const ALLOW_ORIGIN = 'Access-Control-Allow-Origin'
+const ALLOW_CREDENTIALS = 'Access-Control-Allow-Credentials'
+
+async function preflight(cors: any) {
+  const { params } = createTestParams()
+  const server = await createTestServer({ cors }, params)
+  return await server.httpHandler(
+    createTestRequest({ origin: ORIGIN }, 'OPTIONS'),
+    null,
+    new AbortController().signal,
+  )
+}
+
+describe('CORS credentials defaults', () => {
+  it('omits Allow-Credentials while still allowing origin for cors: true', async () => {
+    const response = await preflight(true)
+
+    expect(response.headers.get(ALLOW_ORIGIN)).toBe(ORIGIN)
+    expect(response.headers.get(ALLOW_CREDENTIALS)).toBeNull()
+  })
+
+  it('enables credentials for explicit origin allowlist', async () => {
+    const response = await preflight([ORIGIN])
+
+    expect(response.headers.get(ALLOW_ORIGIN)).toBe(ORIGIN)
+    expect(response.headers.get(ALLOW_CREDENTIALS)).toBe('true')
+  })
+
+  it('skips CORS headers entirely for origins not in the allowlist', async () => {
+    const response = await preflight(['https://other.example.com'])
+
+    expect(response.headers.get(ALLOW_ORIGIN)).toBeNull()
+    expect(response.headers.get(ALLOW_CREDENTIALS)).toBeNull()
+  })
+
+  it('omits credentials for custom params with origin: true', async () => {
+    const response = await preflight({ origin: true })
+
+    expect(response.headers.get(ALLOW_ORIGIN)).toBe(ORIGIN)
+    expect(response.headers.get(ALLOW_CREDENTIALS)).toBeNull()
+  })
+
+  it('enables credentials for custom params with explicit origins', async () => {
+    const response = await preflight({ origin: [ORIGIN] })
+
+    expect(response.headers.get(ALLOW_ORIGIN)).toBe(ORIGIN)
+    expect(response.headers.get(ALLOW_CREDENTIALS)).toBe('true')
+  })
+
+  it('enables credentials when a custom function vets the origin', async () => {
+    const response = await preflight((origin: string) => origin === ORIGIN)
+
+    expect(response.headers.get(ALLOW_ORIGIN)).toBe(ORIGIN)
+    expect(response.headers.get(ALLOW_CREDENTIALS)).toBe('true')
+  })
+
+  it('omits credentials when a custom function reflects any origin', async () => {
+    const response = await preflight(() => ({ origin: true }))
+
+    expect(response.headers.get(ALLOW_ORIGIN)).toBe(ORIGIN)
+    expect(response.headers.get(ALLOW_CREDENTIALS)).toBeNull()
+  })
+})

--- a/packages/http-transport/vitest.config.ts
+++ b/packages/http-transport/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: { environment: 'node', include: ['tests/**/*.spec.ts'] },
+})


### PR DESCRIPTION
Fixes the first two items of #214 (the WS-token-in-URL item needs coordinated transport/protocol work and stays open).

- **`cors: true` no longer reflects arbitrary origins with credentials**: the defaults sent `Access-Control-Allow-Credentials: true` while reflecting the request origin verbatim, letting any website make credentialed requests against a cookie-authed API. Credentials are now granted only when the config supplies an explicit origin allowlist (string array, object form, or a vetting function whose returned allowlist actually contains the requesting origin — a returned list is matched, not trusted). The params type became a union that makes `origin: true` + `allowCredentials` a compile error while still accepting composed `true | string[]` values; a JS caller passing the vulnerable combo has it ignored at runtime. Origin-dependent responses now also emit `Vary: Origin` (merged with existing Vary values) so shared caches can't serve one origin's CORS response to another.
- **Request body size cap**: the Node runtime buffered non-blob bodies unboundedly (`Buffer.concat(await bodyStream.toArray())`) with no backpressure — a single large request could exhaust memory. A new `maxRequestBodySize` option (default 128 MiB, matching Bun's native default so all runtimes behave identically) is enforced incrementally on every body path: declared oversized `Content-Length` is rejected before reading, the buffering loop and a byte-counting transform on blob/undecodable streams abort with 413 `Payload Too Large` the moment the running total exceeds the cap, and stream errors propagate through an awaited pipeline so an oversized upload yields a catchable 413 instead of an uncaught stream error. The option is also wired into `Bun.serve` (runtime-specific setting wins).

Tests cover: credentialed vs credential-less config shapes (through the public type, with compile-time fixtures), the vetting-function allowlist match and mismatch, Vary merging, and 413s for oversized buffered/blob/undecodable/declared bodies on both the direct handler and the real uWS adapter — asserting the server survives and serves the next request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable request body size limits, defaulting to 128 MiB.
  * Oversized requests are rejected with HTTP 413 responses.
  * Improved streaming protection to avoid buffering oversized uploads.
  * Enhanced CORS handling, including safer credential rules and `Vary: Origin` responses.
* **Bug Fixes**
  * Preserved multiple `Vary` response header values.
  * Ensured servers continue handling requests after rejected uploads.
* **Tests**
  * Added coverage for request size limits, streaming uploads, and CORS behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->