### PR TITLE
Refactor workflow workers to preserve configured concurrency

### DIFF
--- a/packages/neem/src/internal/worker/entry.ts
+++ b/packages/neem/src/internal/worker/entry.ts
@@ -24,6 +24,7 @@ const workerData = rawWorkerData as RuntimeWorkerData
 let runtime: NeemRuntime | undefined
 let logger: Logger | undefined
 let started = false
+let stopRequested = false
 
 function postMessage(message: WorkerMessage): void {
   port.postMessage(message)
@@ -96,6 +97,7 @@ async function stopRuntime(options: { force?: boolean } = {}): Promise<void> {
 }
 
 async function stopAndExit(): Promise<void> {
+  stopRequested = true
   try {
     await stopRuntime()
     postMessage({ type: 'stopped' })
@@ -107,6 +109,23 @@ async function stopAndExit(): Promise<void> {
     reportError(error, 'runtime')
     process.exit(1)
   }
+}
+
+async function watchRuntimeFinished(current: NeemRuntime): Promise<void> {
+  if (!current.finished) return
+
+  try {
+    await current.finished
+    if (stopRequested) return
+    reportError(
+      new Error('Neem runtime finished before stop was requested'),
+      'runtime',
+    )
+  } catch (error) {
+    if (stopRequested) return
+    reportError(error, 'runtime')
+  }
+  process.exit(1)
 }
 
 port.on('message', (message: ParentMessage) => {
@@ -138,6 +157,7 @@ async function main(): Promise<void> {
     started = true
     logger?.trace({ upstreams: upstreams.length }, 'Neem runtime worker ready')
     postMessage({ type: 'ready', data: { upstreams } })
+    void watchRuntimeFinished(runtime)
   } catch (error) {
     await stopRuntime({ force: true }).catch((cleanupError) => {
       logger?.warn(

--- a/packages/neem/src/shared/types.ts
+++ b/packages/neem/src/shared/types.ts
@@ -215,6 +215,12 @@ export type NeemRuntimeServerHealth = NeemRuntimeServerSnapshot & {
 export type NeemRuntime = {
   start: () => MaybePromise<readonly NeemRuntimeUpstream[] | undefined>
   stop: () => MaybePromise<void>
+  /**
+   * Settles when long-lived runtime work ends. Completion before a requested
+   * stop is treated as a runtime failure so a ready worker cannot become a
+   * silent zombie.
+   */
+  readonly finished?: PromiseLike<void>
 }
 
 export type NeemRuntimePlan<Options = unknown, Data = unknown> = {

--- a/packages/neem/tests/e2e/fixtures/shared/workers/fail-once-runtime.ts
+++ b/packages/neem/tests/e2e/fixtures/shared/workers/fail-once-runtime.ts
@@ -8,18 +8,28 @@ import { record } from '../support/_events.ts'
 export default defineRuntimeWorker<{ label: string }>({
   definition: { fixture: 'fail-once-runtime' },
   createRuntime(ctx) {
+    let resolveFinished!: () => void
+    let rejectFinished!: (error: Error) => void
+    const finished = new Promise<void>((resolve, reject) => {
+      resolveFinished = resolve
+      rejectFinished = reject
+    })
+    void finished.catch(() => {})
+
     return {
+      finished,
       start() {
         record({ event: 'fail-once-start', name: ctx.name })
         const marker = resolve(process.env.NEEM_FAIL_ONCE_MARKER ?? 'marker')
         if (!existsSync(marker)) {
           writeFileSync(marker, 'failed')
           setTimeout(() => {
-            throw new Error('fixture runtime failure once')
+            rejectFinished(new Error('fixture runtime failure once'))
           }, 25)
         }
       },
       stop() {
+        resolveFinished()
         record({ event: 'fail-once-stop', name: ctx.name })
       },
     }

--- a/packages/workflows/src/adapters/postgres/executor.ts
+++ b/packages/workflows/src/adapters/postgres/executor.ts
@@ -18,7 +18,7 @@ export const createAttemptExecutor = (
     createPostgresWorkflowCommandHelpers(ctx)
 
   const claimAttempt = async (
-    where: string,
+    where: string | readonly string[],
     params: unknown[],
     workerId: string,
     leaseMs: number,
@@ -144,12 +144,7 @@ export const createAttemptExecutor = (
       }
 
       if (eligible.length === 0) return null
-      return claimAttempt(
-        eligible.join(' OR '),
-        params,
-        worker.workerId,
-        worker.leaseMs,
-      )
+      return claimAttempt(eligible, params, worker.workerId, worker.leaseMs)
     },
     async heartbeat(attempt, leaseMs = 30_000) {
       await ready

--- a/packages/workflows/src/adapters/postgres/executor.ts
+++ b/packages/workflows/src/adapters/postgres/executor.ts
@@ -18,13 +18,12 @@ export const createAttemptExecutor = (
     createPostgresWorkflowCommandHelpers(ctx)
 
   const claimAttempt = async (
-    kind: 'activity' | 'task',
     where: string,
     params: unknown[],
     workerId: string,
     leaseMs: number,
   ): Promise<ClaimedAttempt | null> => {
-    const claimed = await claimCommand(kind, where, params, workerId, leaseMs)
+    const claimed = await claimCommand(where, params, workerId, leaseMs)
     if (!claimed) return null
     return {
       id: claimed.id as string,
@@ -110,42 +109,44 @@ export const createAttemptExecutor = (
         ],
       )
     },
-    async claimActivity(worker) {
+    async claim(worker) {
       await ready
-      if (worker.workflowNames.length === 0) return null
-      if (worker.activityNames?.length === 0) return null
-      const params: unknown[] = [...worker.workflowNames]
-      const workflowList = worker.workflowNames
-        .map((_, index) => `$${index + 2}`)
-        .join(', ')
-      const where = [`workflow_name IN (${workflowList})`]
-      if (worker.activityNames !== undefined) {
-        const offset = params.length
-        params.push(...worker.activityNames)
-        where.push(
-          `activity_name IN (${worker.activityNames
-            .map((_, index) => `$${offset + index + 2}`)
-            .join(', ')})`,
+      const params: unknown[] = []
+      const placeholders = (values: readonly string[]) =>
+        values
+          .map((value) => {
+            params.push(value)
+            return `$${params.length}`
+          })
+          .join(', ')
+      const eligible: string[] = []
+
+      if (
+        worker.workflowNames.length > 0 &&
+        worker.activityNames?.length !== 0
+      ) {
+        const activity = [
+          `kind = 'activity'`,
+          `workflow_name IN (${placeholders(worker.workflowNames)})`,
+        ]
+        if (worker.activityNames !== undefined) {
+          activity.push(
+            `activity_name IN (${placeholders(worker.activityNames)})`,
+          )
+        }
+        eligible.push(`(${activity.join(' AND ')})`)
+      }
+
+      if (worker.taskNames.length > 0) {
+        eligible.push(
+          `(kind = 'task' AND task_name IN (${placeholders(worker.taskNames)}))`,
         )
       }
+
+      if (eligible.length === 0) return null
       return claimAttempt(
-        'activity',
-        where.join(' AND '),
+        eligible.join(' OR '),
         params,
-        worker.workerId,
-        worker.leaseMs,
-      )
-    },
-    async claimTask(worker) {
-      await ready
-      if (worker.taskNames.length === 0) return null
-      const taskList = worker.taskNames
-        .map((_, index) => `$${index + 2}`)
-        .join(', ')
-      return claimAttempt(
-        'task',
-        `task_name IN (${taskList})`,
-        [...worker.taskNames],
         worker.workerId,
         worker.leaseMs,
       )

--- a/packages/workflows/src/adapters/postgres/queue.ts
+++ b/packages/workflows/src/adapters/postgres/queue.ts
@@ -116,7 +116,6 @@ export const createPostgresWorkflowCommandHelpers = (
   }
 
   const claimCommand = async (
-    kind: 'continue' | 'activity' | 'task',
     where: string,
     params: unknown[],
     workerId: string,
@@ -129,23 +128,22 @@ export const createPostgresWorkflowCommandHelpers = (
       WITH candidate AS (
         SELECT id
         FROM workflow_commands
-        WHERE kind = $1
-          AND run_at <= now()
+        WHERE run_at <= now()
           AND (lease_token IS NULL OR lease_expires_at <= now())
           AND dead_at IS NULL
-          AND ${where}
+          AND (${where})
         ORDER BY priority DESC, run_at ASC, created_at ASC, id ASC
         LIMIT 1
         FOR UPDATE SKIP LOCKED
       )
       UPDATE workflow_commands
-      SET lease_owner = $${params.length + 2},
-          lease_token = $${params.length + 3},
-          lease_expires_at = now() + ($${params.length + 4}::int * interval '1 millisecond')
+      SET lease_owner = $${params.length + 1},
+          lease_token = $${params.length + 2},
+          lease_expires_at = now() + ($${params.length + 3}::int * interval '1 millisecond')
       WHERE id = (SELECT id FROM candidate)
       RETURNING *
     `,
-      [kind, ...params, workerId, leaseToken, leaseMs],
+      [...params, workerId, leaseToken, leaseMs],
     )
   }
 
@@ -191,11 +189,10 @@ export const createRunCoordinationExecutor = (
       await ready
       if (worker.workflowNames.length === 0) return null
       const workflowList = worker.workflowNames
-        .map((_, index) => `$${index + 2}`)
+        .map((_, index) => `$${index + 1}`)
         .join(', ')
       const claimed = await claimCommand(
-        'continue',
-        `workflow_name IN (${workflowList})`,
+        `kind = 'continue' AND workflow_name IN (${workflowList})`,
         [...worker.workflowNames],
         worker.workerId,
         worker.leaseMs,

--- a/packages/workflows/src/adapters/postgres/queue.ts
+++ b/packages/workflows/src/adapters/postgres/queue.ts
@@ -116,26 +116,52 @@ export const createPostgresWorkflowCommandHelpers = (
   }
 
   const claimCommand = async (
-    where: string,
+    where: string | readonly string[],
     params: unknown[],
     workerId: string,
     leaseMs: number,
   ) => {
     const leaseToken = id()
+    const conditions = typeof where === 'string' ? [where] : where
+    const candidateQuery = (condition: string) => `
+      SELECT id, priority, run_at, created_at
+      FROM workflow_commands
+      WHERE run_at <= now()
+        AND (lease_token IS NULL OR lease_expires_at <= now())
+        AND dead_at IS NULL
+        AND (${condition})
+      ORDER BY priority DESC, run_at ASC, created_at ASC, id ASC
+      LIMIT 1
+      FOR UPDATE SKIP LOCKED
+    `
+    const candidateSql =
+      conditions.length === 1
+        ? `candidate AS (${candidateQuery(conditions[0]!)})`
+        : `
+          -- Per-kind probes preserve the existing ordered claim index while
+          -- the final choice keeps activity and task work globally ordered.
+          ${conditions
+            .map(
+              (condition, index) =>
+                `candidate_${index} AS (${candidateQuery(condition)})`,
+            )
+            .join(', ')},
+          eligible_candidates AS (
+            ${conditions
+              .map((_, index) => `SELECT * FROM candidate_${index}`)
+              .join(' UNION ALL ')}
+          ),
+          candidate AS (
+            SELECT id
+            FROM eligible_candidates
+            ORDER BY priority DESC, run_at ASC, created_at ASC, id ASC
+            LIMIT 1
+          )
+        `
     return await one(
       db,
       `
-      WITH candidate AS (
-        SELECT id
-        FROM workflow_commands
-        WHERE run_at <= now()
-          AND (lease_token IS NULL OR lease_expires_at <= now())
-          AND dead_at IS NULL
-          AND (${where})
-        ORDER BY priority DESC, run_at ASC, created_at ASC, id ASC
-        LIMIT 1
-        FOR UPDATE SKIP LOCKED
-      )
+      WITH ${candidateSql}
       UPDATE workflow_commands
       SET lease_owner = $${params.length + 1},
           lease_token = $${params.length + 2},

--- a/packages/workflows/src/neem/index.ts
+++ b/packages/workflows/src/neem/index.ts
@@ -1,9 +1,9 @@
 export { createWorkflowsRuntime, defineWorkflowsPlanner } from './planner.ts'
 export { defineWorkflows } from './runtime.ts'
 export type {
-  ResolvedActivityWorkerPool,
-  WorkflowsActivityWorkerPoolConfig,
-  WorkflowsNamedActivityWorkerPoolConfig,
+  ResolvedExecutionWorkerPool,
+  WorkflowsExecutionWorkerPoolConfig,
+  WorkflowsNamedExecutionWorkerPoolConfig,
   WorkflowsConfig,
   WorkflowsImplementationsFactory,
   WorkflowsRuntimeFactory,

--- a/packages/workflows/src/neem/planner.ts
+++ b/packages/workflows/src/neem/planner.ts
@@ -23,19 +23,15 @@ export function defineWorkflowsPlanner<
           'coordinator',
           config.workers.coordinator,
         ),
-        activity: config.workers.activity.flatMap((pool) =>
+        execution: config.workers.execution.flatMap((pool) =>
           Array.from(
-            { length: normalizeThreadCount('activity', pool.threads) },
+            { length: normalizeThreadCount('execution', pool.threads) },
             (): WorkflowsWorkerData => ({
-              role: 'activity',
-              activityPool: pool.name,
+              role: 'execution',
+              pool: pool.name,
             }),
           ),
         ),
-        task:
-          config.tasks.length > 0
-            ? createWorkerData('task', config.workers.task)
-            : [],
       },
       options: factory,
     }

--- a/packages/workflows/src/neem/runtime.ts
+++ b/packages/workflows/src/neem/runtime.ts
@@ -4,7 +4,11 @@ import type {
 } from '../implement/index.ts'
 import type { WorkflowRuntimeAdapter } from '../runtime/client.ts'
 import type { AnyScheduleDefinition, MaybePromise } from '../types/index.ts'
-import { collectWorkflowActivityNames } from '../runtime/worker.ts'
+import {
+  collectChildWorkflowNames,
+  collectWorkflowActivityNames,
+  collectWorkflowTaskNames,
+} from '../runtime/worker.ts'
 
 export type AnyWorkflowImplementation = Omit<
   WorkflowImplementation,
@@ -30,36 +34,35 @@ export type WorkflowSchedulesFactory<
   Schedule extends AnyScheduleDefinition = AnyScheduleDefinition,
 > = () => MaybePromise<readonly Schedule[]>
 
-export type WorkflowWorkerRole = 'coordinator' | 'activity' | 'task'
+export type WorkflowWorkerRole = 'coordinator' | 'execution'
 
 export type WorkflowsWorkerPoolConfig = {
   readonly threads?: number
   readonly concurrency?: number
   readonly leaseMs?: number
   readonly pollIntervalMs?: number
-  readonly maxIdleClaims?: number
 }
 
-export type WorkflowsActivityWorkerPoolConfig = WorkflowsWorkerPoolConfig & {
+export type WorkflowsExecutionWorkerPoolConfig = WorkflowsWorkerPoolConfig & {
   readonly activityNames?: readonly string[]
+  readonly taskNames?: readonly string[]
 }
 
-export type WorkflowsNamedActivityWorkerPoolConfig =
-  WorkflowsActivityWorkerPoolConfig & {
+export type WorkflowsNamedExecutionWorkerPoolConfig =
+  WorkflowsExecutionWorkerPoolConfig & {
     readonly name: string
   }
 
 export type WorkflowsWorkersConfig = {
   readonly coordinator?: WorkflowsWorkerPoolConfig
   /**
-   * Either one shared pool (default) or multiple isolated named pools. With
-   * named pools, each claims only its `activityNames`; at most one pool may
-   * omit `activityNames` to act as the catch-all for unmatched activities.
+   * One shared execution pool by default, or named pools selected by activity
+   * and task names. At most one named pool may omit both selectors to claim
+   * everything not assigned explicitly elsewhere.
    */
-  readonly activity?:
-    | WorkflowsActivityWorkerPoolConfig
-    | readonly WorkflowsNamedActivityWorkerPoolConfig[]
-  readonly task?: WorkflowsWorkerPoolConfig
+  readonly execution?:
+    | WorkflowsExecutionWorkerPoolConfig
+    | readonly WorkflowsNamedExecutionWorkerPoolConfig[]
 }
 
 export type WorkflowsConfig<
@@ -87,30 +90,30 @@ export type ResolvedWorkflowsConfig<
   readonly schedules: readonly TScheduleDefinition[]
   readonly workers: {
     readonly coordinator: Required<WorkflowsWorkerPoolConfig>
-    readonly activity: readonly ResolvedActivityWorkerPool[]
-    readonly task: Required<WorkflowsWorkerPoolConfig>
+    readonly execution: readonly ResolvedExecutionWorkerPool[]
   }
 }
 
-export type ResolvedActivityWorkerPool = Required<WorkflowsWorkerPoolConfig> & {
-  readonly name: string
-  readonly activityNames?: readonly string[]
-}
+export type ResolvedExecutionWorkerPool =
+  Required<WorkflowsWorkerPoolConfig> & {
+    readonly name: string
+    readonly activityNames: readonly string[]
+    readonly taskNames: readonly string[]
+  }
 
 export type WorkflowsWorkerData = {
   readonly role: WorkflowWorkerRole
-  /** Which resolved activity pool this worker serves; activity role only. */
-  readonly activityPool?: string
+  /** Which resolved execution pool this worker serves; execution role only. */
+  readonly pool?: string
 }
 
-export const DEFAULT_ACTIVITY_POOL_NAME = 'activity'
+export const DEFAULT_EXECUTION_POOL_NAME = 'execution'
 
 const defaultWorkerConfig = {
   threads: 1,
   concurrency: 1,
   leaseMs: 30_000,
   pollIntervalMs: 250,
-  maxIdleClaims: 1,
 } as const
 
 export function defineWorkflows<
@@ -153,18 +156,27 @@ export async function resolveWorkflowsConfig<
   >
 > {
   const workflows = await config.workflows()
+  const tasks = (await config.tasks?.()) ?? []
+  const workerConfig = config.workers as
+    | (WorkflowsWorkersConfig & Record<string, unknown>)
+    | undefined
+  if (workerConfig && ('activity' in workerConfig || 'task' in workerConfig)) {
+    throw new Error(
+      'Workflows workers.activity and workers.task were replaced by workers.execution',
+    )
+  }
   return {
     runtime: config.runtime,
     workflows,
-    tasks: (await config.tasks?.()) ?? [],
+    tasks,
     schedules: (await config.schedules?.()) ?? [],
     workers: {
       coordinator: normalizeWorkerPool(config.workers?.coordinator),
-      activity: normalizeActivityWorkerPools(
-        config.workers?.activity,
+      execution: normalizeExecutionWorkerPools(
+        config.workers?.execution,
         workflows,
+        tasks,
       ),
-      task: normalizeWorkerPool(config.workers?.task),
     },
   }
 }
@@ -178,97 +190,150 @@ function normalizeWorkerPool<TConfig extends WorkflowsWorkerPoolConfig>(
   }) as Required<TConfig & WorkflowsWorkerPoolConfig>
 }
 
-function normalizeActivityWorkerPools(
+function normalizeExecutionWorkerPools(
   config:
-    | WorkflowsActivityWorkerPoolConfig
-    | readonly WorkflowsNamedActivityWorkerPoolConfig[]
+    | WorkflowsExecutionWorkerPoolConfig
+    | readonly WorkflowsNamedExecutionWorkerPoolConfig[]
     | undefined,
   workflows: readonly AnyWorkflowImplementation[],
-): readonly ResolvedActivityWorkerPool[] {
-  if (config === undefined || !Array.isArray(config)) {
-    return [
-      {
-        name: DEFAULT_ACTIVITY_POOL_NAME,
-        ...normalizeWorkerPool(
-          config as WorkflowsActivityWorkerPoolConfig | undefined,
-        ),
-      },
-    ]
-  }
-
-  const pools = config as readonly WorkflowsNamedActivityWorkerPoolConfig[]
+  tasks: readonly AnyTaskImplementation[],
+): readonly ResolvedExecutionWorkerPool[] {
+  const pools: readonly WorkflowsNamedExecutionWorkerPoolConfig[] =
+    config === undefined || !Array.isArray(config)
+      ? [
+          {
+            name: DEFAULT_EXECUTION_POOL_NAME,
+            ...(config as WorkflowsExecutionWorkerPoolConfig | undefined),
+          },
+        ]
+      : (config as readonly WorkflowsNamedExecutionWorkerPoolConfig[])
   if (pools.length === 0) {
-    throw new Error('Workflows activity worker pool list must not be empty')
+    throw new Error('Workflows execution worker pool list must not be empty')
   }
 
   const names = new Set<string>()
   const claimedActivities = new Map<string, string>()
+  const claimedTasks = new Map<string, string>()
   let catchAll: string | undefined
   for (const pool of pools) {
     if (!pool.name) {
-      throw new Error('Workflows activity worker pool requires a name')
+      throw new Error('Workflows execution worker pool requires a name')
     }
     if (names.has(pool.name)) {
       throw new Error(
-        `Duplicate workflows activity worker pool name [${pool.name}]`,
+        `Duplicate workflows execution worker pool name [${pool.name}]`,
       )
     }
     names.add(pool.name)
 
-    if (pool.activityNames === undefined) {
-      // two catch-alls would race for the same unmatched activities with
-      // conflicting cadence/lease settings
+    if (pool.activityNames === undefined && pool.taskNames === undefined) {
+      // A single catch-all keeps routing deterministic across both namespaces.
       if (catchAll !== undefined) {
         throw new Error(
-          `Workflows activity worker pools [${catchAll}] and [${pool.name}] both omit activityNames; only one catch-all pool is allowed`,
+          `Workflows execution worker pools [${catchAll}] and [${pool.name}] both omit activityNames and taskNames; only one catch-all pool is allowed`,
         )
       }
       catchAll = pool.name
       continue
     }
 
-    for (const activityName of pool.activityNames) {
+    for (const activityName of pool.activityNames ?? []) {
       const owner = claimedActivities.get(activityName)
       if (owner !== undefined) {
         throw new Error(
-          `Activity [${activityName}] is claimed by both workflows worker pools [${owner}] and [${pool.name}]`,
+          `Activity [${activityName}] is claimed by both workflows execution pools [${owner}] and [${pool.name}]`,
         )
       }
       claimedActivities.set(activityName, pool.name)
     }
+    for (const taskName of pool.taskNames ?? []) {
+      const owner = claimedTasks.get(taskName)
+      if (owner !== undefined) {
+        throw new Error(
+          `Task [${taskName}] is claimed by both workflows execution pools [${owner}] and [${pool.name}]`,
+        )
+      }
+      claimedTasks.set(taskName, pool.name)
+    }
   }
 
-  // Selectors and implementations resolve from the same config, so an
-  // unknown name is always a typo or a stale entry — with a catch-all it
-  // would silently reroute the real activity there, so fail loudly.
-  const registered = new Set(collectWorkflowActivityNames(workflows))
-  const unknown = [...claimedActivities.keys()].filter(
-    (name) => !registered.has(name),
+  const registeredActivities = new Set(collectWorkflowActivityNames(workflows))
+  const registeredWorkflows = new Set(
+    workflows.map((implementation) => implementation.workflow.name),
   )
-  if (unknown.length > 0) {
+  const missingChildWorkflows = collectChildWorkflowNames(workflows).filter(
+    (name) => !registeredWorkflows.has(name),
+  )
+  if (missingChildWorkflows.length > 0) {
     throw new Error(
-      `Activities [${unknown.join(', ')}] selected by workflows activity worker pools do not exist in the registered workflows`,
+      `Workflows [${missingChildWorkflows.join(', ')}] referenced by registered workflows have no registered implementation`,
+    )
+  }
+  const registeredTasks = new Set(
+    tasks.map((implementation) => implementation.task.name),
+  )
+  const missingTaskImplementations = collectWorkflowTaskNames(workflows).filter(
+    (name) => !registeredTasks.has(name),
+  )
+  if (missingTaskImplementations.length > 0) {
+    throw new Error(
+      `Tasks [${missingTaskImplementations.join(', ')}] referenced by registered workflows have no registered implementation`,
+    )
+  }
+  const unknownActivities = [...claimedActivities.keys()].filter(
+    (name) => !registeredActivities.has(name),
+  )
+  if (unknownActivities.length > 0) {
+    throw new Error(
+      `Activities [${unknownActivities.join(', ')}] selected by workflows execution pools do not exist in the registered workflows`,
+    )
+  }
+  const unknownTasks = [...claimedTasks.keys()].filter(
+    (name) => !registeredTasks.has(name),
+  )
+  if (unknownTasks.length > 0) {
+    throw new Error(
+      `Tasks [${unknownTasks.join(', ')}] selected by workflows execution pools do not exist in the registered tasks`,
     )
   }
 
-  // Without a catch-all, an activity claimed by no pool would stall its
-  // workflows silently forever — fail loudly at startup instead.
+  // Missing coverage would otherwise leave durable commands stalled forever.
   if (catchAll === undefined) {
-    const uncovered = [...registered].filter(
+    const uncoveredActivities = [...registeredActivities].filter(
       (name) => !claimedActivities.has(name),
     )
-    if (uncovered.length > 0) {
+    if (uncoveredActivities.length > 0) {
       throw new Error(
-        `Activities [${uncovered.join(', ')}] are not claimed by any workflows activity worker pool; add them to a pool or configure a catch-all pool without activityNames`,
+        `Activities [${uncoveredActivities.join(', ')}] are not claimed by any workflows execution pool`,
+      )
+    }
+    const uncoveredTasks = [...registeredTasks].filter(
+      (name) => !claimedTasks.has(name),
+    )
+    if (uncoveredTasks.length > 0) {
+      throw new Error(
+        `Tasks [${uncoveredTasks.join(', ')}] are not claimed by any workflows execution pool`,
       )
     }
   }
 
-  return pools.map((pool) => ({
-    ...normalizeWorkerPool(pool),
-    name: pool.name,
-    ...(pool.activityNames === undefined
-      ? {}
-      : { activityNames: pool.activityNames }),
-  }))
+  return pools.map((pool) => {
+    const isCatchAll = pool.name === catchAll
+    return Object.freeze({
+      ...normalizeWorkerPool(pool),
+      name: pool.name,
+      activityNames:
+        pool.activityNames ??
+        (isCatchAll
+          ? [...registeredActivities].filter(
+              (name) => !claimedActivities.has(name),
+            )
+          : []),
+      taskNames:
+        pool.taskNames ??
+        (isCatchAll
+          ? [...registeredTasks].filter((name) => !claimedTasks.has(name))
+          : []),
+    })
+  })
 }

--- a/packages/workflows/src/neem/worker-entry.ts
+++ b/packages/workflows/src/neem/worker-entry.ts
@@ -46,6 +46,10 @@ export function defineWorkflowsWorker<
         finished,
         async start() {
           const config = await resolveWorkflowsConfig(ctx.definition)
+          const executionPool =
+            ctx.data.role === 'execution'
+              ? resolveExecutionWorkerPool(config, ctx.data)
+              : undefined
           runtime = await config.runtime()
           if (ctx.data.role === 'coordinator' && config.schedules.length > 0) {
             if (!runtime.scheduler) {
@@ -59,6 +63,7 @@ export function defineWorkflowsWorker<
             data: ctx.data,
             runtime,
             config,
+            executionPool,
             container,
             workerId: ctx.name,
             signal: abort.signal,
@@ -95,15 +100,12 @@ async function runRoleLoop(input: {
   readonly data: WorkflowsWorkerData
   readonly runtime: WorkflowRuntimeAdapter
   readonly config: ResolvedWorkflowsConfig
+  readonly executionPool?: ResolvedExecutionWorkerPool
   readonly container: Container
   readonly workerId: string
   readonly signal: AbortSignal
 }): Promise<void> {
   const role = input.data.role
-  const executionPool =
-    role === 'execution'
-      ? resolveExecutionWorkerPool(input.config, input.data)
-      : undefined
   switch (role) {
     case 'coordinator':
       await serveWorkflowWorker({
@@ -126,12 +128,12 @@ async function runRoleLoop(input: {
         container: input.container,
         workflows: input.config.workflows,
         tasks: input.config.tasks,
-        activityNames: executionPool!.activityNames,
-        taskNames: executionPool!.taskNames,
+        activityNames: input.executionPool!.activityNames,
+        taskNames: input.executionPool!.taskNames,
         workerId: input.workerId,
-        concurrency: executionPool!.concurrency,
-        leaseMs: executionPool!.leaseMs,
-        idleDelayMs: executionPool!.pollIntervalMs,
+        concurrency: input.executionPool!.concurrency,
+        leaseMs: input.executionPool!.leaseMs,
+        idleDelayMs: input.executionPool!.pollIntervalMs,
         // Coordinators own maintenance so execution capacity is not duplicated
         // across every named pool and thread.
         reaping: false,

--- a/packages/workflows/src/neem/worker-entry.ts
+++ b/packages/workflows/src/neem/worker-entry.ts
@@ -5,17 +5,12 @@ import type { WorkflowRuntimeAdapter } from '../runtime/client.ts'
 import type {
   AnyTaskImplementation,
   AnyWorkflowImplementation,
-  ResolvedActivityWorkerPool,
+  ResolvedExecutionWorkerPool,
   ResolvedWorkflowsConfig,
   WorkflowsConfig,
   WorkflowsWorkerData,
 } from './runtime.ts'
-import {
-  collectWorkflowActivityNames,
-  runActivityWorker,
-  runTaskWorker,
-  runWorkflowWorker,
-} from '../runtime/worker.ts'
+import { serveExecutionWorker, serveWorkflowWorker } from '../runtime/worker.ts'
 import { resolveWorkflowsConfig } from './runtime.ts'
 
 export type WorkflowsWorkerConfig<
@@ -35,12 +30,20 @@ export function defineWorkflowsWorker<
       const abort = new AbortController()
       const container = new Container({ logger: ctx.logger })
       let workerLoop: Promise<void> | undefined
-      let workerLoopError: unknown
       let runtime: WorkflowRuntimeAdapter | undefined
+      let resolveFinished!: () => void
+      let rejectFinished!: (error: unknown) => void
+      const finished = new Promise<void>((resolve, reject) => {
+        resolveFinished = resolve
+        rejectFinished = reject
+      })
+      // Older hosts may not observe the lifecycle promise.
+      void finished.catch(() => {})
 
       container.provide([provision(CoreInjectables.logger, ctx.logger)])
 
       return {
+        finished,
         async start() {
           const config = await resolveWorkflowsConfig(ctx.definition)
           runtime = await config.runtime()
@@ -52,7 +55,6 @@ export function defineWorkflowsWorker<
             }
             await runtime.scheduler.reconcile(config.schedules)
           }
-          workerLoopError = undefined
           workerLoop = runRoleLoop({
             data: ctx.data,
             runtime,
@@ -60,38 +62,34 @@ export function defineWorkflowsWorker<
             container,
             workerId: ctx.name,
             signal: abort.signal,
-          }).catch((error: unknown) => {
-            workerLoopError = error
+          })
+          workerLoop.then(resolveFinished, (error: unknown) => {
             ctx.logger.error(
               { err: error },
               'Neem workflows worker loop failed',
             )
-            throw error
+            rejectFinished(error)
           })
-          void workerLoop.catch(() => {})
         },
         async stop() {
           abort.abort()
+          let workerLoopFailed = false
+          let workerLoopError: unknown
           try {
             await workerLoop
           } catch (error) {
-            workerLoopError ??= error
+            workerLoopFailed = true
+            workerLoopError = error
           }
           await runtime?.dispose?.()
           workerLoop = undefined
           runtime = undefined
-          if (workerLoopError) throw workerLoopError
+          if (workerLoopFailed) throw workerLoopError
         },
       }
     },
   })
 }
-
-const ROLE_WAKE_KIND = {
-  coordinator: 'continue',
-  activity: 'activity',
-  task: 'task',
-} as const
 
 async function runRoleLoop(input: {
   readonly data: WorkflowsWorkerData
@@ -102,138 +100,62 @@ async function runRoleLoop(input: {
   readonly signal: AbortSignal
 }): Promise<void> {
   const role = input.data.role
-  const activityPool =
-    role === 'activity'
-      ? resolveActivityWorkerPool(input.config, input.data)
+  const executionPool =
+    role === 'execution'
+      ? resolveExecutionWorkerPool(input.config, input.data)
       : undefined
-  const activityNames =
-    activityPool === undefined
-      ? undefined
-      : resolveActivityPoolClaimNames(
-          activityPool,
-          input.config.workers.activity,
-          input.config.workflows,
-        )
-  // Between loop iterations the poll-interval sleep races the adapter's wake
-  // hint (if any), so a fresh command interrupts idle waiting immediately.
-  const idleSleep = async (ms: number) => {
-    const wakeEvents = input.runtime.wakeEvents
-    if (!wakeEvents) return sleep(ms, input.signal)
-    let unsubscribe = () => {}
-    const woken = new Promise<void>((resolve) => {
-      unsubscribe = wakeEvents.onCommand(ROLE_WAKE_KIND[role], resolve)
-    })
-    try {
-      await Promise.race([sleep(ms, input.signal), woken])
-    } finally {
-      unsubscribe()
-    }
-  }
+  switch (role) {
+    case 'coordinator':
+      await serveWorkflowWorker({
+        ...input.runtime,
+        container: input.container,
+        workflows: input.config.workflows,
+        workerId: input.workerId,
+        concurrency: input.config.workers.coordinator.concurrency,
+        leaseMs: input.config.workers.coordinator.leaseMs,
+        idleDelayMs: input.config.workers.coordinator.pollIntervalMs,
+        scheduling:
+          input.config.schedules.length === 0 ? undefined : { everyMs: 1000 },
+        signal: input.signal,
+      })
+      return
 
-  while (!input.signal.aborted) {
-    switch (role) {
-      case 'coordinator':
-        await runWorkflowWorker({
-          ...input.runtime,
-          container: input.container,
-          workflows: input.config.workflows,
-          workerId: input.workerId,
-          concurrency: input.config.workers.coordinator.concurrency,
-          leaseMs: input.config.workers.coordinator.leaseMs,
-          maxIdleClaims: input.config.workers.coordinator.maxIdleClaims,
-          idleDelayMs: input.config.workers.coordinator.pollIntervalMs,
-          scheduling:
-            input.config.schedules.length === 0 ? undefined : { everyMs: 1000 },
-          signal: input.signal,
-        })
-        await idleSleep(input.config.workers.coordinator.pollIntervalMs)
-        continue
-
-      case 'activity':
-        await runActivityWorker({
-          ...input.runtime,
-          container: input.container,
-          workflows: input.config.workflows,
-          activityNames,
-          workerId: input.workerId,
-          concurrency: activityPool!.concurrency,
-          leaseMs: activityPool!.leaseMs,
-          maxIdleClaims: activityPool!.maxIdleClaims,
-          idleDelayMs: activityPool!.pollIntervalMs,
-          signal: input.signal,
-        })
-        await idleSleep(activityPool!.pollIntervalMs)
-        continue
-
-      case 'task':
-        await runTaskWorker({
-          ...input.runtime,
-          container: input.container,
-          tasks: input.config.tasks,
-          workerId: input.workerId,
-          concurrency: input.config.workers.task.concurrency,
-          leaseMs: input.config.workers.task.leaseMs,
-          maxIdleClaims: input.config.workers.task.maxIdleClaims,
-          idleDelayMs: input.config.workers.task.pollIntervalMs,
-          signal: input.signal,
-        })
-        await idleSleep(input.config.workers.task.pollIntervalMs)
-        continue
-    }
+    case 'execution':
+      await serveExecutionWorker({
+        ...input.runtime,
+        container: input.container,
+        workflows: input.config.workflows,
+        tasks: input.config.tasks,
+        activityNames: executionPool!.activityNames,
+        taskNames: executionPool!.taskNames,
+        workerId: input.workerId,
+        concurrency: executionPool!.concurrency,
+        leaseMs: executionPool!.leaseMs,
+        idleDelayMs: executionPool!.pollIntervalMs,
+        // Coordinators own maintenance so execution capacity is not duplicated
+        // across every named pool and thread.
+        reaping: false,
+        signal: input.signal,
+      })
+      return
   }
 }
 
-function resolveActivityWorkerPool(
+export function resolveExecutionWorkerPool(
   config: ResolvedWorkflowsConfig,
   data: WorkflowsWorkerData,
-): ResolvedActivityWorkerPool {
-  const pools = config.workers.activity
-  if (data.activityPool !== undefined) {
-    const pool = pools.find((candidate) => candidate.name === data.activityPool)
+): ResolvedExecutionWorkerPool {
+  const pools = config.workers.execution
+  if (data.pool !== undefined) {
+    const pool = pools.find((candidate) => candidate.name === data.pool)
     if (!pool) {
-      throw new Error(
-        `Unknown workflows activity worker pool [${data.activityPool}]`,
-      )
+      throw new Error(`Unknown workflows execution worker pool [${data.pool}]`)
     }
     return pool
   }
-  // worker data without a pool name (hand-written neem config) is only
-  // unambiguous when a single pool exists
+  // Hand-written worker data can omit a name only when routing is unambiguous.
   if (pools.length === 1) return pools[0]!
   throw new Error(
-    'Workflows activity worker data must name a pool when multiple activity pools are configured',
+    'Workflows execution worker data must name a pool when multiple execution pools are configured',
   )
-}
-
-// A catch-all pool must not claim activities selected by sibling pools, or
-// capacity isolation silently breaks; explicit pools claim their list as-is.
-export function resolveActivityPoolClaimNames(
-  pool: ResolvedActivityWorkerPool,
-  pools: readonly ResolvedActivityWorkerPool[],
-  workflows: ResolvedWorkflowsConfig['workflows'],
-): readonly string[] | undefined {
-  if (pool.activityNames !== undefined) return pool.activityNames
-  const claimedElsewhere = new Set(
-    pools.flatMap((sibling) =>
-      sibling.name === pool.name ? [] : (sibling.activityNames ?? []),
-    ),
-  )
-  if (claimedElsewhere.size === 0) return undefined
-  return collectWorkflowActivityNames(workflows).filter(
-    (name) => !claimedElsewhere.has(name),
-  )
-}
-
-async function sleep(ms: number, signal: AbortSignal): Promise<void> {
-  if (ms <= 0 || signal.aborted) return
-
-  await new Promise<void>((resolve) => {
-    const done = () => {
-      clearTimeout(timeout)
-      signal.removeEventListener('abort', done)
-      resolve()
-    }
-    const timeout = setTimeout(done, ms)
-    signal.addEventListener('abort', done, { once: true })
-  })
 }

--- a/packages/workflows/src/runtime/commands.ts
+++ b/packages/workflows/src/runtime/commands.ts
@@ -53,15 +53,10 @@ export type RunCoordinationWorkerClaim = {
   readonly leaseMs: number
 }
 
-export type ActivityWorkerClaim = {
+export type ExecutionWorkerClaim = {
   readonly workerId: string
   readonly workflowNames: readonly string[]
   readonly activityNames?: readonly string[]
-  readonly leaseMs: number
-}
-
-export type TaskWorkerClaim = {
-  readonly workerId: string
   readonly taskNames: readonly string[]
   readonly leaseMs: number
 }

--- a/packages/workflows/src/runtime/executors.ts
+++ b/packages/workflows/src/runtime/executors.ts
@@ -1,12 +1,11 @@
 import type {
   ActivityAttemptCommand,
-  ActivityWorkerClaim,
   ClaimedAttempt,
   ClaimedCommand,
   ContinueRunCommand,
+  ExecutionWorkerClaim,
   RunCoordinationWorkerClaim,
   TaskAttemptCommand,
-  TaskWorkerClaim,
 } from './commands.ts'
 import type { RuntimeRunStatus } from './status.ts'
 
@@ -47,8 +46,7 @@ export type AttemptExecutor = {
     command: TaskAttemptCommand,
     options?: { readonly runAt?: Date },
   ): Promise<void>
-  claimActivity(worker: ActivityWorkerClaim): Promise<ClaimedAttempt | null>
-  claimTask(worker: TaskWorkerClaim): Promise<ClaimedAttempt | null>
+  claim(worker: ExecutionWorkerClaim): Promise<ClaimedAttempt | null>
   heartbeat(
     attempt: ClaimedAttempt,
     leaseMs?: number,

--- a/packages/workflows/src/runtime/in-memory.ts
+++ b/packages/workflows/src/runtime/in-memory.ts
@@ -135,19 +135,14 @@ export function createInMemoryWorkflowRuntime(
   const runIdempotencyKeys = new Map<string, string>()
   const runLeases = new Map<string, InMemoryRunLease>()
   const continueRunCommands: QueueItem<ContinueRunCommand>[] = []
-  const activityCommands: QueueItem<ActivityAttemptCommand>[] = []
-  const taskCommands: QueueItem<TaskAttemptCommand>[] = []
+  const attemptCommands: QueueItem<AttemptCommand>[] = []
   const claimedContinueRunCommands = new Map<
     string,
     ClaimedQueueItem<ContinueRunCommand>
   >()
-  const claimedActivityCommands = new Map<
+  const claimedAttemptCommands = new Map<
     string,
-    ClaimedQueueItem<ActivityAttemptCommand>
-  >()
-  const claimedTaskCommands = new Map<
-    string,
-    ClaimedQueueItem<TaskAttemptCommand>
+    ClaimedQueueItem<AttemptCommand>
   >()
   const schedules = new Map<string, StoredWorkflowSchedule>()
   const commandWakeListeners = new Map<
@@ -492,12 +487,11 @@ export function createInMemoryWorkflowRuntime(
           const dead = mapDeadCommand(item, 'continue')
           return dead === undefined ? [] : [dead]
         }),
-        ...activityCommands.flatMap((item) => {
-          const dead = mapDeadCommand(item, 'activity')
-          return dead === undefined ? [] : [dead]
-        }),
-        ...taskCommands.flatMap((item) => {
-          const dead = mapDeadCommand(item, 'task')
+        ...attemptCommands.flatMap((item) => {
+          const dead = mapDeadCommand(
+            item,
+            item.payload.kind === 'activityAttempt' ? 'activity' : 'task',
+          )
           return dead === undefined ? [] : [dead]
         }),
       ]
@@ -535,8 +529,14 @@ export function createInMemoryWorkflowRuntime(
         }
       }
       collect(continueRunCommands, 'continue')
-      collect(activityCommands, 'activity')
-      collect(taskCommands, 'task')
+      for (const item of attemptCommands) {
+        if (item.deadAt === undefined || item.reapedAt !== undefined) continue
+        const command = mapDeadCommand(
+          item,
+          item.payload.kind === 'activityAttempt' ? 'activity' : 'task',
+        )
+        if (command !== undefined) dead.push(command)
+      }
       return dead
         .sort((left, right) => left.deadAt.getTime() - right.deadAt.getTime())
         .slice(0, limit === Number.POSITIVE_INFINITY ? undefined : limit)
@@ -554,13 +554,11 @@ export function createInMemoryWorkflowRuntime(
         return true
       }
       if (mark(continueRunCommands)) return
-      if (mark(activityCommands)) return
-      mark(taskCommands)
+      mark(attemptCommands)
     },
     async requeueDeadCommand(commandId) {
       if (requeueDead(continueRunCommands, commandId)) return
-      if (requeueDead(activityCommands, commandId)) return
-      requeueDead(taskCommands, commandId)
+      requeueDead(attemptCommands, commandId)
     },
     async acquireRunLease({ runId, leaseMs }) {
       const date = now()
@@ -1363,11 +1361,9 @@ export function createInMemoryWorkflowRuntime(
       }
     }
     deleteQueueItemsForRunIds(continueRunCommands, treeIds)
-    deleteQueueItemsForRunIds(activityCommands, treeIds)
-    deleteQueueItemsForRunIds(taskCommands, treeIds)
+    deleteQueueItemsForRunIds(attemptCommands, treeIds)
     deleteClaimedCommandsForRunIds(claimedContinueRunCommands, treeIds)
-    deleteClaimedCommandsForRunIds(claimedActivityCommands, treeIds)
-    deleteClaimedCommandsForRunIds(claimedTaskCommands, treeIds)
+    deleteClaimedCommandsForRunIds(claimedAttemptCommands, treeIds)
   }
   const deleteQueueItemsForRunIds = <T extends { readonly runId: string }>(
     queue: QueueItem<T>[],
@@ -1387,8 +1383,7 @@ export function createInMemoryWorkflowRuntime(
   }
   const sweepDeadCommands = (deadBefore: number) => {
     sweepDeadQueueItems(continueRunCommands, deadBefore)
-    sweepDeadQueueItems(activityCommands, deadBefore)
-    sweepDeadQueueItems(taskCommands, deadBefore)
+    sweepDeadQueueItems(attemptCommands, deadBefore)
   }
   const sweepDeadQueueItems = <T extends { readonly runId: string }>(
     queue: QueueItem<T>[],
@@ -1405,12 +1400,42 @@ export function createInMemoryWorkflowRuntime(
   const claimQueued = <T>(
     queue: QueueItem<T>[],
     matches: (item: QueueItem<T>) => boolean,
+    compare?: (left: QueueItem<T>, right: QueueItem<T>) => number,
   ): QueueItem<T> | undefined => {
-    const index = queue.findIndex(
+    let index = queue.findIndex(
       (item) => item.deadAt === undefined && matches(item),
     )
     if (index === -1) return undefined
+    if (compare) {
+      for (
+        let candidateIndex = index + 1;
+        candidateIndex < queue.length;
+        candidateIndex += 1
+      ) {
+        const candidate = queue[candidateIndex]!
+        if (
+          candidate.deadAt === undefined &&
+          matches(candidate) &&
+          compare(candidate, queue[index]!) < 0
+        ) {
+          index = candidateIndex
+        }
+      }
+    }
     return queue.splice(index, 1)[0]
+  }
+
+  const compareAttemptCommands = (
+    left: QueueItem<AttemptCommand>,
+    right: QueueItem<AttemptCommand>,
+  ) => {
+    const byRunAt =
+      (left.runAt ?? left.createdAt).getTime() -
+      (right.runAt ?? right.createdAt).getTime()
+    if (byRunAt !== 0) return byRunAt
+    const byCreatedAt = left.createdAt.getTime() - right.createdAt.getTime()
+    if (byCreatedAt !== 0) return byCreatedAt
+    return left.id.localeCompare(right.id)
   }
 
   const matchesClaim = (
@@ -1535,12 +1560,8 @@ export function createInMemoryWorkflowRuntime(
     ...(item.runAt === undefined ? {} : { runAt: item.runAt }),
   })
   const attemptCommandExists = (attemptId: string) =>
-    activityCommands.some((item) => item.payload.attemptId === attemptId) ||
-    taskCommands.some((item) => item.payload.attemptId === attemptId) ||
-    [...claimedActivityCommands.values()].some(
-      (item) => item.payload.attemptId === attemptId,
-    ) ||
-    [...claimedTaskCommands.values()].some(
+    attemptCommands.some((item) => item.payload.attemptId === attemptId) ||
+    [...claimedAttemptCommands.values()].some(
       (item) => item.payload.attemptId === attemptId,
     )
 
@@ -1589,12 +1610,12 @@ export function createInMemoryWorkflowRuntime(
     },
   }
 
-  const claimedAttempt = <T extends AttemptCommand>(
-    item: QueueItem<T> | undefined,
+  const claimedAttempt = (
+    item: QueueItem<AttemptCommand> | undefined,
   ):
     | {
         readonly claim: ClaimedAttempt
-        readonly item: ClaimedQueueItem<T>
+        readonly item: ClaimedQueueItem<AttemptCommand>
       }
     | undefined => {
     if (!item) return undefined
@@ -1616,7 +1637,7 @@ export function createInMemoryWorkflowRuntime(
   const attemptExecutor: AttemptExecutor = {
     async dispatchActivity(command, options) {
       if (attemptCommandExists(command.attemptId)) return
-      activityCommands.push(
+      attemptCommands.push(
         queueItem(id('activity-command'), command, options?.runAt),
       )
       if (options?.runAt === undefined || options.runAt <= new Date()) {
@@ -1625,81 +1646,57 @@ export function createInMemoryWorkflowRuntime(
     },
     async dispatchTask(command, options) {
       if (attemptCommandExists(command.attemptId)) return
-      taskCommands.push(queueItem(id('task-command'), command, options?.runAt))
+      attemptCommands.push(
+        queueItem(id('task-command'), command, options?.runAt),
+      )
       if (options?.runAt === undefined || options.runAt <= new Date()) {
         fireWake(commandWakeListeners.get('task'))
       }
     },
-    async claimActivity(worker) {
-      const date = now()
-      const claimed = claimedAttempt(
-        claimQueued(activityCommands, (queued) => {
-          const command = queued.payload
-          return (
-            worker.workflowNames.includes(command.workflowName) &&
-            (queued.runAt === undefined || queued.runAt <= date) &&
-            (worker.activityNames === undefined ||
-              worker.activityNames.includes(command.activityName))
-          )
-        }),
-      )
-      if (!claimed) return null
-      claimedActivityCommands.set(claimed.claim.id, claimed.item)
-      return claimed.claim
-    },
-    async claimTask(worker) {
+    async claim(worker) {
       const date = now()
       const claimed = claimedAttempt(
         claimQueued(
-          taskCommands,
-          (queued) =>
-            worker.taskNames.includes(queued.payload.taskName) &&
-            (queued.runAt === undefined || queued.runAt <= date),
+          attemptCommands,
+          (queued) => {
+            const command = queued.payload
+            if (queued.runAt !== undefined && queued.runAt > date) return false
+            if (command.kind === 'taskAttempt') {
+              return worker.taskNames.includes(command.taskName)
+            }
+            return (
+              worker.workflowNames.includes(command.workflowName) &&
+              (worker.activityNames === undefined ||
+                worker.activityNames.includes(command.activityName))
+            )
+          },
+          compareAttemptCommands,
         ),
       )
       if (!claimed) return null
-      claimedTaskCommands.set(claimed.claim.id, claimed.item)
+      claimedAttemptCommands.set(claimed.claim.id, claimed.item)
       return claimed.claim
     },
     async heartbeat(attempt) {
-      const inFlight =
-        attempt.command.kind === 'activityAttempt'
-          ? claimedActivityCommands
-          : claimedTaskCommands
-      if (!matchesClaim(inFlight.get(attempt.id), attempt)) {
+      if (!matchesClaim(claimedAttemptCommands.get(attempt.id), attempt)) {
         throw new Error('Workflow attempt heartbeat lease lost')
       }
       return { runStatus: runs.get(attempt.command.runId)?.status ?? 'queued' }
     },
     async ack(attempt) {
-      const inFlight =
-        attempt.command.kind === 'activityAttempt'
-          ? claimedActivityCommands
-          : claimedTaskCommands
-      if (!matchesClaim(inFlight.get(attempt.id), attempt)) {
+      if (!matchesClaim(claimedAttemptCommands.get(attempt.id), attempt)) {
         throw new Error('Stale workflow command ack')
       }
-      inFlight.delete(attempt.id)
+      claimedAttemptCommands.delete(attempt.id)
     },
     async release(attempt, options) {
-      if (attempt.command.kind === 'activityAttempt') {
-        const claimed = claimedActivityCommands.get(attempt.id)
-        if (!claimed || !matchesClaim(claimed, attempt)) {
-          return
-        }
-
-        claimedActivityCommands.delete(attempt.id)
-        activityCommands.push(releaseQueueItem(claimed, options))
-        return
-      }
-
-      const claimed = claimedTaskCommands.get(attempt.id)
+      const claimed = claimedAttemptCommands.get(attempt.id)
       if (!claimed || !matchesClaim(claimed, attempt)) {
         return
       }
 
-      claimedTaskCommands.delete(attempt.id)
-      taskCommands.push(releaseQueueItem(claimed, options))
+      claimedAttemptCommands.delete(attempt.id)
+      attemptCommands.push(releaseQueueItem(claimed, options))
     },
     async deleteUnclaimed({ runId }) {
       const deleteQueued = <T extends AttemptCommand>(
@@ -1714,7 +1711,7 @@ export function createInMemoryWorkflowRuntime(
         return deleted
       }
 
-      return deleteQueued(activityCommands) + deleteQueued(taskCommands)
+      return deleteQueued(attemptCommands)
     },
   }
 
@@ -1867,8 +1864,18 @@ export function createInMemoryWorkflowRuntime(
       children: [...children.values()],
       attempts: [...attempts.values()],
       continueRunCommands: continueRunCommands.map(inspectQueueItem),
-      activityCommands: activityCommands.map(inspectQueueItem),
-      taskCommands: taskCommands.map(inspectQueueItem),
+      activityCommands: attemptCommands
+        .filter(
+          (item): item is QueueItem<ActivityAttemptCommand> =>
+            item.payload.kind === 'activityAttempt',
+        )
+        .map(inspectQueueItem),
+      taskCommands: attemptCommands
+        .filter(
+          (item): item is QueueItem<TaskAttemptCommand> =>
+            item.payload.kind === 'taskAttempt',
+        )
+        .map(inspectQueueItem),
       schedules: [...schedules.values()],
     }),
     wakeEvents: {

--- a/packages/workflows/src/runtime/index.ts
+++ b/packages/workflows/src/runtime/index.ts
@@ -1,13 +1,12 @@
 export type {
   ActivityAttemptCommand,
-  ActivityWorkerClaim,
   AttemptCommand,
   ClaimedAttempt,
   ClaimedCommand,
   ContinueRunCommand,
+  ExecutionWorkerClaim,
   RunCoordinationWorkerClaim,
   TaskAttemptCommand,
-  TaskWorkerClaim,
 } from './commands.ts'
 export { createWorkflowRuntimeClient } from './client.ts'
 export type {
@@ -119,18 +118,16 @@ export type {
 } from './store.ts'
 export {
   runActivityAttempt,
-  runActivityWorker,
+  runExecutionWorker,
   runTaskAttempt,
-  runTaskWorker,
   runWorkflowWorker,
   WorkflowAttemptTimeoutError,
 } from './worker.ts'
 export type {
   AttemptAbortReason,
   RunActivityAttemptInput,
-  RunActivityWorkerInput,
+  RunExecutionWorkerInput,
   RunTaskAttemptInput,
-  RunTaskWorkerInput,
   RunWorkflowWorkerInput,
   WorkerLoopOptions,
   WorkerLoopResult,

--- a/packages/workflows/src/runtime/index.ts
+++ b/packages/workflows/src/runtime/index.ts
@@ -121,6 +121,8 @@ export {
   runExecutionWorker,
   runTaskAttempt,
   runWorkflowWorker,
+  serveExecutionWorker,
+  serveWorkflowWorker,
   WorkflowAttemptTimeoutError,
 } from './worker.ts'
 export type {

--- a/packages/workflows/src/runtime/worker.ts
+++ b/packages/workflows/src/runtime/worker.ts
@@ -3,12 +3,14 @@ export {
   type RunActivityAttemptInput,
 } from './worker/activity-attempt.ts'
 export {
+  collectChildWorkflowNames,
   collectWorkflowActivityNames,
-  runActivityWorker,
-  runTaskWorker,
+  collectWorkflowTaskNames,
+  runExecutionWorker,
   runWorkflowWorker,
-  type RunActivityWorkerInput,
-  type RunTaskWorkerInput,
+  serveExecutionWorker,
+  serveWorkflowWorker,
+  type RunExecutionWorkerInput,
   type RunWorkflowWorkerInput,
   type WorkerReapingOptions,
   type WorkerRunTimeoutsOptions,
@@ -16,7 +18,6 @@ export {
 export { WorkflowAttemptTimeoutError } from './worker/heartbeat.ts'
 export type { AttemptAbortReason } from './worker/heartbeat.ts'
 export {
-  runWithConcurrency,
   type WorkerLoopOptions,
   type WorkerLoopResult,
   type WorkerMaintenanceHook,

--- a/packages/workflows/src/runtime/worker/entry.ts
+++ b/packages/workflows/src/runtime/worker/entry.ts
@@ -200,6 +200,7 @@ function workflowDriver(
         workflowNames,
         leaseMs: input.leaseMs ?? DEFAULT_LEASE_MS,
       }),
+    abandon: (claimed) => input.runCoordinationExecutor.release(claimed),
     // Continuations stay atomic during shutdown; interrupting coordination
     // mid-write is less safe than waiting for the claimed command to finish.
     async execute(claimed) {
@@ -279,6 +280,7 @@ function executionDriver(
         taskNames,
         leaseMs: input.leaseMs ?? DEFAULT_LEASE_MS,
       }),
+    abandon: (claimed) => input.attemptExecutor.release(claimed),
     async execute(claimed, signal) {
       try {
         const result =

--- a/packages/workflows/src/runtime/worker/entry.ts
+++ b/packages/workflows/src/runtime/worker/entry.ts
@@ -8,6 +8,7 @@ import type {
   AnyTaskDefinition,
   AnyWorkflowDefinition,
 } from '../../types/index.ts'
+import type { ClaimedAttempt, ClaimedCommand } from '../commands.ts'
 import type { AttemptExecutor, RunCoordinationExecutor } from '../executors.ts'
 import type { WorkflowStore } from '../store.ts'
 import type {
@@ -24,10 +25,12 @@ import {
 import { isAttemptShutdown } from './heartbeat.ts'
 import {
   DEFAULT_LEASE_MS,
+  drainWorkerPool,
   isAttemptHeartbeatLeaseLost,
   isStaleWorkflowCommandAck,
-  runWorkerLoop,
+  serveWorkerPool,
   withDefaultRetentionPruner,
+  type WorkerDriver,
   type WorkerLoopOptions,
   type WorkerLoopResult,
   type WorkerMaintenanceHook,
@@ -69,7 +72,7 @@ export type RunWorkflowWorkerInput = WorkerLoopOptions & {
   readonly runTimeouts?: false | WorkerRunTimeoutsOptions
 }
 
-export type RunActivityWorkerInput = WorkerLoopOptions & {
+export type RunExecutionWorkerInput = WorkerLoopOptions & {
   readonly store: WorkflowStore
   readonly runCoordinationExecutor: RunCoordinationExecutor
   readonly attemptExecutor: AttemptExecutor
@@ -77,17 +80,8 @@ export type RunActivityWorkerInput = WorkerLoopOptions & {
   readonly wakeEvents?: WorkflowWakeEvents
   readonly workflows: readonly AnyWorkflowImplementation[]
   readonly activityNames?: readonly string[]
-  readonly container: Pick<Container, 'createContext'>
-  readonly reaping?: false | WorkerReapingOptions
-}
-
-export type RunTaskWorkerInput = WorkerLoopOptions & {
-  readonly store: WorkflowStore
-  readonly runCoordinationExecutor: RunCoordinationExecutor
-  readonly attemptExecutor: AttemptExecutor
-  readonly atomicCompletion?: WorkflowRuntimeAtomicCompletion
-  readonly wakeEvents?: WorkflowWakeEvents
   readonly tasks: readonly AnyTaskImplementation[]
+  readonly taskNames?: readonly string[]
   readonly container: Pick<Container, 'createContext'>
   readonly reaping?: false | WorkerReapingOptions
 }
@@ -155,28 +149,60 @@ function commandWake(
   return (listener) => wakeEvents.onCommand(kind, listener)
 }
 
+function executionWake(
+  wakeEvents: WorkflowWakeEvents | undefined,
+): ((listener: () => void) => () => void) | undefined {
+  if (!wakeEvents) return undefined
+  return (listener) => {
+    const unsubscribeActivity = wakeEvents.onCommand('activity', listener)
+    const unsubscribeTask = wakeEvents.onCommand('task', listener)
+    return () => {
+      unsubscribeActivity()
+      unsubscribeTask()
+    }
+  }
+}
+
 export async function runWorkflowWorker(
   input: RunWorkflowWorkerInput,
 ): Promise<WorkerLoopResult> {
+  return drainWorkerPool(workflowWorkerOptions(input), workflowDriver(input))
+}
+
+export async function serveWorkflowWorker(
+  input: RunWorkflowWorkerInput & { readonly signal: AbortSignal },
+): Promise<WorkerLoopResult> {
+  return serveWorkerPool(
+    { ...workflowWorkerOptions(input), signal: input.signal },
+    workflowDriver(input),
+  )
+}
+
+function workflowWorkerOptions(input: RunWorkflowWorkerInput) {
+  const maintenance = withRunTimeoutsHook(input, withReapingHook(input))
+  return withDefaultRetentionPruner({
+    ...input,
+    maintenance,
+    onWake: commandWake(input.wakeEvents, 'continue'),
+  })
+}
+
+function workflowDriver(
+  input: RunWorkflowWorkerInput,
+): WorkerDriver<ClaimedCommand> {
   const workflowNames = input.workflows.map(
     (implementation) => implementation.workflow.name,
   )
-  const maintenance = withRunTimeoutsHook(input, withReapingHook(input))
-
-  return runWorkerLoop(
-    withDefaultRetentionPruner({
-      ...input,
-      maintenance,
-      onWake: commandWake(input.wakeEvents, 'continue'),
-    }),
-    async () => {
-      const claimed = await input.runCoordinationExecutor.claim({
+  return {
+    claim: () =>
+      input.runCoordinationExecutor.claim({
         workerId: input.workerId,
         workflowNames,
         leaseMs: input.leaseMs ?? DEFAULT_LEASE_MS,
-      })
-      if (!claimed) return false
-
+      }),
+    // Continuations stay atomic during shutdown; interrupting coordination
+    // mid-write is less safe than waiting for the claimed command to finish.
+    async execute(claimed) {
       try {
         return await runAtomicContinuation(input, async (scoped) => {
           const leaseMs = input.leaseMs ?? DEFAULT_LEASE_MS
@@ -207,75 +233,58 @@ export async function runWorkflowWorker(
         throw error
       }
     },
+  }
+}
+
+export async function runExecutionWorker(
+  input: RunExecutionWorkerInput,
+): Promise<WorkerLoopResult> {
+  return drainWorkerPool(executionWorkerOptions(input), executionDriver(input))
+}
+
+export async function serveExecutionWorker(
+  input: RunExecutionWorkerInput & { readonly signal: AbortSignal },
+): Promise<WorkerLoopResult> {
+  return serveWorkerPool(
+    { ...executionWorkerOptions(input), signal: input.signal },
+    executionDriver(input),
   )
 }
 
-export async function runActivityWorker(
-  input: RunActivityWorkerInput,
-): Promise<WorkerLoopResult> {
+function executionWorkerOptions(input: RunExecutionWorkerInput) {
+  return withDefaultRetentionPruner({
+    ...input,
+    maintenance: withReapingHook(input),
+    onWake: executionWake(input.wakeEvents),
+  })
+}
+
+function executionDriver(
+  input: RunExecutionWorkerInput,
+): WorkerDriver<ClaimedAttempt> {
   const workflowNames = input.workflows.map(
     (implementation) => implementation.workflow.name,
   )
   const activityNames =
     input.activityNames ?? collectWorkflowActivityNames(input.workflows)
-
-  return runWorkerLoop(
-    withDefaultRetentionPruner({
-      ...input,
-      maintenance: withReapingHook(input),
-      onWake: commandWake(input.wakeEvents, 'activity'),
-    }),
-    async () => {
-      const claimed = await input.attemptExecutor.claimActivity({
+  const taskNames =
+    input.taskNames ??
+    input.tasks.map((implementation) => implementation.task.name)
+  return {
+    claim: () =>
+      input.attemptExecutor.claim({
         workerId: input.workerId,
         workflowNames,
         activityNames,
-        leaseMs: input.leaseMs ?? DEFAULT_LEASE_MS,
-      })
-      if (!claimed) return false
-
-      try {
-        const result = await runActivityAttempt({ ...input, claimed })
-        return result.status === 'processed'
-      } catch (error) {
-        if (
-          isStaleWorkflowCommandAck(error) ||
-          isAttemptHeartbeatLeaseLost(error) ||
-          isAttemptShutdown(error)
-        ) {
-          await input.attemptExecutor.release(claimed)
-          return false
-        }
-        await input.attemptExecutor.release(claimed, { error })
-        throw error
-      }
-    },
-  )
-}
-
-export async function runTaskWorker(
-  input: RunTaskWorkerInput,
-): Promise<WorkerLoopResult> {
-  const taskNames = input.tasks.map(
-    (implementation) => implementation.task.name,
-  )
-
-  return runWorkerLoop(
-    withDefaultRetentionPruner({
-      ...input,
-      maintenance: withReapingHook(input),
-      onWake: commandWake(input.wakeEvents, 'task'),
-    }),
-    async () => {
-      const claimed = await input.attemptExecutor.claimTask({
-        workerId: input.workerId,
         taskNames,
         leaseMs: input.leaseMs ?? DEFAULT_LEASE_MS,
-      })
-      if (!claimed) return false
-
+      }),
+    async execute(claimed, signal) {
       try {
-        const result = await runTaskAttempt({ ...input, claimed })
+        const result =
+          claimed.command.kind === 'activityAttempt'
+            ? await runActivityAttempt({ ...input, claimed, signal })
+            : await runTaskAttempt({ ...input, claimed, signal })
         return result.status === 'processed'
       } catch (error) {
         if (
@@ -290,7 +299,7 @@ export async function runTaskWorker(
         throw error
       }
     },
-  )
+  }
 }
 
 export function collectWorkflowActivityNames(
@@ -307,6 +316,50 @@ export function collectWorkflowActivityNames(
       if (node.kind === 'branch' || node.kind === 'parallel') {
         for (const member of Object.values(node.cases)) {
           if (member.kind === 'activity') names.add(member.activity.name)
+        }
+      }
+    }
+  }
+
+  return [...names]
+}
+
+export function collectWorkflowTaskNames(
+  workflows: readonly Pick<AnyWorkflowImplementation, 'nodes'>[],
+): readonly string[] {
+  const names = new Set<string>()
+  for (const workflow of workflows) {
+    for (const node of workflow.nodes) {
+      if (node.kind === 'task' || node.kind === 'mapTask') {
+        names.add(node.target.name)
+        continue
+      }
+
+      if (node.kind === 'branch' || node.kind === 'parallel') {
+        for (const member of Object.values(node.cases)) {
+          if (member.kind === 'task') names.add(member.target.name)
+        }
+      }
+    }
+  }
+
+  return [...names]
+}
+
+export function collectChildWorkflowNames(
+  workflows: readonly Pick<AnyWorkflowImplementation, 'nodes'>[],
+): readonly string[] {
+  const names = new Set<string>()
+  for (const workflow of workflows) {
+    for (const node of workflow.nodes) {
+      if (node.kind === 'workflow' || node.kind === 'mapWorkflow') {
+        names.add(node.target.name)
+        continue
+      }
+
+      if (node.kind === 'branch' || node.kind === 'parallel') {
+        for (const member of Object.values(node.cases)) {
+          if (member.kind === 'workflow') names.add(member.target.name)
         }
       }
     }

--- a/packages/workflows/src/runtime/worker/loop.ts
+++ b/packages/workflows/src/runtime/worker/loop.ts
@@ -1,3 +1,5 @@
+import { setTimeout as wait } from 'node:timers/promises'
+
 import type { DurationString } from '../../types/index.ts'
 import type { WorkflowScheduler } from '../scheduler.ts'
 import type {
@@ -8,28 +10,6 @@ import type {
 import { parseDurationMs } from '../duration.ts'
 
 export const DEFAULT_LEASE_MS = 30_000
-
-export async function runWithConcurrency<T>(
-  items: readonly T[],
-  concurrency: number,
-  worker: (item: T) => Promise<void>,
-): Promise<void> {
-  assertPositiveInteger(concurrency, 'Concurrency')
-
-  let nextIndex = 0
-
-  async function runWorker(): Promise<void> {
-    while (nextIndex < items.length) {
-      const item = items[nextIndex]
-      nextIndex += 1
-      await worker(item)
-    }
-  }
-
-  await Promise.all(
-    Array.from({ length: Math.min(concurrency, items.length) }, runWorker),
-  )
-}
 
 export type WorkerLoopResult = {
   readonly processed: number
@@ -56,7 +36,6 @@ export type WorkerLoopOptions = {
   readonly workerId: string
   readonly concurrency?: number
   readonly leaseMs?: number
-  readonly maxIdleClaims?: number
   readonly idleDelayMs?: number
   /**
    * Push-style wake hint: subscribes a listener that short-circuits the idle
@@ -71,156 +50,289 @@ export type WorkerLoopOptions = {
   readonly signal?: AbortSignal
 }
 
-export async function runWorkerLoop(
+export type WorkerDriver<Claimed> = {
+  readonly claim: () => Promise<Claimed | null>
+  readonly execute: (claimed: Claimed, signal: AbortSignal) => Promise<boolean>
+}
+
+export function drainWorkerPool<Claimed>(
   options: WorkerLoopOptions,
-  claimAndRun: () => Promise<boolean>,
+  driver: WorkerDriver<Claimed>,
+): Promise<WorkerLoopResult> {
+  return runWorkerPool(options, driver, 'drain')
+}
+
+export function serveWorkerPool<Claimed>(
+  options: WorkerLoopOptions & { readonly signal: AbortSignal },
+  driver: WorkerDriver<Claimed>,
+): Promise<WorkerLoopResult> {
+  return runWorkerPool(options, driver, 'serve')
+}
+
+type WorkerMode = 'drain' | 'serve'
+
+type PeriodicTask = {
+  readonly everyMs: number
+  readonly run: (now: Date) => Promise<void>
+  nextAt: number
+}
+
+async function runWorkerPool<Claimed>(
+  options: WorkerLoopOptions,
+  driver: WorkerDriver<Claimed>,
+  mode: WorkerMode,
 ): Promise<WorkerLoopResult> {
   const concurrency = options.concurrency ?? 1
-  const maxIdleClaims = options.maxIdleClaims ?? 1
   assertPositiveInteger(concurrency, 'Concurrency')
-  assertPositiveInteger(maxIdleClaims, 'Max idle claims')
+  if (options.idleDelayMs !== undefined) {
+    assertNonNegative(options.idleDelayMs, 'Idle delay')
+  }
+
+  const periodicTasks = resolvePeriodicTasks(options)
 
   let processed = 0
+  let failed = false
   let firstError: unknown
-  let stopped = false
-  let lastRetentionAt = 0
-  let lastSchedulingAt = 0
-  let retentionRunning = false
-  let schedulingRunning = false
-  const runRetentionPrune = async () => {
-    if (!options.retention || !options.retentionPruner) return
-    const everyMs = options.retention.everyMs ?? 60_000
-    if (!Number.isFinite(everyMs) || everyMs < 0) {
-      throw new Error('Retention everyMs must be a non-negative number')
-    }
-    const date = Date.now()
-    if (retentionRunning || date - lastRetentionAt < everyMs) return
+  const lifecycle = new AbortController()
+  const executions = new AbortController()
+  const wake = createWakeSignal(options.onWake)
+  const forwardAbort = () => {
+    lifecycle.abort(options.signal?.reason)
+    executions.abort(options.signal?.reason)
+    wake.notify()
+  }
+  if (options.signal?.aborted) forwardAbort()
+  else options.signal?.addEventListener('abort', forwardAbort, { once: true })
 
+  const active = new Set<Promise<void>>()
+  const fail = (error: unknown) => {
+    if (!failed) firstError = error
+    failed = true
+    // Claimed siblings finish normally so their leases are not needlessly
+    // abandoned and redelivered after an unrelated execution fails.
+    lifecycle.abort(error)
+    wake.notify()
+  }
+  const startExecution = (claimed: Claimed) => {
+    const task = driver
+      .execute(claimed, executions.signal)
+      .then((didProcess) => {
+        if (didProcess) processed += 1
+      })
+      .catch(fail)
+      .finally(() => {
+        active.delete(task)
+        wake.notify()
+      })
+    active.add(task)
+  }
+  const periodic =
+    mode === 'serve' && periodicTasks.length > 0
+      ? runPeriodicLoop(periodicTasks, lifecycle.signal, wake.notify).catch(
+          fail,
+        )
+      : undefined
+
+  let drainPeriodicPending = mode === 'drain' && periodicTasks.length > 0
+  try {
+    while (!lifecycle.signal.aborted) {
+      let queueEmpty = false
+      while (active.size < concurrency && !lifecycle.signal.aborted) {
+        let claimed: Claimed | null
+        try {
+          claimed = await driver.claim()
+        } catch (error) {
+          fail(error)
+          break
+        }
+        if (claimed === null) {
+          queueEmpty = true
+          break
+        }
+
+        startExecution(claimed)
+      }
+      if (lifecycle.signal.aborted) break
+
+      if (queueEmpty) {
+        if (active.size > 0) {
+          // Polling still discovers due work when an adapter has no wake source.
+          await wake.wait(
+            Math.max(1, options.idleDelayMs ?? 250),
+            lifecycle.signal,
+          )
+          continue
+        }
+
+        if (wake.consume()) continue
+
+        if (mode === 'drain') {
+          if (!drainPeriodicPending) break
+          drainPeriodicPending = false
+          try {
+            await runDuePeriodicTasks(periodicTasks)
+          } catch (error) {
+            fail(error)
+            break
+          }
+          // Maintenance can enqueue immediately claimable work.
+          continue
+        }
+
+        await wake.wait(
+          Math.max(1, options.idleDelayMs ?? 250),
+          lifecycle.signal,
+        )
+        continue
+      }
+
+      // A full pool only needs a completion; durable wakes remain claimable.
+      await wake.wait(undefined, lifecycle.signal)
+    }
+  } finally {
+    lifecycle.abort()
+    wake.notify()
+    await Promise.allSettled(active)
+    await periodic
+    wake.dispose()
+    options.signal?.removeEventListener('abort', forwardAbort)
+  }
+
+  if (failed) throw firstError
+  return { processed }
+}
+
+function resolvePeriodicTasks(options: WorkerLoopOptions): PeriodicTask[] {
+  const tasks: PeriodicTask[] = []
+  if (options.retention && options.retentionPruner) {
+    const everyMs = options.retention.everyMs ?? 60_000
+    assertNonNegative(everyMs, 'Retention everyMs')
     const olderThanMs = parseDurationMs(options.retention.olderThan)
     if (olderThanMs === undefined) {
       throw new Error(
         `Invalid retention olderThan duration [${options.retention.olderThan}]`,
       )
     }
-
-    retentionRunning = true
-    lastRetentionAt = date
-    try {
-      await options.retentionPruner.pruneTerminalRuns({
-        olderThan: new Date(date - olderThanMs),
-        batchSize: options.retention.batchSize,
-        statuses: options.retention.statuses,
-      })
-    } finally {
-      retentionRunning = false
-    }
-  }
-  const maintenanceState = (options.maintenance ?? []).map(() => ({
-    lastAt: 0,
-    running: false,
-  }))
-  const runMaintenance = async () => {
-    const hooks = options.maintenance ?? []
-    for (const [index, hook] of hooks.entries()) {
-      const state = maintenanceState[index]!
-      if (!Number.isFinite(hook.everyMs) || hook.everyMs < 0) {
-        throw new Error('Maintenance everyMs must be a non-negative number')
-      }
-      const date = Date.now()
-      if (state.running || date - state.lastAt < hook.everyMs) continue
-
-      state.running = true
-      state.lastAt = date
-      try {
-        await hook.run(new Date(date))
-      } finally {
-        state.running = false
-      }
-    }
-  }
-  const runScheduling = async () => {
-    if (!options.scheduling || !options.scheduler) return
-    const everyMs = options.scheduling.everyMs ?? 1_000
-    if (!Number.isFinite(everyMs) || everyMs < 0) {
-      throw new Error('Scheduling everyMs must be a non-negative number')
-    }
-    const date = Date.now()
-    if (schedulingRunning || date - lastSchedulingAt < everyMs) return
-
-    schedulingRunning = true
-    lastSchedulingAt = date
-    try {
-      await options.scheduler.fireDue({
-        now: new Date(date),
-        limit: options.scheduling.batchSize,
-      })
-    } finally {
-      schedulingRunning = false
-    }
-  }
-  // Wake hints arriving mid-claim must not be lost: latch them and let the
-  // next idle sleep consume the latch instead of waiting out the delay.
-  let wakePending = false
-  const wakeWaiters = new Set<() => void>()
-  const unsubscribeWake = options.onWake?.(() => {
-    wakePending = true
-    for (const waiter of wakeWaiters) waiter()
-  })
-  const idleSleep = async () => {
-    if (wakePending) {
-      wakePending = false
-      return
-    }
-    let waiter: () => void = () => {}
-    const wakeable = new Promise<void>((resolve) => {
-      waiter = resolve
-      wakeWaiters.add(resolve)
+    tasks.push({
+      everyMs,
+      nextAt: 0,
+      run: (now) =>
+        options
+          .retentionPruner!.pruneTerminalRuns({
+            olderThan: new Date(now.getTime() - olderThanMs),
+            batchSize: options.retention!.batchSize,
+            statuses: options.retention!.statuses,
+          })
+          .then(() => undefined),
     })
-    try {
-      await Promise.race([
-        sleep(options.idleDelayMs ?? 0, options.signal),
-        wakeable,
-      ])
-    } finally {
-      wakeWaiters.delete(waiter)
-    }
-    wakePending = false
   }
+  if (options.scheduling && options.scheduler) {
+    const everyMs = options.scheduling.everyMs ?? 1_000
+    assertNonNegative(everyMs, 'Scheduling everyMs')
+    tasks.push({
+      everyMs,
+      nextAt: 0,
+      run: (now) =>
+        options
+          .scheduler!.fireDue({
+            now,
+            limit: options.scheduling!.batchSize,
+          })
+          .then(() => undefined),
+    })
+  }
+  for (const hook of options.maintenance ?? []) {
+    assertNonNegative(hook.everyMs, 'Maintenance everyMs')
+    tasks.push({ ...hook, nextAt: 0 })
+  }
+  return tasks
+}
 
-  await Promise.allSettled(
-    Array.from({ length: concurrency }, async () => {
-      let idleClaims = 0
-      try {
-        while (
-          !stopped &&
-          !options.signal?.aborted &&
-          idleClaims < maxIdleClaims
-        ) {
-          const didWork = await claimAndRun()
-          if (didWork) {
-            processed += 1
-            idleClaims = 0
-            continue
+async function runPeriodicLoop(
+  tasks: PeriodicTask[],
+  signal: AbortSignal,
+  notify: () => void,
+): Promise<void> {
+  while (!signal.aborted) {
+    await runDuePeriodicTasks(tasks)
+    notify()
+    const nextAt = Math.min(...tasks.map((task) => task.nextAt))
+    // A zero interval remains useful for tests and eager maintenance, but a
+    // timer floor prevents it from becoming an unbounded microtask loop.
+    try {
+      await wait(Math.max(1, nextAt - Date.now()), undefined, { signal })
+    } catch (error) {
+      if (!signal.aborted) throw error
+    }
+  }
+}
+
+async function runDuePeriodicTasks(tasks: PeriodicTask[]): Promise<void> {
+  for (const task of tasks) {
+    const date = Date.now()
+    if (date < task.nextAt) continue
+    task.nextAt = date + task.everyMs
+    await task.run(new Date(date))
+  }
+}
+
+function createWakeSignal(subscribe: WorkerLoopOptions['onWake']): {
+  readonly notify: () => void
+  readonly consume: () => boolean
+  readonly wait: (
+    timeoutMs: number | undefined,
+    signal: AbortSignal,
+  ) => Promise<void>
+  readonly dispose: () => void
+} {
+  let pending = false
+  let waiter: (() => void) | undefined
+  const notify = () => {
+    pending = true
+    waiter?.()
+  }
+  const consume = () => {
+    if (!pending) return false
+    pending = false
+    return true
+  }
+  const unsubscribe = subscribe?.(notify)
+
+  return {
+    notify,
+    consume,
+    async wait(timeoutMs, signal) {
+      if (signal.aborted) return
+      if (consume()) return
+
+      const reason = await new Promise<'notified' | 'timeout' | 'aborted'>(
+        (resolve) => {
+          let settled = false
+          let timeout: ReturnType<typeof setTimeout> | undefined
+          const finish = (result: 'notified' | 'timeout' | 'aborted') => {
+            if (settled) return
+            settled = true
+            if (timeout !== undefined) clearTimeout(timeout)
+            if (waiter === onNotify) waiter = undefined
+            signal.removeEventListener('abort', onAbort)
+            resolve(result)
           }
+          const onNotify = () => finish('notified')
+          const onAbort = () => finish('aborted')
 
-          idleClaims += 1
-          await runRetentionPrune()
-          await runScheduling()
-          await runMaintenance()
-          if (idleClaims < maxIdleClaims) {
-            await idleSleep()
+          waiter = onNotify
+          signal.addEventListener('abort', onAbort, { once: true })
+          if (timeoutMs !== undefined) {
+            timeout = setTimeout(() => finish('timeout'), timeoutMs)
           }
-        }
-      } catch (error) {
-        stopped = true
-        firstError ??= error
-      }
-    }),
-  )
-  unsubscribeWake?.()
-
-  if (firstError) throw firstError
-  return { processed }
+        },
+      )
+      if (reason === 'notified') consume()
+    },
+    dispose() {
+      unsubscribe?.()
+    },
+  }
 }
 
 export function withDefaultRetentionPruner<
@@ -230,27 +342,15 @@ export function withDefaultRetentionPruner<
   return { ...input, retentionPruner: input.store }
 }
 
-async function sleep(
-  ms: number,
-  signal: AbortSignal | undefined,
-): Promise<void> {
-  if (ms <= 0 || signal?.aborted) return
-
-  await new Promise<void>((resolve) => {
-    const done = () => {
-      clearTimeout(timeout)
-      signal?.removeEventListener('abort', done)
-      resolve()
-    }
-
-    const timeout = setTimeout(done, ms)
-    signal?.addEventListener('abort', done, { once: true })
-  })
-}
-
 function assertPositiveInteger(value: number, label: string): void {
   if (!Number.isInteger(value) || value < 1) {
     throw new Error(`${label} must be a positive integer`)
+  }
+}
+
+function assertNonNegative(value: number, label: string): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative number`)
   }
 }
 

--- a/packages/workflows/src/runtime/worker/loop.ts
+++ b/packages/workflows/src/runtime/worker/loop.ts
@@ -52,6 +52,8 @@ export type WorkerLoopOptions = {
 
 export type WorkerDriver<Claimed> = {
   readonly claim: () => Promise<Claimed | null>
+  /** Return a lease acquired after the pool has stopped, before execution. */
+  readonly abandon: (claimed: Claimed) => Promise<void>
   readonly execute: (claimed: Claimed, signal: AbortSignal) => Promise<boolean>
 }
 
@@ -147,6 +149,14 @@ async function runWorkerPool<Claimed>(
         }
         if (claimed === null) {
           queueEmpty = true
+          break
+        }
+        if (lifecycle.signal.aborted) {
+          try {
+            await driver.abandon(claimed)
+          } catch (error) {
+            fail(error)
+          }
           break
         }
 

--- a/packages/workflows/tests/integration/postgres-runtime.spec.ts
+++ b/packages/workflows/tests/integration/postgres-runtime.spec.ts
@@ -422,6 +422,7 @@ describe.skipIf(!postgresTarget.url)(
         workerId: 'activity-stale',
         leaseMs: 60,
         idleDelayMs: 20,
+        reaping: false,
       })
       await firstStartedPromise
       await pool.query(
@@ -429,13 +430,14 @@ describe.skipIf(!postgresTarget.url)(
           UPDATE workflow_commands
           SET lease_owner = 'activity-stealer',
               lease_token = 'stolen',
-              lease_expires_at = now() - interval '1 millisecond'
+              lease_expires_at = now() + interval '100 milliseconds'
           WHERE kind = 'activity' AND run_id = $1
         `,
         [run.id],
       )
 
       await expect(staleWorker).resolves.toStrictEqual({ processed: 0 })
+      await wait(120)
       await runExecutionWorker({
         tasks: [],
         ...runtime,

--- a/packages/workflows/tests/integration/postgres-runtime.spec.ts
+++ b/packages/workflows/tests/integration/postgres-runtime.spec.ts
@@ -14,8 +14,7 @@ import {
 } from '../../src/index.ts'
 import {
   createWorkflowRuntimeClient,
-  runActivityWorker,
-  runTaskWorker,
+  runExecutionWorker,
   runWorkflowWorker,
   type RunSnapshot,
 } from '../../src/runtime/index.ts'
@@ -108,7 +107,6 @@ describe.skipIf(!postgresTarget.url)(
         container,
         workflows: [liveImpl],
         workerId: 'retention-live-worker',
-        maxIdleClaims: 2,
         idleDelayMs: 10,
       })
       const deadCommandRun = await runtime.store.createRun({
@@ -282,7 +280,8 @@ describe.skipIf(!postgresTarget.url)(
         workflows: [workflowImpl],
         workerId: 'coordinator-crash',
       })
-      const claimed = await runtime.attemptExecutor.claimActivity({
+      const claimed = await runtime.attemptExecutor.claim({
+        taskNames: [],
         workerId: 'activity-crashed',
         workflowNames: [workflow.name],
         activityNames: ['content'],
@@ -291,13 +290,13 @@ describe.skipIf(!postgresTarget.url)(
       expect(claimed).not.toBeNull()
 
       await wait(150)
-      await runActivityWorker({
+      await runExecutionWorker({
+        tasks: [],
         ...runtime,
         container,
         workflows: [workflowImpl],
         workerId: 'activity-reclaimer',
         leaseMs: 200,
-        maxIdleClaims: 4,
         idleDelayMs: 20,
       })
       await runWorkflowWorker({
@@ -344,22 +343,22 @@ describe.skipIf(!postgresTarget.url)(
       })
 
       await Promise.all([
-        runActivityWorker({
+        runExecutionWorker({
+          tasks: [],
           ...runtime,
           container,
           workflows: [workflowImpl],
           workerId: 'activity-heartbeat-1',
           leaseMs: 180,
-          maxIdleClaims: 8,
           idleDelayMs: 80,
         }),
-        runActivityWorker({
+        runExecutionWorker({
+          tasks: [],
           ...runtime,
           container,
           workflows: [workflowImpl],
           workerId: 'activity-heartbeat-2',
           leaseMs: 180,
-          maxIdleClaims: 8,
           idleDelayMs: 80,
         }),
       ])
@@ -415,13 +414,13 @@ describe.skipIf(!postgresTarget.url)(
         workerId: 'coordinator-lease-loss',
       })
 
-      const staleWorker = runActivityWorker({
+      const staleWorker = runExecutionWorker({
+        tasks: [],
         ...runtime,
         container,
         workflows: [workflowImpl],
         workerId: 'activity-stale',
         leaseMs: 60,
-        maxIdleClaims: 1,
         idleDelayMs: 20,
       })
       await firstStartedPromise
@@ -437,13 +436,13 @@ describe.skipIf(!postgresTarget.url)(
       )
 
       await expect(staleWorker).resolves.toStrictEqual({ processed: 0 })
-      await runActivityWorker({
+      await runExecutionWorker({
+        tasks: [],
         ...runtime,
         container,
         workflows: [workflowImpl],
         workerId: 'activity-fresh',
         leaseMs: 200,
-        maxIdleClaims: 4,
         idleDelayMs: 20,
       })
       await runWorkflowWorker({
@@ -515,16 +514,15 @@ describe.skipIf(!postgresTarget.url)(
         workflows: [parentImpl, childImpl],
         workerId: 'coordinator-cancel-prime',
         leaseMs: 200,
-        maxIdleClaims: 5,
         idleDelayMs: 10,
       })
-      const activityWorker = runActivityWorker({
+      const activityWorker = runExecutionWorker({
+        tasks: [],
         ...runtime,
         container,
         workflows: [childImpl],
         workerId: 'activity-cancel-late',
         leaseMs: 500,
-        maxIdleClaims: 1,
       })
       await slowStartedPromise
 
@@ -535,7 +533,6 @@ describe.skipIf(!postgresTarget.url)(
         workflows: [parentImpl, childImpl],
         workerId: 'coordinator-cancel',
         leaseMs: 200,
-        maxIdleClaims: 10,
         idleDelayMs: 10,
       })
 
@@ -567,7 +564,6 @@ describe.skipIf(!postgresTarget.url)(
         workflows: [parentImpl, childImpl],
         workerId: 'coordinator-cancel-after-late',
         leaseMs: 200,
-        maxIdleClaims: 5,
         idleDelayMs: 10,
       })
 
@@ -631,13 +627,13 @@ describe.skipIf(!postgresTarget.url)(
         leaseMs,
       })
 
-      const activityWorker = runActivityWorker({
+      const activityWorker = runExecutionWorker({
+        tasks: [],
         ...runtime,
         container,
         workflows: [workflowImpl],
         workerId: 'activity-cancel-signal',
         leaseMs,
-        maxIdleClaims: 1,
       })
       await activityStartedPromise
 
@@ -649,7 +645,6 @@ describe.skipIf(!postgresTarget.url)(
         workflows: [workflowImpl],
         workerId: 'coordinator-cancel-signal',
         leaseMs,
-        maxIdleClaims: 5,
         idleDelayMs: 10,
       })
       await expect(activityWorker).resolves.toStrictEqual({ processed: 1 })
@@ -717,7 +712,6 @@ describe.skipIf(!postgresTarget.url)(
             workflows: [workflowImpl],
             workerId: `coordinator-contention-${index}`,
             leaseMs: 200,
-            maxIdleClaims: 10,
             idleDelayMs: 10,
           }),
         ),
@@ -761,7 +755,6 @@ describe.skipIf(!postgresTarget.url)(
             workflows: [workflowImpl],
             workerId: `schedule-coordinator-${index}`,
             scheduling: { everyMs: 0, batchSize: 10 },
-            maxIdleClaims: 4,
             idleDelayMs: 10,
           }),
         ),
@@ -803,7 +796,6 @@ describe.skipIf(!postgresTarget.url)(
         workflows: [workflowImpl],
         workerId: 'schedule-disable-first',
         scheduling: { everyMs: 0, batchSize: 10 },
-        maxIdleClaims: 4,
         idleDelayMs: 10,
       })
       await runtime.scheduler!.setEnabled(schedule.name, false)
@@ -844,7 +836,6 @@ describe.skipIf(!postgresTarget.url)(
         container,
         workflows: [workflowImpl],
         workerId: 'delayed-start-before',
-        maxIdleClaims: 2,
         idleDelayMs: 20,
       })
       const queued = await runtime.store.loadRunSnapshot(run.id)
@@ -888,31 +879,30 @@ async function runWorkersUntilCompleted(
           workflows: input.workflows,
           workerId: `coordinator-${round}-${index}`,
           leaseMs: input.leaseMs ?? 300,
-          maxIdleClaims: 20,
           idleDelayMs: 10,
         }),
       ),
       ...Array.from({ length: workerCount }, (_, index) =>
-        runActivityWorker({
+        runExecutionWorker({
+          tasks: [],
           ...input.runtime,
           container: input.container,
           workflows: input.workflows,
           workerId: `activity-${round}-${index}`,
           leaseMs: input.leaseMs ?? 300,
-          maxIdleClaims: 20,
           idleDelayMs: 10,
         }),
       ),
       ...Array.from(
         { length: tasks.length === 0 ? 0 : workerCount },
         (_, index) =>
-          runTaskWorker({
+          runExecutionWorker({
+            workflows: [],
             ...input.runtime,
             container: input.container,
             tasks,
             workerId: `task-${round}-${index}`,
             leaseMs: input.leaseMs ?? 300,
-            maxIdleClaims: 20,
             idleDelayMs: 10,
           }),
       ),

--- a/packages/workflows/tests/integration/postgres-wake-events.spec.ts
+++ b/packages/workflows/tests/integration/postgres-wake-events.spec.ts
@@ -13,7 +13,7 @@ import { installPostgresWorkflowSchemaForTesting } from '../../src/adapters/post
 import { defineWorkflow, implementWorkflow } from '../../src/index.ts'
 import {
   createWorkflowRuntimeClient,
-  runActivityWorker,
+  runExecutionWorker,
   runWorkflowWorker,
 } from '../../src/runtime/index.ts'
 import {
@@ -135,18 +135,17 @@ describe.skipIf(!postgresTarget.url)(
           container,
           workflows: [implementation],
           workerId: 'wake-coordinator',
-          maxIdleClaims: 1_000,
           idleDelayMs: LONG_DELAY_MS,
           reaping: false,
           runTimeouts: false,
           signal: abort.signal,
         }),
-        runActivityWorker({
+        runExecutionWorker({
+          tasks: [],
           ...runtime,
           container,
           workflows: [implementation],
           workerId: 'wake-activity',
-          maxIdleClaims: 1_000,
           idleDelayMs: LONG_DELAY_MS,
           reaping: false,
           signal: abort.signal,
@@ -307,20 +306,19 @@ describe.skipIf(!postgresTarget.url)(
           container,
           workflows: [implementation],
           workerId: 'cancel-coordinator',
-          maxIdleClaims: 1_000,
           idleDelayMs: 25,
           reaping: false,
           runTimeouts: false,
           signal: abort.signal,
         }),
-        runActivityWorker({
+        runExecutionWorker({
+          tasks: [],
           ...runtime,
           container,
           workflows: [implementation],
           workerId: 'cancel-activity',
           // heartbeat interval = leaseMs / 3; far beyond the asserted latency
           leaseMs: LONG_DELAY_MS * 3,
-          maxIdleClaims: 1_000,
           idleDelayMs: 25,
           reaping: false,
           signal: abort.signal,

--- a/packages/workflows/tests/integration/postgres-wake-events.spec.ts
+++ b/packages/workflows/tests/integration/postgres-wake-events.spec.ts
@@ -13,8 +13,8 @@ import { installPostgresWorkflowSchemaForTesting } from '../../src/adapters/post
 import { defineWorkflow, implementWorkflow } from '../../src/index.ts'
 import {
   createWorkflowRuntimeClient,
-  runExecutionWorker,
-  runWorkflowWorker,
+  serveExecutionWorker,
+  serveWorkflowWorker,
 } from '../../src/runtime/index.ts'
 import {
   createTestContainer,
@@ -130,7 +130,7 @@ describe.skipIf(!postgresTarget.url)(
 
       const abort = new AbortController()
       const workers = Promise.allSettled([
-        runWorkflowWorker({
+        serveWorkflowWorker({
           ...runtime,
           container,
           workflows: [implementation],
@@ -140,7 +140,7 @@ describe.skipIf(!postgresTarget.url)(
           runTimeouts: false,
           signal: abort.signal,
         }),
-        runExecutionWorker({
+        serveExecutionWorker({
           tasks: [],
           ...runtime,
           container,
@@ -301,7 +301,7 @@ describe.skipIf(!postgresTarget.url)(
 
       const abort = new AbortController()
       const workers = Promise.allSettled([
-        runWorkflowWorker({
+        serveWorkflowWorker({
           ...runtime,
           container,
           workflows: [implementation],
@@ -311,7 +311,7 @@ describe.skipIf(!postgresTarget.url)(
           runTimeouts: false,
           signal: abort.signal,
         }),
-        runExecutionWorker({
+        serveExecutionWorker({
           tasks: [],
           ...runtime,
           container,

--- a/packages/workflows/tests/neem-integration.spec.ts
+++ b/packages/workflows/tests/neem-integration.spec.ts
@@ -184,6 +184,39 @@ describe('workflows Neem integration', () => {
     )
   })
 
+  it('rejects unknown execution worker routing before starting the runtime', async () => {
+    let runtimeCalls = 0
+    const config = defineWorkflows({
+      runtime: () => {
+        runtimeCalls += 1
+        return createInMemoryWorkflowRuntime()
+      },
+      workflows: () => [workflowImpl],
+      workers: { execution: [{ name: 'primary' }] },
+    })
+    const worker = defineWorkflowsWorker(config)
+    const channel = new MessageChannel()
+    const runtime = await worker.createRuntime({
+      mode: 'development',
+      name: 'workflows:execution:missing',
+      data: { role: 'execution', pool: 'missing' },
+      logger,
+      definition: worker.definition,
+      port: channel.port1,
+    })
+
+    try {
+      await expect(runtime.start()).rejects.toThrow(
+        'Unknown workflows execution worker pool [missing]',
+      )
+      expect(runtimeCalls).toBe(0)
+    } finally {
+      await runtime.stop()
+      channel.port1.close()
+      channel.port2.close()
+    }
+  })
+
   it('rejects named pools that leave a registered activity uncovered', async () => {
     const workflowWithActivities = defineWorkflow({
       name: 'neem.integration.pool-coverage',

--- a/packages/workflows/tests/neem-integration.spec.ts
+++ b/packages/workflows/tests/neem-integration.spec.ts
@@ -22,10 +22,9 @@ import {
   defineWorkflows,
   defineWorkflowsPlanner,
   defineWorkflowsWorker,
-  type WorkflowsNamedActivityWorkerPoolConfig,
+  type WorkflowsNamedExecutionWorkerPoolConfig,
 } from '../src/neem/index.ts'
 import { resolveWorkflowsConfig } from '../src/neem/runtime.ts'
-import { resolveActivityPoolClaimNames } from '../src/neem/worker-entry.ts'
 import {
   createInMemoryWorkflowRuntime,
   createWorkflowRuntimeClient,
@@ -56,14 +55,13 @@ describe('workflows Neem integration', () => {
     expect(declaration.host?.entry).toBe('@nmtjs/workflows/neem/host')
   })
 
-  it('plans coordinator, activity, and task worker groups', async () => {
+  it('plans coordinator and execution worker groups', async () => {
     const config = defineWorkflows({
       runtime: () => createInMemoryWorkflowRuntime(),
       workflows: () => [workflowImpl],
       workers: {
         coordinator: { threads: 2, concurrency: 3 },
-        activity: { threads: 1 },
-        task: { threads: 4 },
+        execution: { threads: 4 },
       },
     })
     const planner = defineWorkflowsPlanner(() => config)
@@ -76,12 +74,16 @@ describe('workflows Neem integration', () => {
     expect(plan.options).toBeDefined()
     expect(plan.workers).toStrictEqual({
       coordinator: [{ role: 'coordinator' }, { role: 'coordinator' }],
-      activity: [{ role: 'activity', activityPool: 'activity' }],
-      task: [],
+      execution: [
+        { role: 'execution', pool: 'execution' },
+        { role: 'execution', pool: 'execution' },
+        { role: 'execution', pool: 'execution' },
+        { role: 'execution', pool: 'execution' },
+      ],
     })
   })
 
-  it('plans one worker group per named activity pool', async () => {
+  it('plans one worker group per named execution pool', async () => {
     const pooledWorkflow = defineWorkflow({
       name: 'neem.integration.pooled',
       input: t.object({}),
@@ -99,7 +101,7 @@ describe('workflows Neem integration', () => {
       runtime: () => createInMemoryWorkflowRuntime(),
       workflows: () => [pooledImpl],
       workers: {
-        activity: [
+        execution: [
           {
             name: 'interactive',
             activityNames: ['handleUserRequest'],
@@ -121,16 +123,15 @@ describe('workflows Neem integration', () => {
 
     expect(plan.workers).toStrictEqual({
       coordinator: [{ role: 'coordinator' }],
-      activity: [
-        { role: 'activity', activityPool: 'interactive' },
-        { role: 'activity', activityPool: 'interactive' },
-        { role: 'activity', activityPool: 'batch' },
+      execution: [
+        { role: 'execution', pool: 'interactive' },
+        { role: 'execution', pool: 'interactive' },
+        { role: 'execution', pool: 'batch' },
       ],
-      task: [],
     })
 
     const resolved = await resolveWorkflowsConfig(config)
-    expect(resolved.workers.activity).toMatchObject([
+    expect(resolved.workers.execution).toMatchObject([
       {
         name: 'interactive',
         activityNames: ['handleUserRequest'],
@@ -138,20 +139,25 @@ describe('workflows Neem integration', () => {
         pollIntervalMs: 25,
         leaseMs: 6_000,
       },
-      { name: 'batch', concurrency: 50, pollIntervalMs: 250 },
+      {
+        name: 'batch',
+        activityNames: [],
+        taskNames: [],
+        concurrency: 50,
+        pollIntervalMs: 250,
+      },
     ])
-    expect(resolved.workers.activity[1]!.activityNames).toBeUndefined()
   })
 
-  it('rejects invalid activity pool lists', async () => {
+  it('rejects invalid execution pool lists', async () => {
     const reject = async (
-      activity: readonly WorkflowsNamedActivityWorkerPoolConfig[],
+      execution: readonly WorkflowsNamedExecutionWorkerPoolConfig[],
       message: string,
     ) => {
       const config = defineWorkflows({
         runtime: () => createInMemoryWorkflowRuntime(),
         workflows: () => [workflowImpl],
-        workers: { activity },
+        workers: { execution },
       })
       await expect(resolveWorkflowsConfig(config)).rejects.toThrow(message)
     }
@@ -163,7 +169,7 @@ describe('workflows Neem integration', () => {
         { name: 'one', activityNames: ['a'] },
         { name: 'one', activityNames: ['b'] },
       ],
-      'Duplicate workflows activity worker pool name [one]',
+      'Duplicate workflows execution worker pool name [one]',
     )
     await reject(
       [{ name: 'one' }, { name: 'two' }],
@@ -174,7 +180,7 @@ describe('workflows Neem integration', () => {
         { name: 'one', activityNames: ['a'] },
         { name: 'two', activityNames: ['a'] },
       ],
-      'Activity [a] is claimed by both workflows worker pools [one] and [two]',
+      'Activity [a] is claimed by both workflows execution pools [one] and [two]',
     )
   })
 
@@ -196,11 +202,11 @@ describe('workflows Neem integration', () => {
       runtime: () => createInMemoryWorkflowRuntime(),
       workflows: () => [impl],
       workers: {
-        activity: [{ name: 'interactive', activityNames: ['fast'] }],
+        execution: [{ name: 'interactive', activityNames: ['fast'] }],
       },
     })
     await expect(resolveWorkflowsConfig(uncovered)).rejects.toThrow(
-      'Activities [slow] are not claimed by any workflows activity worker pool',
+      'Activities [slow] are not claimed by any workflows execution pool',
     )
 
     // a catch-all pool absorbs the rest — same pools plus catch-all resolves
@@ -208,7 +214,7 @@ describe('workflows Neem integration', () => {
       runtime: () => createInMemoryWorkflowRuntime(),
       workflows: () => [impl],
       workers: {
-        activity: [
+        execution: [
           { name: 'interactive', activityNames: ['fast'] },
           { name: 'batch' },
         ],
@@ -221,7 +227,7 @@ describe('workflows Neem integration', () => {
       runtime: () => createInMemoryWorkflowRuntime(),
       workflows: () => [impl],
       workers: {
-        activity: [
+        execution: [
           { name: 'interactive', activityNames: ['fast'] },
           { name: 'heavy', activityNames: ['slow'] },
         ],
@@ -235,18 +241,18 @@ describe('workflows Neem integration', () => {
       runtime: () => createInMemoryWorkflowRuntime(),
       workflows: () => [impl],
       workers: {
-        activity: [
+        execution: [
           { name: 'interactive', activityNames: ['fastt'] },
           { name: 'batch' },
         ],
       },
     })
     await expect(resolveWorkflowsConfig(typo)).rejects.toThrow(
-      'Activities [fastt] selected by workflows activity worker pools do not exist in the registered workflows',
+      'Activities [fastt] selected by workflows execution pools do not exist in the registered workflows',
     )
   })
 
-  it('computes catch-all pool claim names as the complement of named pools', async () => {
+  it('resolves catch-all selectors as the complement of named pools', async () => {
     const workflowWithActivities = defineWorkflow({
       name: 'neem.integration.pool-complement',
       input: t.object({}),
@@ -266,44 +272,131 @@ describe('workflows Neem integration', () => {
       runtime: () => createInMemoryWorkflowRuntime(),
       workflows: () => [impl],
       workers: {
-        activity: [
+        execution: [
           { name: 'interactive', activityNames: ['fast'] },
           { name: 'batch' },
         ],
       },
     })
     const resolved = await resolveWorkflowsConfig(config)
-    const [interactive, batch] = resolved.workers.activity
+    const [interactive, batch] = resolved.workers.execution
 
-    expect(
-      resolveActivityPoolClaimNames(
-        interactive!,
-        resolved.workers.activity,
-        resolved.workflows,
-      ),
-    ).toStrictEqual(['fast'])
-    expect(
-      resolveActivityPoolClaimNames(
-        batch!,
-        resolved.workers.activity,
-        resolved.workflows,
-      ),
-    ).toStrictEqual(['slow', 'bulk'])
+    expect(interactive!.activityNames).toStrictEqual(['fast'])
+    expect(batch!.activityNames).toStrictEqual(['slow', 'bulk'])
 
-    // a single catch-all pool claims everything (undefined = no filter)
+    // A single catch-all resolves to every registered execution name.
     const soloConfig = defineWorkflows({
       runtime: () => createInMemoryWorkflowRuntime(),
       workflows: () => [impl],
-      workers: { activity: [{ name: 'only' }] },
+      workers: { execution: [{ name: 'only' }] },
     })
     const solo = await resolveWorkflowsConfig(soloConfig)
-    expect(
-      resolveActivityPoolClaimNames(
-        solo.workers.activity[0]!,
-        solo.workers.activity,
-        solo.workflows,
+    expect(solo.workers.execution[0]!.activityNames).toStrictEqual([
+      'fast',
+      'slow',
+      'bulk',
+    ])
+  })
+
+  it('rejects child workflows without a registered implementation', async () => {
+    const child = defineWorkflow({
+      name: 'neem.integration.unregistered-child',
+      input: t.object({}),
+      output: t.object({}),
+    }).build()
+    const parent = defineWorkflow({
+      name: 'neem.integration.parent-with-unregistered-child',
+      input: t.object({}),
+      output: t.object({}),
+    })
+      .workflow('child', child)
+      .build()
+    const parentImpl = implementWorkflow(parent)
+      .child(child)
+      .finish(() => ({}))
+
+    await expect(
+      resolveWorkflowsConfig(
+        defineWorkflows({
+          runtime: () => createInMemoryWorkflowRuntime(),
+          workflows: () => [parentImpl],
+        }),
       ),
-    ).toBeUndefined()
+    ).rejects.toThrow(
+      `Workflows [${child.name}] referenced by registered workflows have no registered implementation`,
+    )
+  })
+
+  it('validates and resolves task selectors independently from activities', async () => {
+    const task = defineTask({
+      name: 'neem.integration.routed-task',
+      input: t.object({}),
+      output: t.object({}),
+    })
+    const taskImpl = implementTask(task, { handler: async () => ({}) })
+    const workflowWithTask = defineWorkflow({
+      name: 'neem.integration.workflow-with-routed-task',
+      input: t.object({}),
+      output: t.object({}),
+    })
+      .task('run', task)
+      .build()
+    const workflowWithTaskImpl = implementWorkflow(workflowWithTask)
+      .run(task, { input: () => ({}) })
+      .finish(() => ({}))
+    const resolve = (
+      execution: readonly WorkflowsNamedExecutionWorkerPoolConfig[],
+    ) =>
+      resolveWorkflowsConfig(
+        defineWorkflows({
+          runtime: () => createInMemoryWorkflowRuntime(),
+          workflows: () => [],
+          tasks: () => [taskImpl],
+          workers: { execution },
+        }),
+      )
+
+    await expect(
+      resolveWorkflowsConfig(
+        defineWorkflows({
+          runtime: () => createInMemoryWorkflowRuntime(),
+          workflows: () => [workflowWithTaskImpl],
+        }),
+      ),
+    ).rejects.toThrow(
+      `Tasks [${task.name}] referenced by registered workflows have no registered implementation`,
+    )
+
+    await expect(
+      resolve([{ name: 'activity-only', activityNames: [] }]),
+    ).rejects.toThrow(
+      `Tasks [${task.name}] are not claimed by any workflows execution pool`,
+    )
+    await expect(
+      resolve([
+        { name: 'typo', taskNames: ['missing-task'] },
+        { name: 'remaining' },
+      ]),
+    ).rejects.toThrow(
+      'Tasks [missing-task] selected by workflows execution pools do not exist',
+    )
+    await expect(
+      resolve([
+        { name: 'one', taskNames: [task.name] },
+        { name: 'two', taskNames: [task.name] },
+      ]),
+    ).rejects.toThrow(
+      `Task [${task.name}] is claimed by both workflows execution pools [one] and [two]`,
+    )
+
+    const resolved = await resolve([
+      { name: 'tasks', taskNames: [task.name] },
+      { name: 'remaining' },
+    ])
+    expect(resolved.workers.execution).toMatchObject([
+      { name: 'tasks', activityNames: [], taskNames: [task.name] },
+      { name: 'remaining', activityNames: [], taskNames: [] },
+    ])
   })
 
   it('accepts task implementations with typed dependencies', async () => {
@@ -354,7 +447,7 @@ describe('workflows Neem integration', () => {
       }),
       workflows: () => [workflowImpl],
       workers: {
-        coordinator: { pollIntervalMs: 1, maxIdleClaims: 1 },
+        coordinator: { pollIntervalMs: 1 },
       },
     })
     const worker = defineWorkflowsWorker(config)
@@ -373,6 +466,7 @@ describe('workflows Neem integration', () => {
 
     await runtime.start()
     await runtime.stop()
+    await expect(runtime.finished).resolves.toBeUndefined()
     expect(dispose).toHaveBeenCalledOnce()
     channel.port1.close()
     channel.port2.close()
@@ -415,15 +509,15 @@ describe('workflows Neem integration', () => {
       workflows: () => [],
       tasks: () => [taskImpl],
       workers: {
-        task: { pollIntervalMs: 1, maxIdleClaims: 1, leaseMs: 30 },
+        execution: { pollIntervalMs: 1, leaseMs: 30 },
       },
     })
     const worker = defineWorkflowsWorker(config)
     const channel = new MessageChannel()
     const runtime = await worker.createRuntime({
       mode: 'development',
-      name: 'workflows:task:shutdown',
-      data: { role: 'task' },
+      name: 'workflows:execution:shutdown',
+      data: { role: 'execution' },
       logger,
       definition: worker.definition,
       port: channel.port1,
@@ -465,7 +559,7 @@ describe('workflows Neem integration', () => {
       runtime: () => brokenRuntime,
       workflows: () => [workflowImpl],
       workers: {
-        coordinator: { pollIntervalMs: 1, maxIdleClaims: 1 },
+        coordinator: { pollIntervalMs: 1 },
       },
     })
     const worker = defineWorkflowsWorker(config)
@@ -481,6 +575,7 @@ describe('workflows Neem integration', () => {
 
     await runtime.start()
     await waitFor(() => (errorSpy.mock.calls.length > 0 ? true : undefined))
+    await expect(runtime.finished).rejects.toThrow('coordinator claim failed')
     await expect(runtime.stop()).rejects.toThrow('coordinator claim failed')
     expect(errorSpy).toHaveBeenCalledWith(
       { err: failure },
@@ -491,7 +586,7 @@ describe('workflows Neem integration', () => {
     errorSpy.mockRestore()
   })
 
-  it('runs coordinator, activity, and task role loops end-to-end', async () => {
+  it('runs coordinator and execution role loops end-to-end', async () => {
     const task = defineTask({
       name: 'neem.integration.task',
       input: t.object({ text: t.string() }),
@@ -525,14 +620,13 @@ describe('workflows Neem integration', () => {
       workflows: () => [fullWorkflowImpl],
       tasks: () => [taskImpl],
       workers: {
-        coordinator: { pollIntervalMs: 1, maxIdleClaims: 1 },
-        activity: { pollIntervalMs: 1, maxIdleClaims: 1 },
-        task: { pollIntervalMs: 1, maxIdleClaims: 1 },
+        coordinator: { pollIntervalMs: 1 },
+        execution: { pollIntervalMs: 1 },
       },
     })
     const worker = defineWorkflowsWorker(config)
     const runtimes = await Promise.all(
-      (['coordinator', 'activity', 'task'] as const).map(async (role) => {
+      (['coordinator', 'execution'] as const).map(async (role) => {
         const channel = new MessageChannel()
         const runtime = await worker.createRuntime({
           mode: 'development',
@@ -582,7 +676,7 @@ describe('workflows Neem integration', () => {
       workflows: () => [workflowImpl],
       schedules: () => [schedule],
       workers: {
-        coordinator: { pollIntervalMs: 1, maxIdleClaims: 1 },
+        coordinator: { pollIntervalMs: 1 },
       },
     })
     const worker = defineWorkflowsWorker(config)

--- a/packages/workflows/tests/postgres-atomic-runtime.spec.ts
+++ b/packages/workflows/tests/postgres-atomic-runtime.spec.ts
@@ -17,8 +17,7 @@ import {
 } from '../src/index.ts'
 import {
   createWorkflowRuntimeClient,
-  runActivityWorker,
-  runTaskWorker,
+  runExecutionWorker,
   runWorkflowWorker,
 } from '../src/runtime/index.ts'
 
@@ -223,7 +222,8 @@ test('rolls back standalone task completion when command ack fails', async () =>
   const run = await client.start(task, { text: 'alpha' })
 
   await expect(
-    runTaskWorker({
+    runExecutionWorker({
+      workflows: [],
       ...failingRuntime,
       tasks: [taskImpl],
       container: createTestContainer(),
@@ -260,7 +260,8 @@ test('rolls back standalone task failure when command ack fails', async () => {
   const run = await client.start(task, { text: 'alpha' })
 
   await expect(
-    runTaskWorker({
+    runExecutionWorker({
+      workflows: [],
       ...failingRuntime,
       tasks: [taskImpl],
       container: createTestContainer(),
@@ -315,7 +316,8 @@ test('rolls back activity completion when command ack fails', async () => {
   ).toBe(1)
 
   await expect(
-    runActivityWorker({
+    runExecutionWorker({
+      tasks: [],
       ...failingRuntime,
       workflows: [workflowImpl],
       container,
@@ -371,7 +373,8 @@ test('rolls back activity completion when command ack lease is stale', async () 
   ).toBe(1)
 
   await expect(
-    runActivityWorker({
+    runExecutionWorker({
+      tasks: [],
       ...staleRuntime,
       workflows: [workflowImpl],
       container,

--- a/packages/workflows/tests/postgres-drizzle-schema.spec.ts
+++ b/packages/workflows/tests/postgres-drizzle-schema.spec.ts
@@ -1079,7 +1079,8 @@ test('postgres error releases record delivery metadata and cap exponential backo
     input: {},
   }
   await runtime.attemptExecutor.dispatchActivity(command)
-  const claimed = await runtime.attemptExecutor.claimActivity({
+  const claimed = await runtime.attemptExecutor.claim({
+    taskNames: [],
     workerId: 'activity-worker-1',
     workflowNames: ['postgres-error-release-workflow'],
     activityNames: ['content'],
@@ -1155,7 +1156,8 @@ test('returns no activity claim for an empty activity filter', async () => {
   const runtime = createPostgresWorkflowRuntime({ connection })
 
   await expect(
-    runtime.attemptExecutor.claimActivity({
+    runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker',
       workflowNames: ['workflow-without-activities'],
       activityNames: [],
@@ -1185,7 +1187,8 @@ test('extends activity command leases with heartbeat', async () => {
   }
 
   await runtime.attemptExecutor.dispatchActivity(command)
-  const claimed = await runtime.attemptExecutor.claimActivity({
+  const claimed = await runtime.attemptExecutor.claim({
+    taskNames: [],
     workerId: 'activity-worker-1',
     workflowNames: [command.workflowName],
     activityNames: [command.activityName],
@@ -1198,7 +1201,8 @@ test('extends activity command leases with heartbeat', async () => {
   await new Promise((resolve) => setTimeout(resolve, 40))
 
   await expect(
-    runtime.attemptExecutor.claimActivity({
+    runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-2',
       workflowNames: [command.workflowName],
       activityNames: [command.activityName],
@@ -1231,7 +1235,8 @@ test('uses postgres-side timestamps for command claim, heartbeat, and release', 
   }
 
   await runtime.attemptExecutor.dispatchActivity(command)
-  const claimed = await runtime.attemptExecutor.claimActivity({
+  const claimed = await runtime.attemptExecutor.claim({
+    taskNames: [],
     workerId: 'activity-worker-1',
     workflowNames: [command.workflowName],
     activityNames: [command.activityName],
@@ -1944,7 +1949,6 @@ test('worker retention pruning takes the Postgres advisory transaction lock', as
     container,
     workflows: [],
     workerId: 'postgres-retention-worker',
-    maxIdleClaims: 1,
     retention: {
       olderThan: '0ms',
       batchSize: 1,

--- a/packages/workflows/tests/postgres-retry-scheduling.spec.ts
+++ b/packages/workflows/tests/postgres-retry-scheduling.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../src/adapters/postgres.ts'
 import { installPostgresWorkflowSchemaForTesting } from '../src/adapters/postgres/testing.ts'
 import { defineTask, implementTask } from '../src/index.ts'
-import { runTaskWorker, startTaskRun } from '../src/runtime/index.ts'
+import { runExecutionWorker, startTaskRun } from '../src/runtime/index.ts'
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
@@ -78,7 +78,8 @@ describe('postgres retry scheduling', () => {
 
     const firstStartedAt = Date.now()
     activeWorker = new AbortController()
-    await runTaskWorker({
+    await runExecutionWorker({
+      workflows: [],
       ...runtime,
       container: createTestContainer(),
       tasks: [implementation],
@@ -114,7 +115,8 @@ describe('postgres retry scheduling', () => {
       )
       secondStartedAt = Date.now()
       activeWorker = new AbortController()
-      await runTaskWorker({
+      await runExecutionWorker({
+        workflows: [],
         ...runtime,
         container: createTestContainer(),
         tasks: [implementation],

--- a/packages/workflows/tests/postgres-worker-smoke.spec.ts
+++ b/packages/workflows/tests/postgres-worker-smoke.spec.ts
@@ -76,7 +76,6 @@ test('runs direct child and mapWorkflow through postgres workers', async () => {
     container,
     workflows: [parentImpl, childImpl],
     workerId: 'postgres-smoke-worker',
-    maxIdleClaims: 3,
   })
 
   const snapshot = await client.get(run.id)

--- a/packages/workflows/tests/runtime-adapter-contract.spec.ts
+++ b/packages/workflows/tests/runtime-adapter-contract.spec.ts
@@ -195,7 +195,6 @@ function workflowRuntimeAdapterContract(
         container: testContainer,
         workflows: [implementation],
         workerId: 'cancel-worker-1',
-        maxIdleClaims: 3,
       })
 
       const snapshot = await client.get(run.id)
@@ -242,14 +241,12 @@ function workflowRuntimeAdapterContract(
         container: testContainer,
         workflows: [parentImplementation],
         workerId: 'parent-worker-2',
-        maxIdleClaims: 3,
       })
       await runWorkflowWorker({
         ...runtime,
         container: testContainer,
         workflows: [childImplementation],
         workerId: 'child-worker-1',
-        maxIdleClaims: 3,
       })
 
       const parentSnapshot = await client.get(run.id)
@@ -270,7 +267,9 @@ function workflowRuntimeAdapterContract(
 
       const run = await client.start(task, { text: 'alpha' })
       const snapshot = await client.get(run.id)
-      const claimed = await runtime.attemptExecutor.claimTask({
+      const claimed = await runtime.attemptExecutor.claim({
+        workflowNames: [],
+        activityNames: [],
         workerId: 'task-worker-1',
         taskNames: [task.name],
         leaseMs: 30_000,
@@ -325,7 +324,9 @@ function workflowRuntimeAdapterContract(
         run: { id: run.id, status: 'queued' },
       })
       await expect(
-        runtime.attemptExecutor.claimTask({
+        runtime.attemptExecutor.claim({
+          workflowNames: [],
+          activityNames: [],
           workerId: 'task-before-start',
           taskNames: [task.name],
           leaseMs: 30_000,
@@ -367,7 +368,9 @@ function workflowRuntimeAdapterContract(
         },
       ])
       await expect(
-        runtime.attemptExecutor.claimTask({
+        runtime.attemptExecutor.claim({
+          workflowNames: [],
+          activityNames: [],
           workerId: 'task-before-idempotent-start',
           taskNames: [task.name],
           leaseMs: 30_000,
@@ -390,7 +393,9 @@ function workflowRuntimeAdapterContract(
         { text: 'alpha' },
         { idempotencyKey },
       )
-      const claimed = await runtime.attemptExecutor.claimTask({
+      const claimed = await runtime.attemptExecutor.claim({
+        workflowNames: [],
+        activityNames: [],
         workerId: 'task-consume-idempotent-start',
         taskNames: [task.name],
         leaseMs: 30_000,
@@ -404,7 +409,9 @@ function workflowRuntimeAdapterContract(
 
       expect(replay.id).toBe(run.id)
       await expect(
-        runtime.attemptExecutor.claimTask({
+        runtime.attemptExecutor.claim({
+          workflowNames: [],
+          activityNames: [],
           workerId: 'task-after-idempotent-replay',
           taskNames: [task.name],
           leaseMs: 30_000,
@@ -680,7 +687,8 @@ function workflowRuntimeAdapterContract(
         input: {},
       }
       await runtime.attemptExecutor.dispatchActivity(command)
-      const claimed = await runtime.attemptExecutor.claimActivity({
+      const claimed = await runtime.attemptExecutor.claim({
+        taskNames: [],
         workerId: 'activity-worker-1',
         workflowNames: ['dead-attempt-workflow'],
         activityNames: ['content'],
@@ -704,7 +712,8 @@ function workflowRuntimeAdapterContract(
         },
       ])
       await runtime.store.requeueDeadCommand(dead[0]!.id)
-      const requeued = await runtime.attemptExecutor.claimActivity({
+      const requeued = await runtime.attemptExecutor.claim({
+        taskNames: [],
         workerId: 'activity-worker-2',
         workflowNames: ['dead-attempt-workflow'],
         activityNames: ['content'],
@@ -813,7 +822,8 @@ function workflowRuntimeAdapterContract(
         }),
       ).resolves.toBeNull()
       await expect(
-        runtime.attemptExecutor.claimActivity({
+        runtime.attemptExecutor.claim({
+          taskNames: [],
           workerId: 'prune-checker',
           workflowNames: [root.workflowName],
           activityNames: ['content'],
@@ -1299,7 +1309,8 @@ function workflowRuntimeAdapterContract(
         }),
       ).resolves.toBeNull()
       await expect(
-        runtime.attemptExecutor.claimActivity({
+        runtime.attemptExecutor.claim({
+          taskNames: [],
           workerId: 'delete-attempt-checker',
           workflowNames: [root.workflowName],
           activityNames: ['content'],
@@ -1402,7 +1413,6 @@ function workflowRuntimeAdapterContract(
           container: testContainer,
           workflows: [implementation],
           workerId: 'poison-worker-1',
-          maxIdleClaims: 1,
         }),
       ).rejects.toThrow('poison worker continue')
 
@@ -1455,30 +1465,33 @@ function workflowRuntimeAdapterContract(
       await runtime.attemptExecutor.dispatchActivity(activityCommand)
       await runtime.attemptExecutor.dispatchTask(taskCommand)
 
-      const wrongWorkflow = await runtime.attemptExecutor.claimActivity({
+      const wrongWorkflow = await runtime.attemptExecutor.claim({
+        taskNames: [],
         workerId: 'activity-worker-1',
         workflowNames: ['other-workflow'],
         leaseMs: 30_000,
       })
-      const wrongActivity = await runtime.attemptExecutor.claimActivity({
+      const wrongActivity = await runtime.attemptExecutor.claim({
+        taskNames: [],
         workerId: 'activity-worker-1',
         workflowNames: ['attempt-workflow'],
         activityNames: ['other-activity'],
         leaseMs: 30_000,
       })
-      const activity = await runtime.attemptExecutor.claimActivity({
+      const activity = await runtime.attemptExecutor.claim({
+        taskNames: [],
         workerId: 'activity-worker-1',
         workflowNames: ['attempt-workflow'],
         activityNames: ['content'],
         leaseMs: 30_000,
       })
-      const noneWhileActivityClaimed =
-        await runtime.attemptExecutor.claimActivity({
-          workerId: 'activity-worker-2',
-          workflowNames: ['attempt-workflow'],
-          activityNames: ['content'],
-          leaseMs: 30_000,
-        })
+      const noneWhileActivityClaimed = await runtime.attemptExecutor.claim({
+        taskNames: [],
+        workerId: 'activity-worker-2',
+        workflowNames: ['attempt-workflow'],
+        activityNames: ['content'],
+        leaseMs: 30_000,
+      })
 
       expect(wrongWorkflow).toBeNull()
       expect(wrongActivity).toBeNull()
@@ -1500,19 +1513,19 @@ function workflowRuntimeAdapterContract(
       ).rejects.toThrow('Workflow attempt heartbeat lease lost')
       await runtime.attemptExecutor.release(activity!)
 
-      const activityBeforeBackoff = await runtime.attemptExecutor.claimActivity(
-        {
-          workerId: 'activity-worker-2',
-          workflowNames: ['attempt-workflow'],
-          activityNames: ['content'],
-          leaseMs: 30_000,
-        },
-      )
+      const activityBeforeBackoff = await runtime.attemptExecutor.claim({
+        taskNames: [],
+        workerId: 'activity-worker-2',
+        workflowNames: ['attempt-workflow'],
+        activityNames: ['content'],
+        leaseMs: 30_000,
+      })
       expect(activityBeforeBackoff).toBeNull()
 
       await waitForReleaseBackoff()
 
-      const reclaimedActivity = await runtime.attemptExecutor.claimActivity({
+      const reclaimedActivity = await runtime.attemptExecutor.claim({
+        taskNames: [],
         workerId: 'activity-worker-2',
         workflowNames: ['attempt-workflow'],
         activityNames: ['content'],
@@ -1522,7 +1535,8 @@ function workflowRuntimeAdapterContract(
 
       await runtime.attemptExecutor.ack(reclaimedActivity!)
 
-      const activityAfterAck = await runtime.attemptExecutor.claimActivity({
+      const activityAfterAck = await runtime.attemptExecutor.claim({
+        taskNames: [],
         workerId: 'activity-worker-3',
         workflowNames: ['attempt-workflow'],
         activityNames: ['content'],
@@ -1530,12 +1544,16 @@ function workflowRuntimeAdapterContract(
       })
       expect(activityAfterAck).toBeNull()
 
-      const wrongTask = await runtime.attemptExecutor.claimTask({
+      const wrongTask = await runtime.attemptExecutor.claim({
+        workflowNames: [],
+        activityNames: [],
         workerId: 'task-worker-1',
         taskNames: ['other-task'],
         leaseMs: 30_000,
       })
-      const task = await runtime.attemptExecutor.claimTask({
+      const task = await runtime.attemptExecutor.claim({
+        workflowNames: [],
+        activityNames: [],
         workerId: 'task-worker-1',
         taskNames: ['embedding'],
         leaseMs: 30_000,
@@ -1549,7 +1567,9 @@ function workflowRuntimeAdapterContract(
 
       await runtime.attemptExecutor.release(task!)
 
-      const taskBeforeBackoff = await runtime.attemptExecutor.claimTask({
+      const taskBeforeBackoff = await runtime.attemptExecutor.claim({
+        workflowNames: [],
+        activityNames: [],
         workerId: 'task-worker-2',
         taskNames: ['embedding'],
         leaseMs: 30_000,
@@ -1558,7 +1578,9 @@ function workflowRuntimeAdapterContract(
 
       await waitForReleaseBackoff()
 
-      const reclaimedTask = await runtime.attemptExecutor.claimTask({
+      const reclaimedTask = await runtime.attemptExecutor.claim({
+        workflowNames: [],
+        activityNames: [],
         workerId: 'task-worker-2',
         taskNames: ['embedding'],
         leaseMs: 30_000,
@@ -1567,12 +1589,74 @@ function workflowRuntimeAdapterContract(
 
       await runtime.attemptExecutor.ack(reclaimedTask!)
 
-      const taskAfterAck = await runtime.attemptExecutor.claimTask({
+      const taskAfterAck = await runtime.attemptExecutor.claim({
+        workflowNames: [],
+        activityNames: [],
         workerId: 'task-worker-3',
         taskNames: ['embedding'],
         leaseMs: 30_000,
       })
       expect(taskAfterAck).toBeNull()
+    })
+
+    it('claims activities and tasks from one globally ordered queue', async () => {
+      const runtime = await createRuntime()
+      const taskRun = await runtime.store.createRun({
+        kind: 'task',
+        name: 'ordered-task',
+        workflowName: 'ordered-task',
+        taskName: 'ordered-task',
+        input: {},
+      })
+      const activityRun = await runtime.store.createRun({
+        workflowName: 'ordered-workflow',
+        input: {},
+      })
+      const taskCommand = {
+        kind: 'taskAttempt' as const,
+        workflowName: 'ordered-task',
+        taskName: 'ordered-task',
+        runId: taskRun.id,
+        nodeName: '$task',
+        childKey: '$self',
+        attemptId: '00000000-0000-4000-8000-000000000211',
+        leaseToken: 'task-lease',
+        input: {},
+      }
+      const activityCommand = {
+        kind: 'activityAttempt' as const,
+        workflowName: 'ordered-workflow',
+        activityName: 'ordered-activity',
+        runId: activityRun.id,
+        nodeName: 'ordered-activity',
+        childKey: '$self',
+        attemptId: '00000000-0000-4000-8000-000000000212',
+        leaseToken: 'activity-lease',
+        input: {},
+      }
+
+      await runtime.attemptExecutor.dispatchTask(taskCommand)
+      await runtime.attemptExecutor.dispatchActivity(activityCommand)
+
+      const selectors = {
+        workflowNames: ['ordered-workflow'],
+        activityNames: ['ordered-activity'],
+        taskNames: ['ordered-task'],
+        leaseMs: 30_000,
+      }
+      const first = await runtime.attemptExecutor.claim({
+        ...selectors,
+        workerId: 'execution-worker-1',
+      })
+      const second = await runtime.attemptExecutor.claim({
+        ...selectors,
+        workerId: 'execution-worker-1',
+      })
+
+      expect(first?.command).toStrictEqual(taskCommand)
+      expect(second?.command).toStrictEqual(activityCommand)
+      await runtime.attemptExecutor.ack(first!)
+      await runtime.attemptExecutor.ack(second!)
     })
 
     it('leases one coordinator per run and ignores stale lease release', async () => {
@@ -2045,7 +2129,8 @@ function workflowRuntimeAdapterContract(
         command(otherRun.id, '00000000-0000-4000-8000-000000000303'),
         { runAt: new Date(firstRunAt.getTime() + 2) },
       )
-      const claimed = await runtime.attemptExecutor.claimActivity({
+      const claimed = await runtime.attemptExecutor.claim({
+        taskNames: [],
         workerId: 'activity-worker-1',
         workflowNames: ['delete-unclaimed-workflow'],
         activityNames: ['content'],
@@ -2055,7 +2140,8 @@ function workflowRuntimeAdapterContract(
       const deleted = await runtime.attemptExecutor.deleteUnclaimed({
         runId: run.id,
       })
-      const remainingClaim = await runtime.attemptExecutor.claimActivity({
+      const remainingClaim = await runtime.attemptExecutor.claim({
+        taskNames: [],
         workerId: 'activity-worker-2',
         workflowNames: ['delete-unclaimed-workflow'],
         activityNames: ['content'],
@@ -2063,7 +2149,8 @@ function workflowRuntimeAdapterContract(
       })
       await runtime.attemptExecutor.ack(claimed!)
       await runtime.attemptExecutor.ack(remainingClaim!)
-      const emptyClaim = await runtime.attemptExecutor.claimActivity({
+      const emptyClaim = await runtime.attemptExecutor.claim({
+        taskNames: [],
         workerId: 'activity-worker-3',
         workflowNames: ['delete-unclaimed-workflow'],
         activityNames: ['content'],

--- a/packages/workflows/tests/runtime-adapter-contract.spec.ts
+++ b/packages/workflows/tests/runtime-adapter-contract.spec.ts
@@ -1635,8 +1635,13 @@ function workflowRuntimeAdapterContract(
         input: {},
       }
 
-      await runtime.attemptExecutor.dispatchTask(taskCommand)
-      await runtime.attemptExecutor.dispatchActivity(activityCommand)
+      const firstRunAt = new Date(Date.now() - 2)
+      await runtime.attemptExecutor.dispatchTask(taskCommand, {
+        runAt: firstRunAt,
+      })
+      await runtime.attemptExecutor.dispatchActivity(activityCommand, {
+        runAt: new Date(firstRunAt.getTime() + 1),
+      })
 
       const selectors = {
         workflowNames: ['ordered-workflow'],

--- a/packages/workflows/tests/runtime-coordinator.spec.ts
+++ b/packages/workflows/tests/runtime-coordinator.spec.ts
@@ -542,7 +542,6 @@ describe('workflow runtime coordinator', () => {
       container,
       workflows: [implementation],
       workerId: 'workflow-worker-2',
-      maxIdleClaims: 3,
     })
 
     const parent = await client.get(run.id)
@@ -591,7 +590,9 @@ describe('workflow runtime coordinator', () => {
       workerId: 'workflow-worker-1',
     })
     const childRunId = (await client.get(run.id))?.children[0]?.childRunId
-    const claimed = await runtime.attemptExecutor.claimTask({
+    const claimed = await runtime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [task.name],
       leaseMs: 30_000,
@@ -604,7 +605,6 @@ describe('workflow runtime coordinator', () => {
       container,
       workflows: [workflowImplementation],
       workerId: 'workflow-worker-2',
-      maxIdleClaims: 3,
     })
     await runTaskAttempt({
       store: runtime.store,
@@ -664,14 +664,12 @@ describe('workflow runtime coordinator', () => {
       container,
       workflows: [childImplementation],
       workerId: 'child-worker-1',
-      maxIdleClaims: 3,
     })
     await runWorkflowWorker({
       ...runtime,
       container,
       workflows: [parentImplementation],
       workerId: 'parent-worker-2',
-      maxIdleClaims: 3,
     })
 
     const parent = await client.get(run.id)
@@ -1568,7 +1566,8 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-1',
       workflowNames: [workflow.name],
       leaseMs: 30_000,
@@ -1694,7 +1693,8 @@ describe('workflow runtime coordinator', () => {
     })
     expect(activityCommands[0]?.payload.activityName).not.toContain('fallback')
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-1',
       workflowNames: [workflow.name],
       leaseMs: 30_000,
@@ -2105,7 +2105,8 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-1',
       workflowNames: [workflow.name],
       leaseMs: 30_000,
@@ -2209,7 +2210,9 @@ describe('workflow runtime coordinator', () => {
       input: { scenario: 'alpha' },
     })
 
-    const claimed = await runtime.attemptExecutor.claimTask({
+    const claimed = await runtime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [task.name],
       leaseMs: 30_000,
@@ -2341,7 +2344,8 @@ describe('workflow runtime coordinator', () => {
     ])
 
     for (let index = 0; index < 2; index += 1) {
-      const claimed = await runtime.attemptExecutor.claimActivity({
+      const claimed = await runtime.attemptExecutor.claim({
+        taskNames: [],
         workerId: 'activity-worker-1',
         workflowNames: [workflow.name],
         leaseMs: 30_000,
@@ -2433,7 +2437,8 @@ describe('workflow runtime coordinator', () => {
       command,
     })
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-1',
       workflowNames: [workflow.name],
       leaseMs: 30_000,
@@ -2560,7 +2565,8 @@ describe('workflow runtime coordinator', () => {
       (child) => child.kind === 'workflow',
     )!.childRunId!
 
-    const activityClaim = await runtime.attemptExecutor.claimActivity({
+    const activityClaim = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-1',
       workflowNames: [workflow.name],
       leaseMs: 30_000,
@@ -2576,7 +2582,9 @@ describe('workflow runtime coordinator', () => {
       claimed: activityClaim!,
     })
 
-    const taskClaim = await runtime.attemptExecutor.claimTask({
+    const taskClaim = await runtime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [embeddingTask.name],
       leaseMs: 30_000,
@@ -2689,7 +2697,8 @@ describe('workflow runtime coordinator', () => {
     )?.children.find((child) => child.kind === 'workflow')?.childRunId
     expect(childRunId).toBeTypeOf('string')
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-1',
       workflowNames: [workflow.name],
       activityNames: ['sections.fail'],
@@ -2817,7 +2826,9 @@ describe('workflow runtime coordinator', () => {
     ).toStrictEqual([{ text: 'alpha' }, { text: 'beta' }])
 
     for (const _ of [0, 1]) {
-      const claimed = await runtime.attemptExecutor.claimTask({
+      const claimed = await runtime.attemptExecutor.claim({
+        workflowNames: [],
+        activityNames: [],
         workerId: 'task-worker-1',
         taskNames: [embeddingTask.name],
         leaseMs: 30_000,
@@ -2925,7 +2936,9 @@ describe('workflow runtime coordinator', () => {
     const siblingRunId = waiting!.children[1]!.childRunId!
     expect(runtime.inspect().taskCommands).toHaveLength(2)
 
-    const claimed = await runtime.attemptExecutor.claimTask({
+    const claimed = await runtime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [embeddingTask.name],
       leaseMs: 30_000,
@@ -3147,7 +3160,9 @@ describe('workflow runtime coordinator', () => {
     })
 
     for (const _ of [0, 1]) {
-      const claimed = await runtime.attemptExecutor.claimTask({
+      const claimed = await runtime.attemptExecutor.claim({
+        workflowNames: [],
+        activityNames: [],
         workerId: 'task-worker-1',
         taskNames: [embeddingTask.name],
         leaseMs: 30_000,
@@ -4804,7 +4819,8 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-1',
       workflowNames: [workflow.name],
       leaseMs: 30_000,
@@ -4865,7 +4881,8 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-1',
       workflowNames: [workflow.name],
       leaseMs: 30_000,
@@ -4953,7 +4970,8 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-1',
       workflowNames: [workflow.name],
       leaseMs: 30_000,
@@ -5033,7 +5051,8 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-1',
       workflowNames: [workflow.name],
       leaseMs: 30_000,
@@ -5105,7 +5124,8 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-1',
       workflowNames: [workflow.name],
       leaseMs: 30_000,
@@ -5169,7 +5189,8 @@ describe('workflow runtime coordinator', () => {
       input: { scenario: 'alpha' },
     })
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker-1',
       workflowNames: ['missing-workflow'],
       leaseMs: 30_000,
@@ -5452,7 +5473,9 @@ describe('workflow runtime coordinator', () => {
       input: { text: 'alpha' },
     })
 
-    const claimed = await runtime.attemptExecutor.claimTask({
+    const claimed = await runtime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [embeddingTask.name],
       leaseMs: 30_000,
@@ -5549,7 +5572,9 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimTask({
+    const claimed = await runtime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [embeddingTask.name],
       leaseMs: 30_000,
@@ -5624,7 +5649,9 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimTask({
+    const claimed = await runtime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [embeddingTask.name],
       leaseMs: 30_000,
@@ -5703,7 +5730,9 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimTask({
+    const claimed = await runtime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [embeddingTask.name],
       leaseMs: 30_000,
@@ -5793,7 +5822,9 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimTask({
+    const claimed = await runtime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [embeddingTask.name],
       leaseMs: 30_000,
@@ -5923,7 +5954,8 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker',
       workflowNames: [childWorkflow.name],
       leaseMs: 30_000,
@@ -6659,7 +6691,8 @@ describe('workflow runtime coordinator', () => {
       },
     })
 
-    const claimed = await runtime.attemptExecutor.claimActivity({
+    const claimed = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'activity-worker',
       workflowNames: [childWorkflow.name],
       leaseMs: 30_000,

--- a/packages/workflows/tests/runtime-fanout-retry.spec.ts
+++ b/packages/workflows/tests/runtime-fanout-retry.spec.ts
@@ -6,7 +6,7 @@ import { defineWorkflow, implementWorkflow } from '../src/index.ts'
 import {
   createInMemoryWorkflowRuntime,
   memberChildKey,
-  runActivityWorker,
+  runExecutionWorker,
   runWorkflowWorker,
   startWorkflowRun,
 } from '../src/runtime/index.ts'
@@ -98,7 +98,8 @@ describe('workflow fan-out retry state model', () => {
         workflows: [implementation],
         workerId: `coordinator-${round}`,
       })
-      await runActivityWorker({
+      await runExecutionWorker({
+        tasks: [],
         ...runtime,
         container: createTestContainer(),
         workflows: [implementation],
@@ -228,7 +229,8 @@ describe('workflow fan-out retry state model', () => {
       'running',
     )
 
-    await runActivityWorker({
+    await runExecutionWorker({
+      tasks: [],
       ...runtime,
       container: createTestContainer(),
       workflows: [implementation],
@@ -337,7 +339,8 @@ describe('workflow fan-out retry state model', () => {
     // forever (the old model re-claimed every 50ms indefinitely).
     const command = runtime.inspect().activityCommands[0]?.payload
     expect(command).toBeDefined()
-    await runActivityWorker({
+    await runExecutionWorker({
+      tasks: [],
       ...runtime,
       container: createTestContainer(),
       workflows: [driftedImplementation],

--- a/packages/workflows/tests/runtime-interfaces.spec.ts
+++ b/packages/workflows/tests/runtime-interfaces.spec.ts
@@ -216,7 +216,6 @@ describe('workflow runtime interfaces', () => {
       workerId: string
       concurrency?: number
       leaseMs?: number
-      maxIdleClaims?: number
       idleDelayMs?: number
       signal?: AbortSignal
     }>()

--- a/packages/workflows/tests/runtime-scheduler.spec.ts
+++ b/packages/workflows/tests/runtime-scheduler.spec.ts
@@ -384,7 +384,6 @@ describe('scheduled workflow worker loop', () => {
       workflows: [implementation],
       workerId: 'scheduled-worker-1',
       scheduling: { everyMs: 0, batchSize: 10 },
-      maxIdleClaims: 3,
     })
 
     const runs = await client.list({ tags: { schedule: 'worker-schedule' } })

--- a/packages/workflows/tests/runtime-store.spec.ts
+++ b/packages/workflows/tests/runtime-store.spec.ts
@@ -992,13 +992,16 @@ describe('in-memory workflow store', () => {
     await runtime.attemptExecutor.dispatchTask(taskCommand)
     expect(runtime.inspect().taskCommands).toHaveLength(1)
 
-    const claimedActivity = await runtime.attemptExecutor.claimActivity({
+    const claimedActivity = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'worker-1',
       workflowNames: ['case-generation'],
       activityNames: ['writeContent'],
       leaseMs: 30_000,
     })
-    const claimedTask = await runtime.attemptExecutor.claimTask({
+    const claimedTask = await runtime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'worker-1',
       taskNames: ['writeContent'],
       leaseMs: 30_000,
@@ -1016,7 +1019,8 @@ describe('in-memory workflow store', () => {
     await runtime.attemptExecutor.release(claimedActivity!)
     expect(runtime.inspect().activityCommands).toHaveLength(1)
 
-    const releasedActivity = await runtime.attemptExecutor.claimActivity({
+    const releasedActivity = await runtime.attemptExecutor.claim({
+      taskNames: [],
       workerId: 'worker-1',
       workflowNames: ['case-generation'],
       leaseMs: 30_000,
@@ -1025,13 +1029,12 @@ describe('in-memory workflow store', () => {
 
     await waitForReleaseBackoff()
 
-    const delayedReleasedActivity = await runtime.attemptExecutor.claimActivity(
-      {
-        workerId: 'worker-1',
-        workflowNames: ['case-generation'],
-        leaseMs: 30_000,
-      },
-    )
+    const delayedReleasedActivity = await runtime.attemptExecutor.claim({
+      taskNames: [],
+      workerId: 'worker-1',
+      workflowNames: ['case-generation'],
+      leaseMs: 30_000,
+    })
     expect(delayedReleasedActivity?.leaseToken).not.toBe(
       claimedActivity?.leaseToken,
     )

--- a/packages/workflows/tests/runtime-store.spec.ts
+++ b/packages/workflows/tests/runtime-store.spec.ts
@@ -1023,6 +1023,7 @@ describe('in-memory workflow store', () => {
       taskNames: [],
       workerId: 'worker-1',
       workflowNames: ['case-generation'],
+      activityNames: ['writeContent'],
       leaseMs: 30_000,
     })
     expect(releasedActivity).toBeNull()
@@ -1033,6 +1034,7 @@ describe('in-memory workflow store', () => {
       taskNames: [],
       workerId: 'worker-1',
       workflowNames: ['case-generation'],
+      activityNames: ['writeContent'],
       leaseMs: 30_000,
     })
     expect(delayedReleasedActivity?.leaseToken).not.toBe(

--- a/packages/workflows/tests/runtime-wake-events.spec.ts
+++ b/packages/workflows/tests/runtime-wake-events.spec.ts
@@ -6,6 +6,7 @@ import { runWithAttemptHeartbeat } from '../src/runtime/worker/heartbeat.ts'
 import { drainWorkerPool, serveWorkerPool } from '../src/runtime/worker/loop.ts'
 
 const LONG_DELAY_MS = 30_000
+const ignoreAbandonedClaim = async () => {}
 
 describe('workflow wake events', () => {
   it('short-circuits the worker loop idle delay on wake', async () => {
@@ -25,6 +26,7 @@ describe('workflow wake events', () => {
         },
       },
       {
+        abandon: ignoreAbandonedClaim,
         async claim() {
           claims += 1
           if (claims === 1) setTimeout(() => wake(), 20)
@@ -57,6 +59,7 @@ describe('workflow wake events', () => {
         },
       },
       {
+        abandon: ignoreAbandonedClaim,
         async claim() {
           claims += 1
           // fires before the idle sleep starts — must still be observed
@@ -102,6 +105,7 @@ describe('workflow wake events', () => {
         },
       },
       {
+        abandon: ignoreAbandonedClaim,
         async claim() {
           claims += 1
           if (claims === 1) return 'slow'
@@ -157,6 +161,7 @@ describe('workflow wake events', () => {
         idleDelayMs: 2,
       },
       {
+        abandon: ignoreAbandonedClaim,
         async claim() {
           if (!slowClaimed) {
             slowClaimed = true
@@ -196,6 +201,7 @@ describe('workflow wake events', () => {
     const result = await drainWorkerPool(
       { workerId: 'claim-outcomes' },
       {
+        abandon: ignoreAbandonedClaim,
         async claim() {
           return queued.shift() ?? null
         },
@@ -228,6 +234,7 @@ describe('workflow wake events', () => {
         ],
       },
       {
+        abandon: ignoreAbandonedClaim,
         async claim() {
           if (!queued) return null
           queued = false
@@ -251,6 +258,7 @@ describe('workflow wake events', () => {
     const result = await drainWorkerPool(
       { workerId: 'concurrency-bound', concurrency: 2 },
       {
+        abandon: ignoreAbandonedClaim,
         async claim() {
           return queued.shift() ?? null
         },
@@ -280,6 +288,7 @@ describe('workflow wake events', () => {
     const running = drainWorkerPool(
       { workerId: 'execution-failure', concurrency: 2 },
       {
+        abandon: ignoreAbandonedClaim,
         async claim() {
           return queued.shift() ?? null
         },
@@ -316,6 +325,7 @@ describe('workflow wake events', () => {
         idleDelayMs: 2,
       },
       {
+        abandon: ignoreAbandonedClaim,
         async claim() {
           if (!queued) return null
           queued = false
@@ -329,6 +339,45 @@ describe('workflow wake events', () => {
     )
 
     expect(result.processed).toBe(1)
+  })
+
+  it('abandons a claim that resolves after service shutdown', async () => {
+    const abort = new AbortController()
+    let resolveClaim!: (claimed: string) => void
+    let markClaimStarted!: () => void
+    const claimStarted = new Promise<void>((resolve) => {
+      markClaimStarted = resolve
+    })
+    const pendingClaim = new Promise<string>((resolve) => {
+      resolveClaim = resolve
+    })
+    const abandoned: string[] = []
+    const executed: string[] = []
+
+    const running = serveWorkerPool(
+      { workerId: 'shutdown-during-claim', signal: abort.signal },
+      {
+        async claim() {
+          markClaimStarted()
+          return await pendingClaim
+        },
+        async abandon(claimed) {
+          abandoned.push(claimed)
+        },
+        async execute(claimed) {
+          executed.push(claimed)
+          return true
+        },
+      },
+    )
+
+    await claimStarted
+    abort.abort()
+    resolveClaim('late-claim')
+
+    await expect(running).resolves.toStrictEqual({ processed: 0 })
+    expect(abandoned).toStrictEqual(['late-claim'])
+    expect(executed).toStrictEqual([])
   })
 
   it('aborts and awaits active executions during service shutdown', async () => {
@@ -348,6 +397,7 @@ describe('workflow wake events', () => {
     const running = serveWorkerPool(
       { workerId: 'shutdown', signal: abort.signal },
       {
+        abandon: ignoreAbandonedClaim,
         async claim() {
           if (claimed) return null
           claimed = true
@@ -395,6 +445,7 @@ describe('workflow wake events', () => {
     const running = serveWorkerPool(
       { workerId: 'shutdown-failure', signal: abort.signal },
       {
+        abandon: ignoreAbandonedClaim,
         async claim() {
           if (claimed) return null
           claimed = true
@@ -429,6 +480,7 @@ describe('workflow wake events', () => {
           },
         },
         {
+          abandon: ignoreAbandonedClaim,
           async claim() {
             return null
           },
@@ -465,6 +517,7 @@ describe('workflow wake events', () => {
         ],
       },
       {
+        abandon: ignoreAbandonedClaim,
         async claim() {
           if (claimed) return null
           claimed = true

--- a/packages/workflows/tests/runtime-wake-events.spec.ts
+++ b/packages/workflows/tests/runtime-wake-events.spec.ts
@@ -3,30 +3,37 @@ import { describe, expect, it } from 'vitest'
 import type { ClaimedAttempt } from '../src/runtime/commands.ts'
 import type { AttemptExecutor } from '../src/runtime/executors.ts'
 import { runWithAttemptHeartbeat } from '../src/runtime/worker/heartbeat.ts'
-import { runWorkerLoop } from '../src/runtime/worker/loop.ts'
+import { drainWorkerPool, serveWorkerPool } from '../src/runtime/worker/loop.ts'
 
 const LONG_DELAY_MS = 30_000
 
 describe('workflow wake events', () => {
   it('short-circuits the worker loop idle delay on wake', async () => {
+    const abort = new AbortController()
     let wake: () => void = () => {}
     let claims = 0
     const started = Date.now()
 
-    const result = await runWorkerLoop(
+    const result = await serveWorkerPool(
       {
         workerId: 'wake-loop',
-        maxIdleClaims: 2,
         idleDelayMs: LONG_DELAY_MS,
+        signal: abort.signal,
         onWake: (listener) => {
           wake = listener
           return () => {}
         },
       },
-      async () => {
-        claims += 1
-        if (claims === 1) setTimeout(() => wake(), 20)
-        return false
+      {
+        async claim() {
+          claims += 1
+          if (claims === 1) setTimeout(() => wake(), 20)
+          else abort.abort()
+          return null
+        },
+        async execute() {
+          return true
+        },
       },
     )
 
@@ -40,26 +47,445 @@ describe('workflow wake events', () => {
     let claims = 0
     const started = Date.now()
 
-    await runWorkerLoop(
+    await drainWorkerPool(
       {
         workerId: 'wake-latch',
-        maxIdleClaims: 2,
         idleDelayMs: LONG_DELAY_MS,
         onWake: (listener) => {
           wake = listener
           return () => {}
         },
       },
-      async () => {
-        claims += 1
-        // fires before the idle sleep starts — must still be observed
-        if (claims === 1) wake()
-        return false
+      {
+        async claim() {
+          claims += 1
+          // fires before the idle sleep starts — must still be observed
+          if (claims === 1) wake()
+          return null
+        },
+        async execute() {
+          return true
+        },
       },
     )
 
     expect(claims).toBe(2)
     expect(Date.now() - started).toBeLessThan(LONG_DELAY_MS)
+  })
+
+  it('keeps idle concurrency available while a sibling claim is running', async () => {
+    let wake: () => void = () => {}
+    let fastQueued = false
+    let fastStarted = false
+    let releaseSlow!: () => void
+    let markSlowStarted!: () => void
+    let markIdleClaimed!: () => void
+    const slow = new Promise<void>((resolve) => {
+      releaseSlow = resolve
+    })
+    const slowStarted = new Promise<void>((resolve) => {
+      markSlowStarted = resolve
+    })
+    const idleClaimed = new Promise<void>((resolve) => {
+      markIdleClaimed = resolve
+    })
+    let claims = 0
+
+    const running = drainWorkerPool<'slow' | 'fast'>(
+      {
+        workerId: 'wake-concurrency',
+        concurrency: 2,
+        idleDelayMs: LONG_DELAY_MS,
+        onWake: (listener) => {
+          wake = listener
+          return () => {}
+        },
+      },
+      {
+        async claim() {
+          claims += 1
+          if (claims === 1) return 'slow'
+          if (fastQueued) {
+            fastQueued = false
+            return 'fast'
+          }
+          markIdleClaimed()
+          return null
+        },
+        async execute(claimed) {
+          if (claimed === 'slow') {
+            markSlowStarted()
+            await slow
+          } else {
+            fastStarted = true
+          }
+          return true
+        },
+      },
+    )
+
+    await Promise.all([slowStarted, idleClaimed])
+    fastQueued = true
+    wake()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const startedBeforeSlowFinished = fastStarted
+
+    releaseSlow()
+    const result = await running
+
+    expect(startedBeforeSlowFinished).toBe(true)
+    expect(result.processed).toBe(2)
+  })
+
+  it('polls idle capacity while a sibling execution is active', async () => {
+    let slowClaimed = false
+    let fastQueued = false
+    let fastStarted = false
+    let releaseSlow!: () => void
+    let markSlowStarted!: () => void
+    const slow = new Promise<void>((resolve) => {
+      releaseSlow = resolve
+    })
+    const slowStarted = new Promise<void>((resolve) => {
+      markSlowStarted = resolve
+    })
+
+    const running = drainWorkerPool<'slow' | 'fast'>(
+      {
+        workerId: 'poll-active-capacity',
+        concurrency: 2,
+        idleDelayMs: 2,
+      },
+      {
+        async claim() {
+          if (!slowClaimed) {
+            slowClaimed = true
+            return 'slow'
+          }
+          if (!fastQueued) return null
+          fastQueued = false
+          return 'fast'
+        },
+        async execute(claimed) {
+          if (claimed === 'slow') {
+            markSlowStarted()
+            await slow
+          } else {
+            fastStarted = true
+          }
+          return true
+        },
+      },
+    )
+
+    await slowStarted
+    fastQueued = true
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    const startedBeforeSlowFinished = fastStarted
+    releaseSlow()
+
+    const result = await running
+    expect(startedBeforeSlowFinished).toBe(true)
+    expect(result.processed).toBe(2)
+  })
+
+  it('does not treat an unprocessed claim as an empty queue', async () => {
+    const queued = ['skip', 'process']
+    const executed: string[] = []
+
+    const result = await drainWorkerPool(
+      { workerId: 'claim-outcomes' },
+      {
+        async claim() {
+          return queued.shift() ?? null
+        },
+        async execute(claimed) {
+          executed.push(claimed)
+          return claimed === 'process'
+        },
+      },
+    )
+
+    expect(executed).toStrictEqual(['skip', 'process'])
+    expect(result.processed).toBe(1)
+  })
+
+  it('runs drain maintenance once and claims work it creates', async () => {
+    let queued = false
+    let maintenanceRuns = 0
+
+    const result = await drainWorkerPool(
+      {
+        workerId: 'drain-maintenance',
+        maintenance: [
+          {
+            everyMs: 0,
+            async run() {
+              maintenanceRuns += 1
+              queued = true
+            },
+          },
+        ],
+      },
+      {
+        async claim() {
+          if (!queued) return null
+          queued = false
+          return 'created-by-maintenance'
+        },
+        async execute() {
+          return true
+        },
+      },
+    )
+
+    expect(maintenanceRuns).toBe(1)
+    expect(result.processed).toBe(1)
+  })
+
+  it('fills freed capacity without exceeding the concurrency limit', async () => {
+    const queued = [1, 2, 3, 4, 5]
+    let active = 0
+    let maxActive = 0
+
+    const result = await drainWorkerPool(
+      { workerId: 'concurrency-bound', concurrency: 2 },
+      {
+        async claim() {
+          return queued.shift() ?? null
+        },
+        async execute() {
+          active += 1
+          maxActive = Math.max(maxActive, active)
+          await new Promise((resolve) => setTimeout(resolve, 5))
+          active -= 1
+          return true
+        },
+      },
+    )
+
+    expect(maxActive).toBe(2)
+    expect(result.processed).toBe(5)
+  })
+
+  it('lets active siblings finish after an execution fails', async () => {
+    const queued = ['bad', 'slow']
+    let markSlowStarted!: () => void
+    const slowStarted = new Promise<void>((resolve) => {
+      markSlowStarted = resolve
+    })
+    let slowFinished = false
+    let slowWasAborted = false
+
+    const running = drainWorkerPool(
+      { workerId: 'execution-failure', concurrency: 2 },
+      {
+        async claim() {
+          return queued.shift() ?? null
+        },
+        async execute(claimed, signal) {
+          if (claimed === 'bad') {
+            await slowStarted
+            throw new Error('execution failed')
+          }
+          markSlowStarted()
+          await new Promise((resolve) => setTimeout(resolve, 10))
+          slowWasAborted = signal.aborted
+          slowFinished = true
+          return true
+        },
+      },
+    )
+
+    await expect(running).rejects.toThrow('execution failed')
+    expect(slowFinished).toBe(true)
+    expect(slowWasAborted).toBe(false)
+  })
+
+  it('polls as a fallback when no wake source is available', async () => {
+    const abort = new AbortController()
+    let queued = false
+    setTimeout(() => {
+      queued = true
+    }, 10)
+
+    const result = await serveWorkerPool(
+      {
+        workerId: 'poll-fallback',
+        signal: abort.signal,
+        idleDelayMs: 2,
+      },
+      {
+        async claim() {
+          if (!queued) return null
+          queued = false
+          return 'polled'
+        },
+        async execute() {
+          abort.abort()
+          return true
+        },
+      },
+    )
+
+    expect(result.processed).toBe(1)
+  })
+
+  it('aborts and awaits active executions during service shutdown', async () => {
+    const abort = new AbortController()
+    let claimed = false
+    let releaseExecution!: () => void
+    let markExecutionStarted!: () => void
+    const executionStarted = new Promise<void>((resolve) => {
+      markExecutionStarted = resolve
+    })
+    const executionReleased = new Promise<void>((resolve) => {
+      releaseExecution = resolve
+    })
+    let executionSawAbort = false
+    let settled = false
+
+    const running = serveWorkerPool(
+      { workerId: 'shutdown', signal: abort.signal },
+      {
+        async claim() {
+          if (claimed) return null
+          claimed = true
+          return 'active'
+        },
+        async execute(_claimed, signal) {
+          markExecutionStarted()
+          await new Promise<void>((resolve) => {
+            signal.addEventListener(
+              'abort',
+              () => {
+                executionSawAbort = true
+                resolve()
+              },
+              { once: true },
+            )
+          })
+          await executionReleased
+          return false
+        },
+      },
+    ).finally(() => {
+      settled = true
+    })
+
+    await executionStarted
+    abort.abort()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(executionSawAbort).toBe(true)
+    expect(settled).toBe(false)
+
+    releaseExecution()
+    await running
+    expect(settled).toBe(true)
+  })
+
+  it('surfaces unexpected execution failures during shutdown', async () => {
+    const abort = new AbortController()
+    let claimed = false
+    let markExecutionStarted!: () => void
+    const executionStarted = new Promise<void>((resolve) => {
+      markExecutionStarted = resolve
+    })
+
+    const running = serveWorkerPool(
+      { workerId: 'shutdown-failure', signal: abort.signal },
+      {
+        async claim() {
+          if (claimed) return null
+          claimed = true
+          return 'active'
+        },
+        async execute(_claimed, signal) {
+          markExecutionStarted()
+          await new Promise<void>((resolve) => {
+            signal.addEventListener('abort', () => resolve(), { once: true })
+          })
+          throw new Error('shutdown write failed')
+        },
+      },
+    )
+
+    await executionStarted
+    abort.abort()
+    await expect(running).rejects.toThrow('shutdown write failed')
+  })
+
+  it('rejects invalid concurrency before subscribing to wakes', async () => {
+    let subscribed = false
+
+    await expect(
+      drainWorkerPool(
+        {
+          workerId: 'invalid-concurrency',
+          concurrency: 0,
+          onWake() {
+            subscribed = true
+            return () => {}
+          },
+        },
+        {
+          async claim() {
+            return null
+          },
+          async execute() {
+            return false
+          },
+        },
+      ),
+    ).rejects.toThrow('Concurrency must be a positive integer')
+    expect(subscribed).toBe(false)
+  })
+
+  it('runs periodic work independently of claims and preserves its cadence', async () => {
+    const abort = new AbortController()
+    let claimed = false
+    let maintenanceRuns = 0
+    let markExecutionStarted!: () => void
+    const executionStarted = new Promise<void>((resolve) => {
+      markExecutionStarted = resolve
+    })
+
+    const running = serveWorkerPool(
+      {
+        workerId: 'periodic-worker',
+        signal: abort.signal,
+        idleDelayMs: 1,
+        maintenance: [
+          {
+            everyMs: LONG_DELAY_MS,
+            async run() {
+              maintenanceRuns += 1
+            },
+          },
+        ],
+      },
+      {
+        async claim() {
+          if (claimed) return null
+          claimed = true
+          return 'slow'
+        },
+        async execute(_claimed, signal) {
+          markExecutionStarted()
+          await new Promise<void>((resolve) => {
+            signal.addEventListener('abort', () => resolve(), { once: true })
+          })
+          return false
+        },
+      },
+    )
+
+    await executionStarted
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    abort.abort()
+    await running
+
+    expect(maintenanceRuns).toBe(1)
   })
 
   it('runs the heartbeat check immediately on a cancellation wake', async () => {

--- a/packages/workflows/tests/runtime-worker.spec.ts
+++ b/packages/workflows/tests/runtime-worker.spec.ts
@@ -15,14 +15,12 @@ import {
   type WorkflowStore,
   createInMemoryWorkflowRuntime,
   createWorkflowRuntimeClient,
-  runActivityWorker,
-  runTaskWorker,
+  runExecutionWorker,
   runWorkflowWorker,
   runTaskAttempt,
   startTaskRun,
   WorkflowAttemptTimeoutError,
 } from '../src/runtime/index.ts'
-import { runWithConcurrency } from '../src/runtime/worker.ts'
 
 describe('workflow worker runtime', () => {
   const createTestContainer = () => {
@@ -62,7 +60,9 @@ describe('workflow worker runtime', () => {
       input: { text: 'alpha' },
     })
 
-    const claimed = await runtime.attemptExecutor.claimTask({
+    const claimed = await runtime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [task.name],
       leaseMs: 30_000,
@@ -219,13 +219,13 @@ describe('workflow worker runtime', () => {
       task: completionTask,
       input: { text: 'alpha' },
     })
-    const completionClaimed = await completionRuntime.attemptExecutor.claimTask(
-      {
-        workerId: 'task-worker-1',
-        taskNames: [completionTask.name],
-        leaseMs: 30_000,
-      },
-    )
+    const completionClaimed = await completionRuntime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
+      workerId: 'task-worker-1',
+      taskNames: [completionTask.name],
+      leaseMs: 30_000,
+    })
     expect(completionClaimed).not.toBeNull()
     const completionMarker = createAtomicMarker(completionRuntime)
 
@@ -266,7 +266,9 @@ describe('workflow worker runtime', () => {
       task: retryTask,
       input: { text: 'alpha' },
     })
-    const retryClaimed = await retryRuntime.attemptExecutor.claimTask({
+    const retryClaimed = await retryRuntime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [retryTask.name],
       leaseMs: 30_000,
@@ -324,7 +326,9 @@ describe('workflow worker runtime', () => {
       workflows: [reconcileWorkflowImplementation],
       workerId: 'workflow-worker-1',
     })
-    const reconcileClaimed = await reconcileRuntime.attemptExecutor.claimTask({
+    const reconcileClaimed = await reconcileRuntime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [reconcileTask.name],
       leaseMs: 30_000,
@@ -391,7 +395,9 @@ describe('workflow worker runtime', () => {
       workflows: [workflowImplementation],
       workerId: 'workflow-worker-1',
     })
-    const claimed = await runtime.attemptExecutor.claimTask({
+    const claimed = await runtime.attemptExecutor.claim({
+      workflowNames: [],
+      activityNames: [],
       workerId: 'task-worker-1',
       taskNames: [task.name],
       leaseMs: 30_000,
@@ -474,7 +480,6 @@ describe('workflow worker runtime', () => {
       container: createTestContainer(),
       workflows: [],
       workerId: 'retention-worker-1',
-      maxIdleClaims: 1,
       retention: {
         olderThan: '0ms',
         batchSize: 10,
@@ -571,7 +576,6 @@ describe('workflow worker runtime', () => {
       container: createTestContainer(),
       workflows: [implementation],
       workerId: 'workflow-worker-1',
-      maxIdleClaims: 2,
       idleDelayMs: 1,
     })
 
@@ -710,7 +714,8 @@ describe('workflow worker runtime', () => {
       workerId: 'workflow-worker-1',
     })
 
-    const result = await runActivityWorker({
+    const result = await runExecutionWorker({
+      tasks: [],
       store: runtime.store,
       runCoordinationExecutor: runtime.runCoordinationExecutor,
       attemptExecutor: runtime.attemptExecutor,
@@ -796,14 +801,14 @@ describe('workflow worker runtime', () => {
       workflows: [implementation],
       workerId: 'workflow-worker-1',
     })
-    await runActivityWorker({
+    await runExecutionWorker({
+      tasks: [],
       store: runtime.store,
       runCoordinationExecutor: runtime.runCoordinationExecutor,
       attemptExecutor: runtime.attemptExecutor,
       container,
       workflows: [implementation],
       workerId: 'activity-worker-1',
-      maxIdleClaims: 4,
     })
 
     expect(runtime.inspect().continueRunCommands).toHaveLength(1)
@@ -863,14 +868,14 @@ describe('workflow worker runtime', () => {
       workflows: [implementation],
       workerId: 'workflow-worker-1',
     })
-    await runActivityWorker({
+    await runExecutionWorker({
+      tasks: [],
       store: runtime.store,
       runCoordinationExecutor: runtime.runCoordinationExecutor,
       attemptExecutor: runtime.attemptExecutor,
       container,
       workflows: [implementation],
       workerId: 'activity-worker-1',
-      maxIdleClaims: 2,
     })
     await runWorkflowWorker({
       store: runtime.store,
@@ -942,7 +947,8 @@ describe('workflow worker runtime', () => {
       workflows: [implementation],
       workerId: 'workflow-worker-1',
     })
-    await runActivityWorker({
+    await runExecutionWorker({
+      tasks: [],
       store: runtime.store,
       runCoordinationExecutor: runtime.runCoordinationExecutor,
       attemptExecutor: runtime.attemptExecutor,
@@ -1013,8 +1019,8 @@ describe('workflow worker runtime', () => {
     let releaseCount = 0
     const attemptExecutor: AttemptExecutor = {
       ...runtime.attemptExecutor,
-      claimActivity: async (worker) => {
-        const claimed = await runtime.attemptExecutor.claimActivity(worker)
+      claim: async (worker) => {
+        const claimed = await runtime.attemptExecutor.claim(worker)
         if (!claimed) return null
         claimCount += 1
         if (claimCount > 1) throw new Error('claimed released activity again')
@@ -1026,7 +1032,8 @@ describe('workflow worker runtime', () => {
       },
     }
 
-    const result = await runActivityWorker({
+    const result = await runExecutionWorker({
+      tasks: [],
       store: runtime.store,
       runCoordinationExecutor: runtime.runCoordinationExecutor,
       attemptExecutor,
@@ -1034,7 +1041,6 @@ describe('workflow worker runtime', () => {
       workflows: [implementation],
       activityNames: ['missing'],
       workerId: 'activity-worker-1',
-      maxIdleClaims: 2,
     })
 
     expect(result.processed).toBe(0)
@@ -1110,7 +1116,8 @@ describe('workflow worker runtime', () => {
       input: { text: 'alpha' },
     })
 
-    const result = await runTaskWorker({
+    const result = await runExecutionWorker({
+      workflows: [],
       store: runtime.store,
       runCoordinationExecutor: runtime.runCoordinationExecutor,
       attemptExecutor: runtime.attemptExecutor,
@@ -1150,14 +1157,14 @@ describe('workflow worker runtime', () => {
       input: { text: 'alpha' },
     })
 
-    const result = await runTaskWorker({
+    const result = await runExecutionWorker({
+      workflows: [],
       store: runtime.store,
       runCoordinationExecutor: runtime.runCoordinationExecutor,
       attemptExecutor: runtime.attemptExecutor,
       container: createTestContainer(),
       tasks: [implementation],
       workerId: 'task-worker-1',
-      maxIdleClaims: 2,
     })
 
     const completed = await runtime.store.loadRunSnapshot(run.id)
@@ -1212,14 +1219,14 @@ describe('workflow worker runtime', () => {
       input: { text: 'alpha' },
     })
 
-    await runTaskWorker({
+    await runExecutionWorker({
+      workflows: [],
       store: runtime.store,
       runCoordinationExecutor: runtime.runCoordinationExecutor,
       attemptExecutor: runtime.attemptExecutor,
       container: createTestContainer(),
       tasks: [implementation],
       workerId: 'task-worker-1',
-      maxIdleClaims: 2,
     })
     releaseLateHandler()
     await lateHandlerFinished
@@ -1267,7 +1274,8 @@ describe('workflow worker runtime', () => {
       input: { text: 'alpha' },
     })
 
-    await runTaskWorker({
+    await runExecutionWorker({
+      workflows: [],
       store: runtime.store,
       runCoordinationExecutor: runtime.runCoordinationExecutor,
       attemptExecutor: runtime.attemptExecutor,
@@ -1307,7 +1315,8 @@ describe('workflow worker runtime', () => {
         input: { text: 'alpha' },
       })
 
-      await runTaskWorker({
+      await runExecutionWorker({
+        workflows: [],
         store: runtime.store,
         runCoordinationExecutor: runtime.runCoordinationExecutor,
         attemptExecutor: runtime.attemptExecutor,
@@ -1320,7 +1329,8 @@ describe('workflow worker runtime', () => {
       )
 
       vi.setSystemTime(new Date('2026-01-01T00:00:01.000Z'))
-      await runTaskWorker({
+      await runExecutionWorker({
+        workflows: [],
         store: runtime.store,
         runCoordinationExecutor: runtime.runCoordinationExecutor,
         attemptExecutor: runtime.attemptExecutor,
@@ -1333,7 +1343,8 @@ describe('workflow worker runtime', () => {
       )
 
       vi.setSystemTime(new Date('2026-01-01T00:00:03.000Z'))
-      await runTaskWorker({
+      await runExecutionWorker({
+        workflows: [],
         store: runtime.store,
         runCoordinationExecutor: runtime.runCoordinationExecutor,
         attemptExecutor: runtime.attemptExecutor,
@@ -1379,7 +1390,8 @@ describe('workflow worker runtime', () => {
       })
       let heartbeatCount = 0
 
-      const worker = runTaskWorker({
+      const worker = runExecutionWorker({
+        workflows: [],
         store: runtime.store,
         runCoordinationExecutor: runtime.runCoordinationExecutor,
         attemptExecutor: {
@@ -1443,7 +1455,8 @@ describe('workflow worker runtime', () => {
       let acked = false
       let released = false
 
-      const worker = runTaskWorker({
+      const worker = runExecutionWorker({
+        workflows: [],
         store: runtime.store,
         runCoordinationExecutor: runtime.runCoordinationExecutor,
         attemptExecutor: {
@@ -1513,7 +1526,8 @@ describe('workflow worker runtime', () => {
       let released = false
       let retried = false
 
-      const worker = runTaskWorker({
+      const worker = runExecutionWorker({
+        workflows: [],
         store: runtime.store,
         runCoordinationExecutor: runtime.runCoordinationExecutor,
         attemptExecutor: {
@@ -1593,7 +1607,8 @@ describe('workflow worker runtime', () => {
       let acked = false
       let released = false
 
-      const worker = runTaskWorker({
+      const worker = runExecutionWorker({
+        workflows: [],
         store: runtime.store,
         runCoordinationExecutor: runtime.runCoordinationExecutor,
         attemptExecutor: {
@@ -1629,26 +1644,5 @@ describe('workflow worker runtime', () => {
     } finally {
       vi.useRealTimers()
     }
-  })
-
-  it('runs workers without exceeding concurrency', async () => {
-    const items = [1, 2, 3, 4, 5]
-    let active = 0
-    let maxActive = 0
-
-    await runWithConcurrency(items, 2, async () => {
-      active += 1
-      maxActive = Math.max(maxActive, active)
-      await new Promise((resolve) => setTimeout(resolve, 5))
-      active -= 1
-    })
-
-    expect(maxActive).toBe(2)
-  })
-
-  it('rejects invalid concurrency', async () => {
-    await expect(runWithConcurrency([1], 0, async () => {})).rejects.toThrow(
-      'Concurrency must be a positive integer',
-    )
   })
 })

--- a/skills/use-neemata/references/workflows.md
+++ b/skills/use-neemata/references/workflows.md
@@ -3,7 +3,7 @@
 Use `@nmtjs/workflows` for durable, contract-first orchestration: multi-step
 processes that must survive crashes, retry safely, fan out to child runs, and
 be observable/cancellable by id. Runs are persisted (Postgres in production),
-executed by coordinator/activity/task workers with at-least-once command
+executed by coordinator and execution workers with at-least-once command
 delivery and exactly-once state transitions.
 
 Import rules (no `nmtjs` umbrella exports; always package subpaths):
@@ -260,14 +260,17 @@ export default defineWorkflows({
   tasks: () => taskImplementations,
   workers: {
     coordinator: { threads: 2, concurrency: 2 },
-    activity: { threads: 2, concurrency: 4 },
-    task: { threads: 2, concurrency: 4 },
+    execution: { threads: 2, concurrency: 4 },
   },
 })
 ```
 
-Worker pool options: `threads`, `concurrency`, `leaseMs`, `pollIntervalMs`,
-`maxIdleClaims`; the activity pool additionally accepts `activityNames` to
-pin a pool to specific activities. The task pool only spawns when task
-implementations exist. Worker shutdown aborts in-flight handlers with reason
-`shutdown` and releases their commands for redelivery.
+Worker pool options are `threads`, `concurrency`, `leaseMs`, and
+`pollIntervalMs`. The execution pool runs both workflow activities and
+standalone tasks. It can instead be an array of named pools with
+`activityNames` and/or `taskNames` selectors; one pool may omit both selectors
+as the catch-all for work not assigned elsewhere. Worker shutdown aborts
+in-flight handlers with reason `shutdown` and releases their commands for
+redelivery. Every task and child workflow referenced by a registered workflow
+must also have an implementation in `tasks` or `workflows`; startup rejects
+incomplete registries before they can create unclaimable work.


### PR DESCRIPTION
## Summary

- replace the finite worker-lane barrier with explicit finite drain and long-lived serve modes that preserve configured capacity
- unify activity and standalone-task infrastructure behind one execution worker, one atomic cross-kind claim, and one shared concurrency budget
- add durable worker-loop supervision so unexpected Neem worker completion triggers runtime recovery instead of leaving a ready-but-dead worker
- validate execution-pool routing, task implementations, and child-workflow implementations at startup

## Why

The previous worker loop retired an idle lane after its first empty claim and waited for every sibling lane to settle before the caller could create another group. A long-running attempt could therefore prevent newly woken work from using otherwise available concurrency slots.

The same activity/task split also duplicated worker lifecycle, configuration, claiming, wake, and maintenance behavior even though both command kinds use the same attempt infrastructure.

Closes #262.

## User impact

`workers.activity` and `workers.task` are replaced by `workers.execution`. Activities and tasks now share the concurrency budget of their execution pool. Deployments that need isolation can configure named execution pools with `activityNames` and `taskNames` selectors.

The public worker runners are similarly consolidated as `runExecutionWorker` and `serveExecutionWorker`; activity and task definitions and execution semantics remain distinct.

Invalid or incomplete routing now fails during Neem configuration resolution instead of creating durable commands that no worker can claim.

## Validation

- 445 workflow tests
- 85 Neem unit tests
- targeted Neem worker-failure recovery e2e test
- TypeScript project check
- formatting and lint checks
- final Fable 5 architectural and follow-up reviews: agreed, no blockers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified execution workers for workflow activities and standalone tasks.
  * Added execution-pool configuration with named pools and catch-all routing.
  * Improved worker lifecycle control and wake/drain/serve behavior.
* **Bug Fixes**
  * Prevented spurious errors during intentional shutdown; improved detection of unexpected runtime termination.
* **Breaking Changes**
  * Replaced activity/task worker roles, configuration, and claim APIs with unified execution equivalents.
  * Startup now fails fast for invalid or incomplete execution-pool coverage.
* **Documentation**
  * Updated worker-role and execution-pool configuration guidance to match the new model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->