### PR TITLE
streaming: credit-based flow control end-to-end

### DIFF
--- a/packages/application/src/host.ts
+++ b/packages/application/src/host.ts
@@ -41,7 +41,7 @@ export interface ApplicationHostDefinition<
   transports: Transports
   gateway?: Pick<
     GatewayOptions<ApplicationResolvedProcedure>,
-    'streamTimeouts' | 'heartbeat'
+    'streamIdleTimeout' | 'heartbeat'
   >
   identity?: ConnectionIdentity
 }
@@ -57,7 +57,7 @@ export type ApplicationHostDefinitionOptions<
   transports: Transports
   gateway?: Pick<
     GatewayOptions<ApplicationResolvedProcedure>,
-    'streamTimeouts' | 'heartbeat'
+    'streamIdleTimeout' | 'heartbeat'
   >
   identity?: ConnectionIdentity
 }
@@ -75,7 +75,7 @@ export interface ApplicationHostOptions<
   transports: ApplicationHostTransportConfig<Transports>
   gateway?: Pick<
     GatewayOptions<ApplicationResolvedProcedure>,
-    'streamTimeouts' | 'heartbeat'
+    'streamIdleTimeout' | 'heartbeat'
   >
   identity?: ConnectionIdentity
 }

--- a/packages/application/tests/neem-entrypoints.spec.ts
+++ b/packages/application/tests/neem-entrypoints.spec.ts
@@ -6,7 +6,7 @@ import { MessageChannel } from 'node:worker_threads'
 import type { TransportWorker } from '@nmtjs/gateway'
 import type { NeemRuntimePlanner, NeemRuntimePlannerContext } from '@nmtjs/neem'
 import { createLogger, createValueInjectable } from '@nmtjs/core'
-import { createTransport, StreamTimeout } from '@nmtjs/gateway'
+import { createTransport } from '@nmtjs/gateway'
 import { t } from '@nmtjs/type'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 
@@ -104,7 +104,7 @@ describe('Neem application entrypoints', () => {
       transports: { http: transport },
       gateway: {
         heartbeat: { interval: 4321, timeout: 8765 },
-        streamTimeouts: { [StreamTimeout.Pull]: 1111 },
+        streamIdleTimeout: 1111,
       },
       identity,
     })
@@ -126,9 +126,7 @@ describe('Neem application entrypoints', () => {
         interval: 4321,
         timeout: 8765,
       })
-      expect(
-        created.host.gateway.options.streamTimeouts[StreamTimeout.Pull],
-      ).toBe(1111)
+      expect(created.host.gateway.options.streamIdleTimeout).toBe(1111)
       expect(created.host.gateway.options.identity).toBe(identity)
     } finally {
       await created.stop()

--- a/packages/application/tests/runtime-host.spec.ts
+++ b/packages/application/tests/runtime-host.spec.ts
@@ -1,7 +1,7 @@
 import type { TransportWorker, TransportWorkerParams } from '@nmtjs/gateway'
 import type { ProtocolFormats } from '@nmtjs/protocol/server'
 import { createFactoryInjectable, createLogger } from '@nmtjs/core'
-import { createTransport, StreamTimeout } from '@nmtjs/gateway'
+import { createTransport } from '@nmtjs/gateway'
 import { t } from '@nmtjs/type'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -283,7 +283,7 @@ describe('application runtime boundary', () => {
       transports: { http: { transport: http.transport, options: httpOptions } },
       gateway: {
         heartbeat: false,
-        streamTimeouts: { [StreamTimeout.Pull]: 100 },
+        streamIdleTimeout: 100,
       },
     })
     const memoryHost = createApplicationHost(app, {
@@ -305,9 +305,7 @@ describe('application runtime boundary', () => {
       expect(http.state.startParams[0].formats).toBe(formats)
       expect(memory.state.startParams[0].formats).toBe(formats)
       expect(httpHost.gateway.options.heartbeat).toBe(false)
-      expect(httpHost.gateway.options.streamTimeouts[StreamTimeout.Pull]).toBe(
-        100,
-      )
+      expect(httpHost.gateway.options.streamIdleTimeout).toBe(100)
     } finally {
       await memoryHost.stop()
       await httpHost.stop()

--- a/packages/client/src/layers/rpc.ts
+++ b/packages/client/src/layers/rpc.ts
@@ -304,6 +304,26 @@ export const createRpcLayer = (
 
     const { procedure, signal } = call
     const stream = new ProtocolServerRPCStream({
+      // one chunk credit per consumer read (hwm 0): the server sends nothing
+      // until the consumer actually iterates
+      pull: () => {
+        if (!core.messageContext) return
+
+        core.emitStreamEvent({
+          direction: 'outgoing',
+          streamType: 'rpc',
+          action: 'pull',
+          callId: message.callId,
+        })
+
+        const buffer = core.protocol.encodeMessage(
+          core.messageContext,
+          ClientMessageType.RpcStreamPull,
+          { callId: message.callId, size: 1 },
+        )
+
+        core.send(buffer).catch(noopFn)
+      },
       start: (controller) => {
         if (!signal) return
 
@@ -521,6 +541,34 @@ export const createRpcLayer = (
     }
   }
 
+  // A failed local push (e.g. transform/decode error) must surface as a
+  // stream abort on both sides, never as an unhandled rejection.
+  const abortRpcStreamOnPushFailure = (callId: number, reason: unknown) => {
+    if (!rpcStreams.has(callId)) return
+
+    calls.get(callId)?.cleanup?.()
+    calls.delete(callId)
+    void rpcStreams.abort(callId, reason).catch(noopFn)
+
+    if (core.messageContext) {
+      core.emitStreamEvent({
+        direction: 'outgoing',
+        streamType: 'rpc',
+        action: 'abort',
+        callId,
+        reason: toReasonString(reason),
+      })
+
+      const buffer = core.protocol.encodeMessage(
+        core.messageContext,
+        ClientMessageType.RpcAbort,
+        { callId, reason: toReasonString(reason) },
+      )
+
+      core.send(buffer).catch(noopFn)
+    }
+  }
+
   core.on('message', (message: any) => {
     switch (message.type) {
       case ServerMessageType.RpcResponse:
@@ -537,7 +585,12 @@ export const createRpcLayer = (
           callId: message.callId,
           byteLength: message.chunk.byteLength,
         })
-        void rpcStreams.push(message.callId, message.chunk)
+        // push is intentionally not awaited: writes apply in arrival order
+        // via the writable queue, and awaiting here would stall messages of
+        // unrelated streams behind this one's backpressure
+        rpcStreams
+          .push(message.callId, message.chunk)
+          .catch((error) => abortRpcStreamOnPushFailure(message.callId, error))
         break
       case ServerMessageType.RpcStreamEnd:
         calls.get(message.callId)?.cleanup?.()
@@ -547,7 +600,7 @@ export const createRpcLayer = (
           action: 'end',
           callId: message.callId,
         })
-        void rpcStreams.end(message.callId)
+        void rpcStreams.end(message.callId).catch(noopFn)
         calls.delete(message.callId)
         break
       case ServerMessageType.RpcStreamAbort:
@@ -559,7 +612,7 @@ export const createRpcLayer = (
           callId: message.callId,
           reason: message.reason,
         })
-        void rpcStreams.abort(message.callId, message.reason)
+        void rpcStreams.abort(message.callId, message.reason).catch(noopFn)
         calls.delete(message.callId)
         break
     }

--- a/packages/client/src/layers/rpc.ts
+++ b/packages/client/src/layers/rpc.ts
@@ -603,8 +603,18 @@ export const createRpcLayer = (
         void rpcStreams.end(message.callId).catch(noopFn)
         calls.delete(message.callId)
         break
-      case ServerMessageType.RpcStreamAbort:
-        calls.get(message.callId)?.cleanup?.()
+      case ServerMessageType.RpcStreamAbort: {
+        const call = calls.get(message.callId)
+        call?.cleanup?.()
+        // an abort may arrive before the stream response was processed;
+        // settle the still-pending call or it would hang forever (no-op if
+        // the call already resolved with a stream)
+        call?.reject(
+          new ProtocolError(
+            ErrorCode.ClientRequestError,
+            message.reason ?? 'RPC stream aborted',
+          ),
+        )
         core.emitStreamEvent({
           direction: 'incoming',
           streamType: 'rpc',
@@ -615,6 +625,7 @@ export const createRpcLayer = (
         void rpcStreams.abort(message.callId, message.reason).catch(noopFn)
         calls.delete(message.callId)
         break
+      }
     }
   })
 

--- a/packages/client/src/layers/streams.ts
+++ b/packages/client/src/layers/streams.ts
@@ -241,7 +241,13 @@ export const createStreamLayer = (core: ClientCore): StreamLayerApi => {
           streamId: message.streamId,
           byteLength: message.chunk.byteLength,
         })
-        void serverStreams.push(message.streamId, message.chunk)
+        // not awaited: the writable queue keeps per-stream arrival order and
+        // awaiting would stall other streams' messages; a failed push aborts
+        // the stream on both sides instead of leaking a rejection
+        serverStreams.push(message.streamId, message.chunk).catch((error) => {
+          if (!serverStreams.has(message.streamId)) return
+          abortServerBlob(message.streamId, error)
+        })
         break
       case ServerMessageType.ServerStreamEnd:
         serverBlobInitializers.delete(message.streamId)
@@ -251,7 +257,7 @@ export const createStreamLayer = (core: ClientCore): StreamLayerApi => {
           action: 'end',
           streamId: message.streamId,
         })
-        void serverStreams.end(message.streamId)
+        void serverStreams.end(message.streamId).catch(noopFn)
         break
       case ServerMessageType.ServerStreamAbort:
         serverBlobInitializers.delete(message.streamId)
@@ -262,7 +268,7 @@ export const createStreamLayer = (core: ClientCore): StreamLayerApi => {
           streamId: message.streamId,
           reason: message.reason,
         })
-        void serverStreams.abort(message.streamId, message.reason)
+        void serverStreams.abort(message.streamId, message.reason).catch(noopFn)
         break
       case ServerMessageType.ClientStreamPull:
         core.emitStreamEvent({

--- a/packages/client/src/streams.ts
+++ b/packages/client/src/streams.ts
@@ -32,8 +32,12 @@ export class ClientStreams {
   async abort(streamId: number, reason?: any) {
     const stream = this.#collection.get(streamId)
     if (!stream) return // Stream already cleaned up
-    await stream.abort(reason)
-    this.remove(streamId)
+    try {
+      await stream.abort(reason)
+    } finally {
+      // a rejecting source cancel() must not leak the manager entry
+      this.remove(streamId)
+    }
   }
 
   pull(streamId: number, size: number) {
@@ -51,7 +55,8 @@ export class ClientStreams {
       const abortPromises = [...this.#collection.values()].map((stream) =>
         stream.abort(reason),
       )
-      await Promise.all(abortPromises)
+      // allSettled: one rejecting cancel() must not stop clearing the rest
+      await Promise.allSettled(abortPromises)
     }
     this.#collection.clear()
   }

--- a/packages/client/src/streams.ts
+++ b/packages/client/src/streams.ts
@@ -93,6 +93,8 @@ export class ServerStreams<
 
   async abort(streamId: number, reason?: unknown) {
     if (this.has(streamId)) {
+      // a write parked on backpressure would block abort() from settling
+      this.#collection.get(streamId)?.releaseParkedWrites()
       const writer = this.#writers.get(streamId)
       if (writer) {
         await writer.abort(reason)
@@ -110,6 +112,9 @@ export class ServerStreams<
   }
 
   async end(streamId: number) {
+    // no more data is coming: flush parked writes into the readable queue so
+    // close() can settle while the consumer drains at its own pace
+    this.#collection.get(streamId)?.releaseParkedWrites()
     const writer = this.#writers.get(streamId)
     if (writer) {
       await writer.close()
@@ -120,6 +125,9 @@ export class ServerStreams<
 
   async clear(reason?: any) {
     if (reason) {
+      for (const stream of this.#collection.values()) {
+        stream.releaseParkedWrites()
+      }
       const abortPromises = [...this.#writers.values()].map((writer) =>
         writer.abort(reason).finally(() => writer.releaseLock()),
       )

--- a/packages/client/tests/rpc-streams.spec.ts
+++ b/packages/client/tests/rpc-streams.spec.ts
@@ -1,5 +1,9 @@
 import type { BaseClientFormat } from '@nmtjs/protocol/client'
-import { ConnectionType, ServerMessageType } from '@nmtjs/protocol'
+import {
+  ClientMessageType,
+  ConnectionType,
+  ServerMessageType,
+} from '@nmtjs/protocol'
 import { describe, expect, it, vi } from 'vitest'
 
 import { EventEmitter } from '../src/events.ts'
@@ -8,6 +12,12 @@ import { BaseClientTransformer } from '../src/transformers.ts'
 
 const encodeJson = (value: unknown) =>
   new TextEncoder().encode(JSON.stringify(value))
+
+// the client package targets browsers, so Node's `process` global is untyped
+const nodeProcess = (globalThis as any).process as {
+  on: (event: 'unhandledRejection', cb: (reason: unknown) => void) => void
+  off: (event: 'unhandledRejection', cb: (reason: unknown) => void) => void
+}
 
 class MockCore extends EventEmitter<{
   message: [message: unknown, raw: ArrayBufferView]
@@ -42,7 +52,7 @@ class MockCore extends EventEmitter<{
 }
 
 describe('RPC streams', () => {
-  it('does not send extra transport messages while consuming bidirectional RPC streams', async () => {
+  it('sends exactly one RpcStreamPull per consumed chunk and nothing else', async () => {
     const core = new MockCore()
     const rpcLayer = createRpcLayer(
       core as any,
@@ -66,12 +76,22 @@ describe('RPC streams', () => {
 
     const iterable = await streamPromise
     core.send.mockClear()
+    core.protocol.encodeMessage.mockClear()
+
+    // no credit is granted before the consumer starts iterating
+    expect(core.send).not.toHaveBeenCalled()
 
     const iterator = iterable[Symbol.asyncIterator]()
     const firstChunkPromise = iterator.next()
 
     await Promise.resolve()
-    expect(core.send).not.toHaveBeenCalled()
+    // the read triggers one single-chunk credit grant
+    expect(core.send).toHaveBeenCalledTimes(1)
+    expect(core.protocol.encodeMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      ClientMessageType.RpcStreamPull,
+      { callId: 0, size: 1 },
+    )
 
     core.emit(
       'message',
@@ -87,7 +107,17 @@ describe('RPC streams', () => {
       done: false,
       value: { ok: true, echoed: { userId: '1' } },
     })
-    expect(core.send).not.toHaveBeenCalled()
+    // receiving the chunk itself grants nothing
+    expect(core.send).toHaveBeenCalledTimes(1)
+
+    const secondChunkPromise = iterator.next()
+    await Promise.resolve()
+    expect(core.send).toHaveBeenCalledTimes(2)
+    expect(core.protocol.encodeMessage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      ClientMessageType.RpcStreamPull,
+      { callId: 0, size: 1 },
+    )
 
     core.emit(
       'message',
@@ -95,11 +125,11 @@ describe('RPC streams', () => {
       new Uint8Array([3]),
     )
 
-    await expect(iterator.next()).resolves.toEqual({
+    await expect(secondChunkPromise).resolves.toEqual({
       done: true,
       value: undefined,
     })
-    expect(core.send).not.toHaveBeenCalled()
+    expect(core.send).toHaveBeenCalledTimes(2)
   })
 
   it('reuses the initial stream when autoReconnect is enabled', async () => {
@@ -131,7 +161,13 @@ describe('RPC streams', () => {
     const firstChunkPromise = iterator.next()
 
     await Promise.resolve()
-    expect(core.send).not.toHaveBeenCalled()
+    // only the credit grant for the pending read goes out
+    expect(core.send).toHaveBeenCalledTimes(1)
+    expect(core.protocol.encodeMessage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      ClientMessageType.RpcStreamPull,
+      { callId: 0, size: 1 },
+    )
 
     core.emit(
       'message',
@@ -147,7 +183,8 @@ describe('RPC streams', () => {
       done: false,
       value: { ok: true, echoed: { userId: '1' } },
     })
-    expect(core.send).not.toHaveBeenCalled()
+
+    const secondChunkPromise = iterator.next()
 
     core.emit(
       'message',
@@ -155,10 +192,72 @@ describe('RPC streams', () => {
       new Uint8Array([3]),
     )
 
-    await expect(iterator.next()).resolves.toEqual({
+    await expect(secondChunkPromise).resolves.toEqual({
       done: true,
       value: undefined,
     })
+  })
+
+  it('aborts the stream on a malformed chunk without unhandled rejections', async () => {
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason)
+    }
+    nodeProcess.on('unhandledRejection', onUnhandled)
+
+    try {
+      const core = new MockCore()
+      const rpcLayer = createRpcLayer(
+        core as any,
+        { addServerBlobStream: vi.fn() } as any,
+        new BaseClientTransformer(),
+      )
+
+      const streamPromise = rpcLayer.call(
+        'users/profile',
+        { userId: '1' },
+        { _stream_response: true },
+      )
+
+      core.emit(
+        'message',
+        { type: ServerMessageType.RpcStreamResponse, callId: 0 },
+        new Uint8Array([1]),
+      )
+
+      const iterable = await streamPromise
+      const iterator = iterable[Symbol.asyncIterator]()
+      const nextPromise = iterator.next()
+
+      core.protocol.encodeMessage.mockClear()
+
+      // invalid JSON: the stream transform (format.decode) throws
+      core.emit(
+        'message',
+        {
+          type: ServerMessageType.RpcStreamChunk,
+          callId: 0,
+          chunk: new TextEncoder().encode('{not json'),
+        },
+        new Uint8Array([2]),
+      )
+
+      // the decode error surfaces to the consumer...
+      await expect(nextPromise).rejects.toThrow()
+
+      // ...and the server is told to abort the call
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      expect(core.protocol.encodeMessage).toHaveBeenCalledWith(
+        expect.anything(),
+        ClientMessageType.RpcAbort,
+        expect.objectContaining({ callId: 0 }),
+      )
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      expect(unhandled).toEqual([])
+    } finally {
+      nodeProcess.off('unhandledRejection', onUnhandled)
+    }
   })
 
   it('propagates server abort reasons to stream consumers', async () => {

--- a/packages/client/tests/rpc-streams.spec.ts
+++ b/packages/client/tests/rpc-streams.spec.ts
@@ -260,6 +260,36 @@ describe('RPC streams', () => {
     }
   })
 
+  it('rejects a pending call when the stream aborts before the stream response', async () => {
+    const core = new MockCore()
+    const rpcLayer = createRpcLayer(
+      core as any,
+      { addServerBlobStream: vi.fn() } as any,
+      new BaseClientTransformer(),
+    )
+
+    const streamPromise = rpcLayer.call(
+      'users/profile',
+      { userId: '1' },
+      { _stream_response: true },
+    )
+
+    // abort lands while the call is still pending (e.g. server-side idle
+    // timeout before the RpcStreamResponse was ever processed): the call
+    // must settle instead of hanging forever
+    core.emit(
+      'message',
+      {
+        type: ServerMessageType.RpcStreamAbort,
+        callId: 0,
+        reason: 'stream idle timeout',
+      },
+      new Uint8Array([1]),
+    )
+
+    await expect(streamPromise).rejects.toThrow('stream idle timeout')
+  })
+
   it('propagates server abort reasons to stream consumers', async () => {
     const core = new MockCore()
     const rpcLayer = createRpcLayer(

--- a/packages/client/tests/rpc-streams.spec.ts
+++ b/packages/client/tests/rpc-streams.spec.ts
@@ -13,10 +13,23 @@ import { BaseClientTransformer } from '../src/transformers.ts'
 const encodeJson = (value: unknown) =>
   new TextEncoder().encode(JSON.stringify(value))
 
-// the client package targets browsers, so Node's `process` global is untyped
-const nodeProcess = (globalThis as any).process as {
-  on: (event: 'unhandledRejection', cb: (reason: unknown) => void) => void
-  off: (event: 'unhandledRejection', cb: (reason: unknown) => void) => void
+// these tests also run in browsers, where Node's `process` global does not
+// exist — collect unhandled rejections via whichever API the environment has
+const trackUnhandledRejections = (sink: unknown[]): (() => void) => {
+  const nodeProcess = (globalThis as any).process
+  if (typeof nodeProcess?.on === 'function') {
+    const handler = (reason: unknown) => {
+      sink.push(reason)
+    }
+    nodeProcess.on('unhandledRejection', handler)
+    return () => nodeProcess.off('unhandledRejection', handler)
+  }
+  const handler = (event: PromiseRejectionEvent) => {
+    event.preventDefault()
+    sink.push(event.reason)
+  }
+  globalThis.addEventListener('unhandledrejection', handler)
+  return () => globalThis.removeEventListener('unhandledrejection', handler)
 }
 
 class MockCore extends EventEmitter<{
@@ -200,10 +213,7 @@ describe('RPC streams', () => {
 
   it('aborts the stream on a malformed chunk without unhandled rejections', async () => {
     const unhandled: unknown[] = []
-    const onUnhandled = (reason: unknown) => {
-      unhandled.push(reason)
-    }
-    nodeProcess.on('unhandledRejection', onUnhandled)
+    const untrack = trackUnhandledRejections(unhandled)
 
     try {
       const core = new MockCore()
@@ -256,7 +266,7 @@ describe('RPC streams', () => {
       await new Promise<void>((resolve) => setTimeout(resolve, 0))
       expect(unhandled).toEqual([])
     } finally {
-      nodeProcess.off('unhandledRejection', onUnhandled)
+      untrack()
     }
   })
 

--- a/packages/client/tests/streams.spec.ts
+++ b/packages/client/tests/streams.spec.ts
@@ -120,6 +120,22 @@ describe('ClientStreams', () => {
 
       expect(cancel).toHaveBeenCalled()
     })
+
+    it('removes the stream even when the source cancel rejects', async () => {
+      const cancel = vi.fn(() => {
+        throw new Error('cancel failed')
+      })
+      const source = createReadable([new Uint8Array([1])], cancel)
+      const streams = new ClientStreams()
+      streams.add(source, 5, metadata)
+
+      // e.g. a server-initiated abort against a source with broken cleanup:
+      // the failure surfaces, but the manager entry must not leak
+      await expect(streams.abort(5, 'server abort')).rejects.toThrow(
+        'cancel failed',
+      )
+      expect(() => streams.get(5)).toThrow('Stream not found')
+    })
   })
 
   describe('clear', () => {
@@ -150,6 +166,31 @@ describe('ClientStreams', () => {
 
       expect(() => streams.get(1)).toThrow('Stream not found')
       expect(() => streams.get(2)).toThrow('Stream not found')
+    })
+
+    it('clears the rest even when one source cancel rejects', async () => {
+      const rejectingCancel = vi.fn(() => {
+        throw new Error('cancel failed')
+      })
+      const healthyCancel = vi.fn()
+      const streams = new ClientStreams()
+      streams.add(
+        createReadable([new Uint8Array([1])], rejectingCancel),
+        7,
+        metadata,
+      )
+      streams.add(
+        createReadable([new Uint8Array([2])], healthyCancel),
+        8,
+        metadata,
+      )
+
+      await streams.clear(new Error('shutdown'))
+
+      expect(rejectingCancel).toHaveBeenCalledTimes(1)
+      expect(healthyCancel).toHaveBeenCalledTimes(1)
+      expect(() => streams.get(7)).toThrow('Stream not found')
+      expect(() => streams.get(8)).toThrow('Stream not found')
     })
   })
 })

--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -1,5 +1,3 @@
-// TODO: add proper queueing/backpressure strategy support
-
 import type { MaybePromise } from './types.ts'
 
 export interface DuplexStreamOptions<O = unknown, I = O> {
@@ -18,19 +16,46 @@ export class DuplexStream<O = unknown, I = O> {
   readonly readable: globalThis.ReadableStream<O>
   readonly writable!: globalThis.WritableStream<I>
 
+  // writes parked on readable backpressure, released in FIFO order by pull()
+  #parkedWrites: (() => void)[] = []
+  // once draining, writes stop parking so close()/abort() can settle even
+  // when the consumer never reads again (a parked in-flight sink.write would
+  // otherwise block them forever per the streams spec)
+  #draining = false
+
   constructor(options: DuplexStreamOptions<O, I> = {}) {
     this.readable = new globalThis.ReadableStream<O>(
       {
-        cancel: options.cancel,
+        cancel: (reason) => {
+          // the consumer walked away: pending writes can never be read, let
+          // them settle instead of deadlocking the writer
+          this.releaseParkedWrites()
+          options.cancel?.(reason)
+        },
         start: (controller) => {
           // @ts-expect-error
           this.writable = new globalThis.WritableStream<I>(
             {
               write: (_chunk) => {
-                const chunk = options?.transform
-                  ? options?.transform(_chunk)
-                  : _chunk
-                controller.enqueue(chunk as O)
+                let chunk: O
+                if (options.transform) {
+                  try {
+                    chunk = options.transform(_chunk)
+                  } catch (error) {
+                    // reject the write AND error the readable — otherwise a
+                    // pending reader would hang forever on a bad chunk
+                    controller.error(error)
+                    throw error
+                  }
+                } else {
+                  chunk = _chunk as unknown as O
+                }
+                controller.enqueue(chunk)
+                if (!this.#draining && (controller.desiredSize ?? 1) <= 0) {
+                  return new Promise<void>((resolve) => {
+                    this.#parkedWrites.push(resolve)
+                  })
+                }
               },
               abort: (reason) => controller.error(reason),
               close: () => {
@@ -46,9 +71,25 @@ export class DuplexStream<O = unknown, I = O> {
           )
           options.start?.(controller)
         },
-        pull: options?.pull,
+        pull: (controller) => {
+          this.#parkedWrites.shift()?.()
+          return options.pull?.(controller)
+        },
       },
       options.readableStrategy,
     )
+  }
+
+  /**
+   * Settles any write parked on backpressure and disables further parking.
+   * Must be called before closing/aborting the writable while the consumer
+   * may no longer be reading: the streams spec makes close()/abort() wait
+   * for the in-flight sink.write to settle first.
+   */
+  releaseParkedWrites() {
+    this.#draining = true
+    const parked = this.#parkedWrites
+    this.#parkedWrites = []
+    for (const resolve of parked) resolve()
   }
 }

--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -30,7 +30,8 @@ export class DuplexStream<O = unknown, I = O> {
           // the consumer walked away: pending writes can never be read, let
           // them settle instead of deadlocking the writer
           this.releaseParkedWrites()
-          options.cancel?.(reason)
+          // returned so cancel() awaits async cleanup and surfaces rejections
+          return options.cancel?.(reason)
         },
         start: (controller) => {
           // @ts-expect-error

--- a/packages/common/src/streams.ts
+++ b/packages/common/src/streams.ts
@@ -5,7 +5,7 @@ export interface DuplexStreamOptions<O = unknown, I = O> {
   pull?: (
     controller: globalThis.ReadableStreamDefaultController<O>,
   ) => MaybePromise<void>
-  cancel?: (reason: unknown) => void
+  cancel?: (reason: unknown) => MaybePromise<void>
   transform?: (chunk: I) => O
   close?: () => void
   readableStrategy?: globalThis.QueuingStrategy<O>

--- a/packages/common/tests/streams.spec.ts
+++ b/packages/common/tests/streams.spec.ts
@@ -10,15 +10,21 @@ const writeAndClose = async <T>(writable: WritableStream<T>, chunks: T[]) => {
 }
 
 const writeAndAbort = async <T>(
-  writable: WritableStream<T>,
+  stream: DuplexStream<T>,
   chunks: T[],
   error?: Error,
 ) => {
-  const writer = writable.getWriter()
-  for (const chunk of chunks) await writer.write(chunk)
+  const writer = stream.writable.getWriter()
+  const writes = chunks.map((chunk) => writer.write(chunk))
+  // writes park on backpressure without a consumer; abort() waits for the
+  // in-flight write, so parked writes must be released first
+  stream.releaseParkedWrites()
+  await Promise.all(writes)
   await writer.abort(error ?? new Error('Stream aborted'))
   writer.releaseLock()
 }
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
 
 describe('DuplexStream', () => {
   it('should push and read chunks', async () => {
@@ -111,7 +117,7 @@ describe('DuplexStream', () => {
   it('should abort the stream with error', async () => {
     const stream = new DuplexStream<string>()
 
-    await writeAndAbort(stream.writable, ['hello'], new Error('Test abort'))
+    await writeAndAbort(stream, ['hello'], new Error('Test abort'))
 
     const reader = stream.readable.getReader()
 
@@ -121,7 +127,7 @@ describe('DuplexStream', () => {
   it('should abort with default error message', async () => {
     const stream = new DuplexStream<string>()
 
-    await writeAndAbort(stream.writable, ['hello'])
+    await writeAndAbort(stream, ['hello'])
 
     const reader = stream.readable.getReader()
 
@@ -155,5 +161,123 @@ describe('DuplexStream', () => {
 
     expect(result.done).toBe(true)
     expect(result.value).toBeUndefined()
+  })
+
+  describe('backpressure', () => {
+    it('parks write until the reader reads at hwm 1', async () => {
+      const stream = new DuplexStream<string>({
+        readableStrategy: { highWaterMark: 1 },
+      })
+      const writer = stream.writable.getWriter()
+
+      let settled = false
+      const write = writer.write('a').then(() => {
+        settled = true
+      })
+
+      await tick()
+      expect(settled).toBe(false)
+
+      const reader = stream.readable.getReader()
+      await expect(reader.read()).resolves.toEqual({ done: false, value: 'a' })
+
+      await write
+      expect(settled).toBe(true)
+    })
+
+    it('parks write until the next read request at hwm 0', async () => {
+      const stream = new DuplexStream<string>({
+        readableStrategy: { highWaterMark: 0 },
+      })
+      const writer = stream.writable.getWriter()
+
+      let settled = false
+      const write = writer.write('a').then(() => {
+        settled = true
+      })
+
+      await tick()
+      expect(settled).toBe(false)
+
+      const reader = stream.readable.getReader()
+      // first read is satisfied from the queue and does not replenish credit
+      await expect(reader.read()).resolves.toEqual({ done: false, value: 'a' })
+      await tick()
+      expect(settled).toBe(false)
+
+      // an outstanding read request triggers pull, which releases the write
+      const second = reader.read()
+      await write
+      expect(settled).toBe(true)
+
+      // at hwm 0 this write parks again until yet another read request
+      void writer.write('b').catch(() => {})
+      await expect(second).resolves.toEqual({ done: false, value: 'b' })
+    })
+
+    it('applies parked writes in FIFO order', async () => {
+      const stream = new DuplexStream<string>({
+        readableStrategy: { highWaterMark: 1 },
+      })
+      const writer = stream.writable.getWriter()
+
+      const results: string[] = []
+      void writer.write('a')
+      void writer.write('b')
+      void writer.write('c')
+      void writer.close()
+
+      for await (const chunk of stream.readable as any) {
+        results.push(chunk)
+      }
+      expect(results).toEqual(['a', 'b', 'c'])
+    })
+
+    it('releaseParkedWrites lets abort settle without a consumer', async () => {
+      const stream = new DuplexStream<string>()
+      const writer = stream.writable.getWriter()
+
+      const write = writer.write('a')
+      stream.releaseParkedWrites()
+      await write
+      await writer.abort(new Error('boom'))
+
+      const reader = stream.readable.getReader()
+      await expect(reader.read()).rejects.toThrow('boom')
+    })
+
+    it('releases parked writes when the readable is cancelled', async () => {
+      const stream = new DuplexStream<string>()
+      const writer = stream.writable.getWriter()
+
+      let settled = false
+      const write = writer.write('a').then(() => {
+        settled = true
+      })
+
+      await tick()
+      expect(settled).toBe(false)
+
+      await stream.readable.cancel('gone')
+      await write
+      expect(settled).toBe(true)
+    })
+  })
+
+  describe('transform errors', () => {
+    it('rejects the write and errors the readable', async () => {
+      const stream = new DuplexStream<number, string>({
+        transform: () => {
+          throw new Error('bad chunk')
+        },
+      })
+
+      const reader = stream.readable.getReader()
+      const pending = reader.read()
+
+      const writer = stream.writable.getWriter()
+      await expect(writer.write('x')).rejects.toThrow('bad chunk')
+      await expect(pending).rejects.toThrow('bad chunk')
+    })
   })
 })

--- a/packages/gateway/src/enums.ts
+++ b/packages/gateway/src/enums.ts
@@ -8,9 +8,3 @@ export enum ProxyableTransportType {
   HTTP = 'http',
   HTTP2 = 'http2',
 }
-
-export enum StreamTimeout {
-  Pull = 'Pull',
-  Consume = 'Consume',
-  Finish = 'Finish',
-}

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -92,8 +92,12 @@ export interface GatewayOptions<
   }
   identity?: ConnectionIdentity
   /**
-   * Aborts any stream (blob or RPC) with no activity in either direction for
-   * this long. Activity = chunk sent/received, credit granted/received.
+   * Bounds peer inactivity per stream. For RPC streams it caps only how long
+   * the server waits for consumer credit (a client that isn't pulling);
+   * producer stalls with a live, waiting consumer are allowed indefinitely
+   * (sparse streams, e.g. pubsub subscriptions). For blob streams it bounds
+   * inactivity in either direction (chunk sent/received, credit
+   * granted/received). Expiry aborts the stream.
    */
   streamIdleTimeout?: number
 
@@ -867,15 +871,15 @@ export class Gateway<
           ]()
 
           while (true) {
-            const result = (await Promise.race([
-              iterator.next(),
-              flow.promise,
-            ])) as IteratorResult<unknown>
-            if (result.done) break
-            signal.throwIfAborted()
+            // The credit wait comes BEFORE next(): a consumer that never
+            // iterates must not pin the generator, call container and
+            // reservation forever — with zero credit the producer is never
+            // advanced and the wait's idle timer reaps the stream. Sparse
+            // producers stay safe: a waiting consumer has already granted
+            // credit before the silence, and next() races only the abort.
             while (credit.credits <= 0) {
-              // idle detection bounds only consumer inactivity: a chunk is
-              // ready but the client isn't pulling
+              // idle detection bounds only consumer inactivity: the producer
+              // is ready but the client isn't pulling
               const grant = createFuture<void>()
               credit.notify = grant.resolve
               const idleTimer = setTimeout(
@@ -891,6 +895,14 @@ export class Gateway<
               }
               signal.throwIfAborted()
             }
+            const result = (await Promise.race([
+              iterator.next(),
+              flow.promise,
+            ])) as IteratorResult<unknown>
+            // the last credit is answered by End instead of a chunk: the
+            // consumer's final read resolves done
+            if (result.done) break
+            signal.throwIfAborted()
             credit.credits--
             const chunkEncoded = encoder.encode(result.value)
             const sent = transport.send!(

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -66,8 +66,6 @@ type RpcStreamCreditState = {
   credits: number
   // resolves the in-flight credit wait; also poked on abort/teardown
   notify: (() => void) | null
-  // resets the stream idle timer (any activity)
-  touch: () => void
   // fails the whole stream (e.g. credit violation) from the message handler
   fail: (error: Error) => void
 }
@@ -703,7 +701,6 @@ export class Gateway<
                 break
               }
               credit.credits += message.size
-              credit.touch()
               credit.notify?.()
             }
             break
@@ -827,23 +824,18 @@ export class Gateway<
         signal.throwIfAborted()
 
         const creditKey = `${connectionId}:${callId}`
-        // Rejects on abort, idle expiry, or credit violation. EVERY await in
-        // the streaming loop races against it, so a handler stalled inside
-        // next() cannot outlive the call abort or the idle timeout.
+        // Rejects on call abort or a credit violation. Every await in the
+        // streaming loop races against it, so a handler stalled inside
+        // next() cannot outlive the call (client abort, connection teardown).
+        // Deliberately NOT wired to the idle timer: a silent producer with a
+        // live, waiting client is not a fault (sparse streams, e.g. pubsub
+        // subscriptions) — the client controls cancellation and heartbeat
+        // reaps dead connections into the same abort signal.
         const flow = createFuture<never>()
         flow.promise.catch(noopFn)
-        let idleTimer: ReturnType<typeof setTimeout> | undefined
-        const touch = () => {
-          clearTimeout(idleTimer)
-          idleTimer = setTimeout(
-            () => flow.reject(new StreamFlowError(STREAM_IDLE_TIMEOUT_REASON)),
-            this.options.streamIdleTimeout,
-          )
-        }
         const credit: RpcStreamCreditState = {
           credits: 0,
           notify: null,
-          touch,
           fail: (error) => flow.reject(error),
         }
         // installed BEFORE RpcStreamResponse goes out: a synchronous
@@ -851,7 +843,6 @@ export class Gateway<
         this.rpcStreamCredits.set(creditKey, credit)
         const onAbort = () => flow.reject(signal.reason)
         signal.addEventListener('abort', onAbort, { once: true })
-        touch()
 
         let iterator: AsyncIterator<unknown> | undefined
         try {
@@ -883,11 +874,19 @@ export class Gateway<
             if (result.done) break
             signal.throwIfAborted()
             while (credit.credits <= 0) {
+              // idle detection bounds only consumer inactivity: a chunk is
+              // ready but the client isn't pulling
               const grant = createFuture<void>()
               credit.notify = grant.resolve
+              const idleTimer = setTimeout(
+                () =>
+                  flow.reject(new StreamFlowError(STREAM_IDLE_TIMEOUT_REASON)),
+                this.options.streamIdleTimeout,
+              )
               try {
                 await Promise.race([grant.promise, flow.promise])
               } finally {
+                clearTimeout(idleTimer)
                 credit.notify = null
               }
               signal.throwIfAborted()
@@ -905,7 +904,6 @@ export class Gateway<
             if (sent === false) {
               throw new StreamFlowError(STREAM_TRANSPORT_DROP_REASON)
             }
-            touch()
           }
 
           const sentEnd = transport.send!(
@@ -935,7 +933,6 @@ export class Gateway<
           }
         } finally {
           signal.removeEventListener('abort', onAbort)
-          clearTimeout(idleTimer)
           this.rpcStreamCredits.delete(creditKey)
           if (iterator) {
             // cooperative unwind on every exit path; timeboxed because

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -36,7 +36,12 @@ import {
   ProtocolBlob,
   ServerMessageType,
 } from '@nmtjs/protocol'
-import { getFormat, ProtocolError, versions } from '@nmtjs/protocol/server'
+import {
+  getFormat,
+  MAX_STREAM_CREDITS,
+  ProtocolError,
+  versions,
+} from '@nmtjs/protocol/server'
 
 import type { GatewayApi, GatewayResolvedProcedure } from './api.ts'
 import type { GatewayConnection } from './connections.ts'
@@ -61,6 +66,10 @@ type RpcStreamCreditState = {
   credits: number
   // resolves the in-flight credit wait; also poked on abort/teardown
   notify: (() => void) | null
+  // resets the stream idle timer (any activity)
+  touch: () => void
+  // fails the whole stream (e.g. credit violation) from the message handler
+  fail: (error: Error) => void
 }
 
 /**
@@ -105,6 +114,21 @@ const DEFAULT_STREAM_IDLE_TIMEOUT = 30_000
  * close or container disposal can't hang closeConnection() and stop().
  */
 export const GATEWAY_TEARDOWN_STEP_TIMEOUT = 10_000
+/**
+ * Upper bound for the RPC stream iterator's return() during cleanup: on
+ * async generators it queues behind a stalled next(), so unwinding is only
+ * cooperative and must not hang the message handler forever.
+ */
+export const RPC_STREAM_CLEANUP_TIMEOUT = 10_000
+/**
+ * Once a terminal stream frame (end/abort) is dropped by the transport,
+ * stream-level recovery is impossible — the peer would wait forever. Closing
+ * the connection guarantees peer-side cleanup via the socket close.
+ */
+const TERMINAL_FRAME_DROP_CLOSE = {
+  code: 1011,
+  reason: 'stream terminal frame dropped',
+}
 
 export class Gateway<
   ResolvedProcedure extends GatewayResolvedProcedure = GatewayResolvedProcedure,
@@ -325,29 +349,12 @@ export class Gateway<
     const container = connection.container.fork(Scope.Call)
 
     const dispose = async () => {
-      const streamAbortReason = 'Blob was not consumed before handler completed'
-
-      const unconsumedStreamIds = this.blobStreams.getClientCallStreamIds(
-        connection.id,
-        callId,
-      )
-
-      for (const streamId of unconsumedStreamIds) {
-        messageContext.transport.send?.(
-          connection.id,
-          connection.protocol.encodeMessage(
-            messageContext,
-            ServerMessageType.ClientStreamAbort,
-            { streamId, reason: streamAbortReason },
-          ),
-        )
-      }
-
-      // Abort streams related to this call
+      // Abort streams related to this call; the per-stream notifier delivers
+      // the wire abort (with reason) at most once
       this.blobStreams.abortClientCallStreams(
         connection.id,
         callId,
-        streamAbortReason,
+        'Blob was not consumed before handler completed',
       )
 
       this.rpcs.delete(connection.id, callId, controller)
@@ -388,7 +395,7 @@ export class Gateway<
       transport,
       streamId,
       addClientStream: ({ streamId, callId, metadata }) => {
-        const stream = this.blobStreams.createClientStream(
+        this.blobStreams.createClientStream(
           connectionId,
           callId,
           streamId,
@@ -403,7 +410,7 @@ export class Gateway<
                 streamId,
                 pullSize,
               )
-              transport.send!(
+              const sent = transport.send!(
                 connectionId,
                 protocol.encodeMessage(
                   this.createMessageContext(connection, transportKey),
@@ -411,21 +418,36 @@ export class Gateway<
                   { streamId, size: pullSize },
                 ),
               )
+              if (sent === false) {
+                // phantom credit would stall both sides: Node won't re-invoke
+                // _read for a pull the client never received
+                this.blobStreams.revokeClientStreamGrant(
+                  connectionId,
+                  streamId,
+                  pullSize,
+                )
+                this.blobStreams.abortClientStream(
+                  connectionId,
+                  streamId,
+                  STREAM_TRANSPORT_DROP_REASON,
+                )
+              }
             },
           },
+          (reason) => {
+            const sent = transport.send!(
+              connectionId,
+              protocol.encodeMessage(
+                this.createMessageContext(connection, transportKey),
+                ServerMessageType.ClientStreamAbort,
+                { streamId, reason },
+              ),
+            )
+            if (sent === false) {
+              void this.closeConnection(connectionId, TERMINAL_FRAME_DROP_CLOSE)
+            }
+          },
         )
-
-        stream.once('error', () => {
-          this.send(
-            transportKey,
-            connectionId,
-            protocol.encodeMessage(
-              this.createMessageContext(connection, transportKey),
-              ServerMessageType.ClientStreamAbort,
-              { streamId },
-            ),
-          )
-        })
 
         return createProtocolBlobReference(streamId, metadata)
       },
@@ -598,10 +620,12 @@ export class Gateway<
             break
           }
           case ClientMessageType.ClientStreamAbort: {
+            // peer-originated: never echo the abort back
             this.blobStreams.abortClientStream(
               connectionId,
               message.streamId,
               message.reason,
+              false,
             )
             break
           }
@@ -616,17 +640,6 @@ export class Gateway<
                 { streamId: message.streamId },
                 'Client stream push exceeds granted credit, aborting stream',
               )
-              messageContext.transport.send?.(
-                connectionId,
-                connection.protocol.encodeMessage(
-                  messageContext,
-                  ServerMessageType.ClientStreamAbort,
-                  {
-                    streamId: message.streamId,
-                    reason: STREAM_CREDIT_VIOLATION_REASON,
-                  },
-                ),
-              )
               this.blobStreams.abortClientStream(
                 connectionId,
                 message.streamId,
@@ -640,14 +653,30 @@ export class Gateway<
             break
           }
           case ClientMessageType.ServerStreamAbort: {
+            // peer-originated: never echo the abort back
             this.blobStreams.abortServerStream(
               connectionId,
               message.streamId,
               message.reason,
+              false,
             )
             break
           }
           case ClientMessageType.ServerStreamPull: {
+            if (message.size === 0) {
+              // zero-size pulls grant nothing but would reset the idle timer
+              // forever — a free keepalive, so treat them as violations
+              logger.warn(
+                { streamId: message.streamId },
+                'Zero-size server stream pull, aborting stream',
+              )
+              this.blobStreams.abortServerStream(
+                connectionId,
+                message.streamId,
+                STREAM_CREDIT_VIOLATION_REASON,
+              )
+              break
+            }
             this.blobStreams.pullServerStream(
               connectionId,
               message.streamId,
@@ -660,7 +689,21 @@ export class Gateway<
               `${connectionId}:${message.callId}`,
             )
             if (credit) {
+              // zero-size pulls are a free keepalive, oversized totals break
+              // the counter — both are violations
+              if (
+                message.size === 0 ||
+                credit.credits + message.size > MAX_STREAM_CREDITS
+              ) {
+                logger.warn(
+                  { callId: message.callId, size: message.size },
+                  'Invalid RPC stream pull size, aborting stream',
+                )
+                credit.fail(new StreamFlowError(STREAM_CREDIT_VIOLATION_REASON))
+                break
+              }
               credit.credits += message.size
+              credit.touch()
               credit.notify?.()
             }
             break
@@ -780,29 +823,77 @@ export class Gateway<
       const response = await this.dispatchRpc(connection, context)
 
       if (typeof response === 'function') {
-        transport.send!(
-          connectionId,
-          protocol.encodeMessage(context, ServerMessageType.RpcStreamResponse, {
-            callId,
-          }),
-        )
+        // don't open a stream for a call aborted while dispatching
+        signal.throwIfAborted()
 
         const creditKey = `${connectionId}:${callId}`
-        const credit: RpcStreamCreditState = { credits: 0, notify: null }
+        // Rejects on abort, idle expiry, or credit violation. EVERY await in
+        // the streaming loop races against it, so a handler stalled inside
+        // next() cannot outlive the call abort or the idle timeout.
+        const flow = createFuture<never>()
+        flow.promise.catch(noopFn)
+        let idleTimer: ReturnType<typeof setTimeout> | undefined
+        const touch = () => {
+          clearTimeout(idleTimer)
+          idleTimer = setTimeout(
+            () => flow.reject(new StreamFlowError(STREAM_IDLE_TIMEOUT_REASON)),
+            this.options.streamIdleTimeout,
+          )
+        }
+        const credit: RpcStreamCreditState = {
+          credits: 0,
+          notify: null,
+          touch,
+          fail: (error) => flow.reject(error),
+        }
+        // installed BEFORE RpcStreamResponse goes out: a synchronous
+        // transport may deliver the first pull re-entrantly during the send
         this.rpcStreamCredits.set(creditKey, credit)
-        // wake a pending credit wait so the loop can observe the abort
-        const wake = () => credit.notify?.()
-        signal.addEventListener('abort', wake, { once: true })
+        const onAbort = () => flow.reject(signal.reason)
+        signal.addEventListener('abort', onAbort, { once: true })
+        touch()
 
+        let iterator: AsyncIterator<unknown> | undefined
         try {
-          for await (const chunk of response()) {
+          const sentResponse = transport.send!(
+            connectionId,
+            protocol.encodeMessage(
+              context,
+              ServerMessageType.RpcStreamResponse,
+              { callId },
+            ),
+          )
+          if (sentResponse === false) {
+            // the client never learns this call is a stream; nothing
+            // stream-level can recover it
+            void this.closeConnection(connectionId, TERMINAL_FRAME_DROP_CLOSE)
+            return
+          }
+          signal.throwIfAborted()
+
+          iterator = (response() as AsyncIterable<unknown>)[
+            Symbol.asyncIterator
+          ]()
+
+          while (true) {
+            const result = (await Promise.race([
+              iterator.next(),
+              flow.promise,
+            ])) as IteratorResult<unknown>
+            if (result.done) break
             signal.throwIfAborted()
             while (credit.credits <= 0) {
-              await this.waitForRpcStreamCredit(credit, signal)
+              const grant = createFuture<void>()
+              credit.notify = grant.resolve
+              try {
+                await Promise.race([grant.promise, flow.promise])
+              } finally {
+                credit.notify = null
+              }
               signal.throwIfAborted()
             }
             credit.credits--
-            const chunkEncoded = encoder.encode(chunk)
+            const chunkEncoded = encoder.encode(result.value)
             const sent = transport.send!(
               connectionId,
               protocol.encodeMessage(
@@ -811,27 +902,27 @@ export class Gateway<
                 { callId, chunk: chunkEncoded },
               ),
             )
-            // for-await invokes the iterator's return() on throw, so the
-            // handler's finally blocks still run
             if (sent === false) {
               throw new StreamFlowError(STREAM_TRANSPORT_DROP_REASON)
             }
+            touch()
           }
 
-          const sent = transport.send!(
+          const sentEnd = transport.send!(
             connectionId,
             protocol.encodeMessage(context, ServerMessageType.RpcStreamEnd, {
               callId,
             }),
           )
-          if (sent === false) {
-            throw new StreamFlowError(STREAM_TRANSPORT_DROP_REASON)
+          if (sentEnd === false) {
+            // terminal frame lost: the client would wait forever
+            void this.closeConnection(connectionId, TERMINAL_FRAME_DROP_CLOSE)
           }
         } catch (error) {
           if (!isAbortError(error) && !(error instanceof StreamFlowError)) {
             this.logger.error(error)
           }
-          transport.send!(
+          const sentAbort = transport.send!(
             connectionId,
             protocol.encodeMessage(context, ServerMessageType.RpcStreamAbort, {
               callId,
@@ -839,9 +930,29 @@ export class Gateway<
                 error instanceof StreamFlowError ? error.message : undefined,
             }),
           )
+          if (sentAbort === false) {
+            void this.closeConnection(connectionId, TERMINAL_FRAME_DROP_CLOSE)
+          }
         } finally {
-          signal.removeEventListener('abort', wake)
+          signal.removeEventListener('abort', onAbort)
+          clearTimeout(idleTimer)
           this.rpcStreamCredits.delete(creditKey)
+          if (iterator) {
+            // cooperative unwind on every exit path; timeboxed because
+            // return() queues behind a stalled next() on async generators
+            try {
+              await withTimeout(
+                Promise.resolve(iterator.return?.()),
+                RPC_STREAM_CLEANUP_TIMEOUT,
+                new Error('RPC stream iterator cleanup timed out'),
+              )
+            } catch (error) {
+              this.logger.warn(
+                { error, callId },
+                'RPC stream iterator cleanup failed',
+              )
+            }
+          }
         }
       } else {
         const streams = this.blobStreams.getServerStreamsMetadata(
@@ -871,27 +982,6 @@ export class Gateway<
       const level = error instanceof ProtocolError ? 'trace' : 'error'
       this.logger[level](error)
     }
-  }
-
-  /**
-   * Blocks until the client grants at least one chunk credit. A consumer
-   * that never pulls counts as idle, so the wait is bounded by the stream
-   * idle timeout; abort/teardown resolves the wait early via notify().
-   */
-  private waitForRpcStreamCredit(
-    credit: RpcStreamCreditState,
-    signal: AbortSignal,
-  ): Promise<void> {
-    if (credit.credits > 0 || signal.aborted) return Promise.resolve()
-    const future = createFuture<void>()
-    credit.notify = future.resolve
-    return withTimeout(
-      future.promise,
-      this.options.streamIdleTimeout,
-      new StreamFlowError(STREAM_IDLE_TIMEOUT_REASON),
-    ).finally(() => {
-      credit.notify = null
-    })
   }
 
   private releaseRpcStreamCredits(connectionId: string) {
@@ -1003,7 +1093,7 @@ export class Gateway<
             )
           },
           end: () => {
-            transport.send!(
+            const sent = transport.send!(
               connectionId,
               protocol.encodeMessage(
                 context,
@@ -1013,9 +1103,14 @@ export class Gateway<
                 },
               ),
             )
+            if (sent === false) {
+              // terminal frame lost after local state removal: the client
+              // would wait forever, only a connection close can recover
+              void this.closeConnection(connectionId, TERMINAL_FRAME_DROP_CLOSE)
+            }
           },
           error: (error) => {
-            transport.send!(
+            const sent = transport.send!(
               connectionId,
               protocol.encodeMessage(
                 context,
@@ -1023,6 +1118,9 @@ export class Gateway<
                 { streamId, reason: error.message },
               ),
             )
+            if (sent === false) {
+              void this.closeConnection(connectionId, TERMINAL_FRAME_DROP_CLOSE)
+            }
           },
         },
       )

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -41,7 +41,6 @@ import { getFormat, ProtocolError, versions } from '@nmtjs/protocol/server'
 import type { GatewayApi, GatewayResolvedProcedure } from './api.ts'
 import type { GatewayConnection } from './connections.ts'
 import type { ProxyableTransportType } from './enums.ts'
-import type { StreamConfig } from './streams.ts'
 import type { TransportWorker, TransportWorkerParams } from './transport.ts'
 import type {
   ConnectionIdentity,
@@ -49,10 +48,26 @@ import type {
   GatewayRpcContext,
 } from './types.ts'
 import { ConnectionManager } from './connections.ts'
-import { StreamTimeout } from './enums.ts'
 import * as injectables from './injectables.ts'
 import { RpcManager } from './rpcs.ts'
-import { BlobStreamsManager } from './streams.ts'
+import {
+  BlobStreamsManager,
+  STREAM_CREDIT_VIOLATION_REASON,
+  STREAM_IDLE_TIMEOUT_REASON,
+  STREAM_TRANSPORT_DROP_REASON,
+} from './streams.ts'
+
+type RpcStreamCreditState = {
+  credits: number
+  // resolves the in-flight credit wait; also poked on abort/teardown
+  notify: (() => void) | null
+}
+
+/**
+ * Flow-control failure whose message is meant for the peer (sent as the
+ * stream abort reason) rather than logged as a server error.
+ */
+class StreamFlowError extends Error {}
 
 export interface GatewayOptions<
   ResolvedProcedure extends GatewayResolvedProcedure = GatewayResolvedProcedure,
@@ -69,7 +84,11 @@ export interface GatewayOptions<
     }
   }
   identity?: ConnectionIdentity
-  streamTimeouts?: Partial<StreamConfig['timeouts']>
+  /**
+   * Aborts any stream (blob or RPC) with no activity in either direction for
+   * this long. Activity = chunk sent/received, credit granted/received.
+   */
+  streamIdleTimeout?: number
 
   /**
    * Server-initiated heartbeat for bidirectional connections.
@@ -80,6 +99,7 @@ export interface GatewayOptions<
 
 const DEFAULT_GATEWAY_HEARTBEAT_INTERVAL = 15000
 const DEFAULT_GATEWAY_HEARTBEAT_TIMEOUT = 5000
+const DEFAULT_STREAM_IDLE_TIMEOUT = 30_000
 /**
  * Upper bound per connection teardown step so a never-settling transport
  * close or container disposal can't hang closeConnection() and stop().
@@ -103,13 +123,14 @@ export class Gateway<
   >()
   // In-flight teardowns keyed by connection id, see closeConnection
   private readonly closingConnections = new Map<string, Promise<void>>()
-  public options: Required<
-    Omit<GatewayOptions<ResolvedProcedure>, 'streamTimeouts'> & {
-      streamTimeouts: Required<
-        Exclude<GatewayOptions<ResolvedProcedure>['streamTimeouts'], undefined>
-      >
-    }
-  >
+  /**
+   * Chunk-count credits for in-flight RPC streaming responses, keyed by
+   * connectionId:callId. Entries live strictly within handleRpcMessage's
+   * streaming section (the callId is reserved in RpcManager for that whole
+   * span, so there is no reuse race); teardown also sweeps by connection.
+   */
+  private readonly rpcStreamCredits = new Map<string, RpcStreamCreditState>()
+  public options: Required<GatewayOptions<ResolvedProcedure>>
 
   constructor(options: GatewayOptions<ResolvedProcedure>) {
     this.options = {
@@ -118,12 +139,10 @@ export class Gateway<
         timeout: DEFAULT_GATEWAY_HEARTBEAT_TIMEOUT,
       },
       ...options,
-      streamTimeouts: {
-        [StreamTimeout.Pull]: 15000,
-        [StreamTimeout.Consume]: 15000,
-        [StreamTimeout.Finish]: 120000,
-        ...options.streamTimeouts,
-      },
+      // ?? instead of spread-default so an explicit `undefined` can't
+      // override it
+      streamIdleTimeout:
+        options.streamIdleTimeout ?? DEFAULT_STREAM_IDLE_TIMEOUT,
       identity:
         options.identity ??
         createFactoryInjectable({
@@ -135,7 +154,7 @@ export class Gateway<
     this.connections = new ConnectionManager()
     this.rpcs = new RpcManager()
     this.blobStreams = new BlobStreamsManager({
-      timeouts: this.options.streamTimeouts,
+      idleTimeout: this.options.streamIdleTimeout,
     })
   }
 
@@ -376,12 +395,20 @@ export class Gateway<
           metadata,
           {
             read: (size) => {
+              // record the grant before it goes on the wire so a push racing
+              // in can never be flagged as a credit violation
+              const pullSize = size || 65535
+              this.blobStreams.grantClientStream(
+                connectionId,
+                streamId,
+                pullSize,
+              )
               transport.send!(
                 connectionId,
                 protocol.encodeMessage(
                   this.createMessageContext(connection, transportKey),
                   ServerMessageType.ClientStreamPull,
-                  { streamId, size: size || 65535 },
+                  { streamId, size: pullSize },
                 ),
               )
             },
@@ -579,11 +606,33 @@ export class Gateway<
             break
           }
           case ClientMessageType.ClientStreamPush: {
-            this.blobStreams.pushToClientStream(
+            const accepted = this.blobStreams.pushToClientStream(
               connectionId,
               message.streamId,
               message.chunk,
             )
+            if (!accepted) {
+              logger.warn(
+                { streamId: message.streamId },
+                'Client stream push exceeds granted credit, aborting stream',
+              )
+              messageContext.transport.send?.(
+                connectionId,
+                connection.protocol.encodeMessage(
+                  messageContext,
+                  ServerMessageType.ClientStreamAbort,
+                  {
+                    streamId: message.streamId,
+                    reason: STREAM_CREDIT_VIOLATION_REASON,
+                  },
+                ),
+              )
+              this.blobStreams.abortClientStream(
+                connectionId,
+                message.streamId,
+                STREAM_CREDIT_VIOLATION_REASON,
+              )
+            }
             break
           }
           case ClientMessageType.ClientStreamEnd: {
@@ -599,7 +648,21 @@ export class Gateway<
             break
           }
           case ClientMessageType.ServerStreamPull: {
-            this.blobStreams.pullServerStream(connectionId, message.streamId)
+            this.blobStreams.pullServerStream(
+              connectionId,
+              message.streamId,
+              message.size,
+            )
+            break
+          }
+          case ClientMessageType.RpcStreamPull: {
+            const credit = this.rpcStreamCredits.get(
+              `${connectionId}:${message.callId}`,
+            )
+            if (credit) {
+              credit.credits += message.size
+              credit.notify?.()
+            }
             break
           }
           default:
@@ -724,11 +787,23 @@ export class Gateway<
           }),
         )
 
+        const creditKey = `${connectionId}:${callId}`
+        const credit: RpcStreamCreditState = { credits: 0, notify: null }
+        this.rpcStreamCredits.set(creditKey, credit)
+        // wake a pending credit wait so the loop can observe the abort
+        const wake = () => credit.notify?.()
+        signal.addEventListener('abort', wake, { once: true })
+
         try {
           for await (const chunk of response()) {
             signal.throwIfAborted()
+            while (credit.credits <= 0) {
+              await this.waitForRpcStreamCredit(credit, signal)
+              signal.throwIfAborted()
+            }
+            credit.credits--
             const chunkEncoded = encoder.encode(chunk)
-            transport.send!(
+            const sent = transport.send!(
               connectionId,
               protocol.encodeMessage(
                 context,
@@ -736,24 +811,37 @@ export class Gateway<
                 { callId, chunk: chunkEncoded },
               ),
             )
+            // for-await invokes the iterator's return() on throw, so the
+            // handler's finally blocks still run
+            if (sent === false) {
+              throw new StreamFlowError(STREAM_TRANSPORT_DROP_REASON)
+            }
           }
 
-          transport.send!(
+          const sent = transport.send!(
             connectionId,
             protocol.encodeMessage(context, ServerMessageType.RpcStreamEnd, {
               callId,
             }),
           )
+          if (sent === false) {
+            throw new StreamFlowError(STREAM_TRANSPORT_DROP_REASON)
+          }
         } catch (error) {
-          if (!isAbortError(error)) {
+          if (!isAbortError(error) && !(error instanceof StreamFlowError)) {
             this.logger.error(error)
           }
           transport.send!(
             connectionId,
             protocol.encodeMessage(context, ServerMessageType.RpcStreamAbort, {
               callId,
+              reason:
+                error instanceof StreamFlowError ? error.message : undefined,
             }),
           )
+        } finally {
+          signal.removeEventListener('abort', wake)
+          this.rpcStreamCredits.delete(creditKey)
         }
       } else {
         const streams = this.blobStreams.getServerStreamsMetadata(
@@ -782,6 +870,37 @@ export class Gateway<
       )
       const level = error instanceof ProtocolError ? 'trace' : 'error'
       this.logger[level](error)
+    }
+  }
+
+  /**
+   * Blocks until the client grants at least one chunk credit. A consumer
+   * that never pulls counts as idle, so the wait is bounded by the stream
+   * idle timeout; abort/teardown resolves the wait early via notify().
+   */
+  private waitForRpcStreamCredit(
+    credit: RpcStreamCreditState,
+    signal: AbortSignal,
+  ): Promise<void> {
+    if (credit.credits > 0 || signal.aborted) return Promise.resolve()
+    const future = createFuture<void>()
+    credit.notify = future.resolve
+    return withTimeout(
+      future.promise,
+      this.options.streamIdleTimeout,
+      new StreamFlowError(STREAM_IDLE_TIMEOUT_REASON),
+    ).finally(() => {
+      credit.notify = null
+    })
+  }
+
+  private releaseRpcStreamCredits(connectionId: string) {
+    const prefix = `${connectionId}:`
+    for (const [key, credit] of this.rpcStreamCredits) {
+      if (key.startsWith(prefix)) {
+        this.rpcStreamCredits.delete(key)
+        credit.notify?.()
+      }
     }
   }
 
@@ -838,6 +957,7 @@ export class Gateway<
     }
     await guard(() => connection.abortController.abort())
     await guard(() => this.rpcs.close(connectionId))
+    await guard(() => this.releaseRpcStreamCredits(connectionId))
     await guard(() => this.blobStreams.cleanupConnection(connectionId))
     await guard(() => connection.container.dispose())
   }
@@ -864,45 +984,48 @@ export class Gateway<
       const blob = ProtocolBlob.from(source, metadata, (metadata) => {
         return encoder.encodeBlob(streamId, metadata)
       })
-      const stream = this.blobStreams.createServerStream(
+      // the credit pump drives this sink; the manager aborts the stream when
+      // chunk delivery reports a dropped frame
+      this.blobStreams.createServerStream(
         connectionId,
         callId,
         streamId,
         blob,
+        {
+          chunk: (chunk) => {
+            return transport.send!(
+              connectionId,
+              protocol.encodeMessage(
+                context,
+                ServerMessageType.ServerStreamPush,
+                { streamId, chunk },
+              ),
+            )
+          },
+          end: () => {
+            transport.send!(
+              connectionId,
+              protocol.encodeMessage(
+                context,
+                ServerMessageType.ServerStreamEnd,
+                {
+                  streamId,
+                },
+              ),
+            )
+          },
+          error: (error) => {
+            transport.send!(
+              connectionId,
+              protocol.encodeMessage(
+                context,
+                ServerMessageType.ServerStreamAbort,
+                { streamId, reason: error.message },
+              ),
+            )
+          },
+        },
       )
-
-      stream.on('data', (chunk) => {
-        transport.send!(
-          connectionId,
-          protocol.encodeMessage(context, ServerMessageType.ServerStreamPush, {
-            streamId: streamId,
-            chunk: Buffer.from(chunk),
-          }),
-        )
-      })
-
-      stream.on('error', (error) => {
-        transport.send!(
-          connectionId,
-          protocol.encodeMessage(context, ServerMessageType.ServerStreamAbort, {
-            streamId: streamId,
-            reason: error.message,
-          }),
-        )
-      })
-
-      stream.once('finish', () => {
-        transport.send!(
-          connectionId,
-          protocol.encodeMessage(context, ServerMessageType.ServerStreamEnd, {
-            streamId: streamId,
-          }),
-        )
-      })
-
-      stream.once('close', () => {
-        this.blobStreams.removeServerStream(connectionId, streamId)
-      })
 
       return blob
     }

--- a/packages/gateway/src/streams.ts
+++ b/packages/gateway/src/streams.ts
@@ -8,6 +8,7 @@ import type {
 import type { ProtocolServerStreamSink } from '@nmtjs/protocol/server'
 import { noopFn } from '@nmtjs/common'
 import {
+  MAX_STREAM_CREDITS,
   ProtocolClientStream,
   ProtocolServerStream,
 } from '@nmtjs/protocol/server'
@@ -28,6 +29,9 @@ type ClientStreamState = {
   // outstanding byte credit: incremented per pull sent, decremented per push
   granted: number
   idleTimer: ReturnType<typeof setTimeout> | undefined
+  // single wire-abort notification for locally-initiated aborts
+  notify?: (reason: string) => void
+  notified: boolean
 }
 
 type ServerStreamState = {
@@ -35,6 +39,8 @@ type ServerStreamState = {
   callId: number
   stream: ProtocolServerStream
   idleTimer: ReturnType<typeof setTimeout> | undefined
+  // set for peer-originated aborts so the sink error is not echoed back
+  suppressNotify: boolean
 }
 
 type StreamState = ClientStreamState | ServerStreamState
@@ -50,6 +56,10 @@ type StreamState = ClientStreamState | ServerStreamState
  *   A transport-dropped frame aborts the stream (credits keep outstanding
  *   data far below the transport backpressure limit, so this is a safety
  *   net, not a flow-control mechanism).
+ * - Outstanding credit is capped at MAX_STREAM_CREDITS: peer grants beyond
+ *   the cap are violations, server-side upload grants are clamped.
+ * - Every stream sends AT MOST one wire abort; peer-originated aborts are
+ *   never echoed back.
  * - Every stream has a single idle timeout, reset on any activity in either
  *   direction; expiry aborts the stream.
  */
@@ -77,6 +87,7 @@ export class BlobStreamsManager {
     streamId: number,
     metadata: ProtocolBlobMetadata,
     options: Stream.ReadableOptions,
+    notify?: (reason: string) => void,
   ) {
     const stream = new ProtocolClientStream(streamId, metadata, options)
     stream.on('error', noopFn)
@@ -88,6 +99,8 @@ export class BlobStreamsManager {
       stream,
       granted: 0,
       idleTimer: undefined,
+      notify,
+      notified: false,
     }
     this.clientStreams.set(key, state)
     this.trackClientCall(connectionId, callId, streamId)
@@ -103,8 +116,22 @@ export class BlobStreamsManager {
     const key = this.getKey(connectionId, streamId)
     const state = this.clientStreams.get(key)
     if (state) {
-      state.granted += size
+      // pull sizes are server-chosen, so overflow is clamped, not a violation
+      state.granted = Math.min(state.granted + size, MAX_STREAM_CREDITS)
       this.touch(state)
+    }
+  }
+
+  /** Rolls back a grant whose pull frame never made it onto the wire. */
+  revokeClientStreamGrant(
+    connectionId: string,
+    streamId: number,
+    size: number,
+  ) {
+    const key = this.getKey(connectionId, streamId)
+    const state = this.clientStreams.get(key)
+    if (state) {
+      state.granted = Math.max(state.granted - size, 0)
     }
   }
 
@@ -136,10 +163,19 @@ export class BlobStreamsManager {
     }
   }
 
-  abortClientStream(connectionId: string, streamId: number, error = 'Aborted') {
+  abortClientStream(
+    connectionId: string,
+    streamId: number,
+    error = 'Aborted',
+    notifyPeer = true,
+  ) {
     const key = this.getKey(connectionId, streamId)
     const state = this.clientStreams.get(key)
     if (state) {
+      if (notifyPeer && !state.notified) {
+        state.notified = true
+        state.notify?.(error)
+      }
       state.stream.destroy(new Error(error))
       this.removeClientStream(connectionId, streamId)
     }
@@ -223,8 +259,10 @@ export class BlobStreamsManager {
         sink.end()
       },
       error: (error) => {
+        const state = this.serverStreams.get(key)
+        const suppress = state?.suppressNotify ?? false
         this.removeServerStream(connectionId, streamId)
-        sink.error(error)
+        if (!suppress) sink.error(error)
       },
     })
 
@@ -233,6 +271,7 @@ export class BlobStreamsManager {
       callId,
       stream,
       idleTimer: undefined,
+      suppressNotify: false,
     }
 
     this.serverStreams.set(key, state)
@@ -249,16 +288,29 @@ export class BlobStreamsManager {
     const state = this.serverStreams.get(key)
     if (state) {
       this.touch(state)
-      state.stream.grant(size)
+      const granted = state.stream.grant(size)
+      if (!granted) {
+        this.abortServerStream(
+          connectionId,
+          streamId,
+          STREAM_CREDIT_VIOLATION_REASON,
+        )
+      }
     }
   }
 
-  abortServerStream(connectionId: string, streamId: number, error = 'Aborted') {
+  abortServerStream(
+    connectionId: string,
+    streamId: number,
+    error = 'Aborted',
+    notifyPeer = true,
+  ) {
     const key = this.getKey(connectionId, streamId)
     const state = this.serverStreams.get(key)
     if (state) {
+      if (!notifyPeer) state.suppressNotify = true
       // destroy(error) reports through the stream sink, which removes the
-      // state and notifies the peer
+      // state and notifies the peer (unless suppressed)
       state.stream.destroy(new Error(error))
       this.removeServerStream(connectionId, streamId)
     }
@@ -436,14 +488,25 @@ export class BlobStreamsManager {
     const clientStreamIds = this.connectionClientStreams.get(connectionId)
     if (clientStreamIds) {
       for (const streamId of Array.from(clientStreamIds)) {
-        this.abortClientStream(connectionId, streamId, 'Connection closed')
+        // the connection is being torn down: peer notifications go nowhere
+        this.abortClientStream(
+          connectionId,
+          streamId,
+          'Connection closed',
+          false,
+        )
       }
     }
 
     const serverStreamIds = this.connectionServerStreams.get(connectionId)
     if (serverStreamIds) {
       for (const streamId of Array.from(serverStreamIds)) {
-        this.abortServerStream(connectionId, streamId, 'Connection closed')
+        this.abortServerStream(
+          connectionId,
+          streamId,
+          'Connection closed',
+          false,
+        )
       }
     }
   }

--- a/packages/gateway/src/streams.ts
+++ b/packages/gateway/src/streams.ts
@@ -137,7 +137,8 @@ export class BlobStreamsManager {
 
   /**
    * Returns `false` on a credit violation (push larger than the outstanding
-   * grant) — the caller is expected to abort the stream and notify the peer.
+   * grant, or an empty push — a free idle-timer refresh otherwise) — the
+   * caller is expected to abort the stream and notify the peer.
    */
   pushToClientStream(
     connectionId: string,
@@ -147,7 +148,7 @@ export class BlobStreamsManager {
     const key = this.getKey(connectionId, streamId)
     const state = this.clientStreams.get(key)
     if (!state) return true
-    if (chunk.byteLength > state.granted) return false
+    if (chunk.byteLength === 0 || chunk.byteLength > state.granted) return false
     state.granted -= chunk.byteLength
     state.stream.write(chunk)
     this.touch(state)

--- a/packages/gateway/src/streams.ts
+++ b/packages/gateway/src/streams.ts
@@ -5,43 +5,53 @@ import type {
   ProtocolBlob,
   ProtocolBlobMetadata,
 } from '@nmtjs/protocol'
+import type { ProtocolServerStreamSink } from '@nmtjs/protocol/server'
 import { noopFn } from '@nmtjs/common'
 import {
   ProtocolClientStream,
   ProtocolServerStream,
 } from '@nmtjs/protocol/server'
 
-import { StreamTimeout } from './enums.ts'
+export const STREAM_IDLE_TIMEOUT_REASON = 'stream idle timeout'
+export const STREAM_CREDIT_VIOLATION_REASON = 'stream credit violation'
+export const STREAM_TRANSPORT_DROP_REASON =
+  'transport backpressure overflow (frame dropped)'
 
 export type StreamConfig = {
-  timeouts: {
-    [StreamTimeout.Pull]: number
-    [StreamTimeout.Consume]: number
-    [StreamTimeout.Finish]: number
-  }
+  idleTimeout: number
 }
-
-type StreamTimeouts = Record<StreamTimeout, any>
 
 type ClientStreamState = {
   connectionId: string
   callId: number
   stream: ProtocolClientStream
-  timeouts: StreamTimeouts
+  // outstanding byte credit: incremented per pull sent, decremented per push
+  granted: number
+  idleTimer: ReturnType<typeof setTimeout> | undefined
 }
 
 type ServerStreamState = {
   connectionId: string
   callId: number
   stream: ProtocolServerStream
-  timeouts: StreamTimeouts
+  idleTimer: ReturnType<typeof setTimeout> | undefined
 }
 
 type StreamState = ClientStreamState | ServerStreamState
 
 /**
- * @todo Clarify Pull/Consume timeout semantics - currently ambiguous whether
- *       Pull timeout means "client not pulling" or "server not producing" for server streams
+ * Credit invariants:
+ * - Uploads (client streams): the server grants byte credits by sending
+ *   ClientStreamPull (driven by consumer _read demand); the client spends
+ *   them with ClientStreamPush. A push exceeding the outstanding credit is a
+ *   protocol violation and aborts the stream.
+ * - Downloads (server streams): the client grants byte credits with
+ *   ServerStreamPull; the credit pump emits at most that many bytes.
+ *   A transport-dropped frame aborts the stream (credits keep outstanding
+ *   data far below the transport backpressure limit, so this is a safety
+ *   net, not a flow-control mechanism).
+ * - Every stream has a single idle timeout, reset on any activity in either
+ *   direction; expiry aborts the stream.
  */
 export class BlobStreamsManager {
   readonly clientStreams = new Map<string, ClientStreamState>()
@@ -53,14 +63,10 @@ export class BlobStreamsManager {
   readonly clientCallStreams = new Map<string, Set<number>>()
   readonly serverCallStreams = new Map<string, Set<number>>()
 
-  readonly timeoutDurations: Record<StreamTimeout, number>
+  readonly idleTimeout: number
 
   constructor(config: StreamConfig) {
-    this.timeoutDurations = {
-      [StreamTimeout.Pull]: config.timeouts[StreamTimeout.Pull],
-      [StreamTimeout.Consume]: config.timeouts[StreamTimeout.Consume],
-      [StreamTimeout.Finish]: config.timeouts[StreamTimeout.Finish],
-    }
+    this.idleTimeout = config.idleTimeout
   }
 
   // --- Client Streams (Upload) ---
@@ -80,33 +86,45 @@ export class BlobStreamsManager {
       connectionId,
       callId,
       stream,
-      timeouts: {
-        [StreamTimeout.Pull]: undefined,
-        [StreamTimeout.Consume]: undefined,
-        [StreamTimeout.Finish]: undefined,
-      },
+      granted: 0,
+      idleTimer: undefined,
     }
     this.clientStreams.set(key, state)
     this.trackClientCall(connectionId, callId, streamId)
     this.trackConnectionClientStream(connectionId, streamId)
 
-    this.startTimeout(state, StreamTimeout.Consume)
+    this.touch(state)
 
     return stream
   }
 
+  /** Records a pull about to be sent to the client as outstanding credit. */
+  grantClientStream(connectionId: string, streamId: number, size: number) {
+    const key = this.getKey(connectionId, streamId)
+    const state = this.clientStreams.get(key)
+    if (state) {
+      state.granted += size
+      this.touch(state)
+    }
+  }
+
+  /**
+   * Returns `false` on a credit violation (push larger than the outstanding
+   * grant) — the caller is expected to abort the stream and notify the peer.
+   */
   pushToClientStream(
     connectionId: string,
     streamId: number,
     chunk: ArrayBufferView,
-  ) {
+  ): boolean {
     const key = this.getKey(connectionId, streamId)
     const state = this.clientStreams.get(key)
-    if (state) {
-      state.stream.write(chunk)
-      this.clearTimeout(state, StreamTimeout.Consume)
-      this.startTimeout(state, StreamTimeout.Pull)
-    }
+    if (!state) return true
+    if (chunk.byteLength > state.granted) return false
+    state.granted -= chunk.byteLength
+    state.stream.write(chunk)
+    this.touch(state)
+    return true
   }
 
   endClientStream(connectionId: string, streamId: number) {
@@ -151,9 +169,7 @@ export class BlobStreamsManager {
     const state = this.clientStreams.get(key)
     if (state) {
       this.clientStreams.delete(key)
-      this.clearTimeout(state, StreamTimeout.Finish)
-      this.clearTimeout(state, StreamTimeout.Pull)
-      this.clearTimeout(state, StreamTimeout.Consume)
+      this.clearIdleTimer(state)
       this.untrackClientCall(connectionId, state.callId, streamId)
       this.untrackConnectionClientStream(connectionId, streamId)
     }
@@ -184,41 +200,56 @@ export class BlobStreamsManager {
     callId: number,
     streamId: number,
     blob: ProtocolBlob,
+    sink: ProtocolServerStreamSink,
   ) {
-    const stream = new ProtocolServerStream(streamId, blob)
     const key = this.getKey(connectionId, streamId)
+
+    const stream = new ProtocolServerStream(streamId, blob, {
+      chunk: (chunk) => {
+        const state = this.serverStreams.get(key)
+        if (state) this.touch(state)
+        const sent = sink.chunk(chunk)
+        if (sent === false) {
+          this.abortServerStream(
+            connectionId,
+            streamId,
+            STREAM_TRANSPORT_DROP_REASON,
+          )
+        }
+        return sent
+      },
+      end: () => {
+        this.removeServerStream(connectionId, streamId)
+        sink.end()
+      },
+      error: (error) => {
+        this.removeServerStream(connectionId, streamId)
+        sink.error(error)
+      },
+    })
 
     const state: ServerStreamState = {
       connectionId,
       callId,
       stream,
-      timeouts: {
-        [StreamTimeout.Pull]: undefined,
-        [StreamTimeout.Consume]: undefined,
-        [StreamTimeout.Finish]: undefined,
-      },
+      idleTimer: undefined,
     }
-
-    // Prevent unhandled 'error' events, in case the user did not subscribe to them
-    stream.on('error', noopFn)
 
     this.serverStreams.set(key, state)
     this.trackServerCall(connectionId, callId, streamId)
     this.trackConnectionServerStream(connectionId, streamId)
 
-    this.startTimeout(state, StreamTimeout.Finish)
-    this.startTimeout(state, StreamTimeout.Consume)
+    this.touch(state)
 
     return stream
   }
 
-  pullServerStream(connectionId: string, streamId: number) {
+  pullServerStream(connectionId: string, streamId: number, size: number) {
     const key = this.getKey(connectionId, streamId)
     const state = this.serverStreams.get(key)
     if (state) {
-      state.stream.resume()
-      this.clearTimeout(state, StreamTimeout.Consume)
-      this.startTimeout(state, StreamTimeout.Pull)
+      this.touch(state)
+      state.stream.grant(size)
     }
   }
 
@@ -226,6 +257,8 @@ export class BlobStreamsManager {
     const key = this.getKey(connectionId, streamId)
     const state = this.serverStreams.get(key)
     if (state) {
+      // destroy(error) reports through the stream sink, which removes the
+      // state and notifies the peer
       state.stream.destroy(new Error(error))
       this.removeServerStream(connectionId, streamId)
     }
@@ -236,43 +269,38 @@ export class BlobStreamsManager {
     const state = this.serverStreams.get(key)
     if (state) {
       this.serverStreams.delete(key)
-      this.clearTimeout(state, StreamTimeout.Pull)
-      this.clearTimeout(state, StreamTimeout.Consume)
-      this.clearTimeout(state, StreamTimeout.Finish)
+      this.clearIdleTimer(state)
       this.untrackServerCall(connectionId, state.callId, streamId)
       this.untrackConnectionServerStream(connectionId, streamId)
     }
   }
 
-  // --- Timeouts ---
+  // --- Idle timeout ---
 
-  private startTimeout(state: StreamState, type: StreamTimeout) {
-    this.clearTimeout(state, type)
-    const duration = this.timeoutDurations[type]
-    const timeout = setTimeout(() => {
+  private touch(state: StreamState) {
+    this.clearIdleTimer(state)
+    state.idleTimer = setTimeout(() => {
+      state.idleTimer = undefined
       if (state.stream instanceof ProtocolClientStream) {
         this.abortClientStream(
           state.connectionId,
           state.stream.id,
-          `${type} timeout`,
+          STREAM_IDLE_TIMEOUT_REASON,
         )
       } else {
         this.abortServerStream(
           state.connectionId,
           state.stream.id,
-          `${type} timeout`,
+          STREAM_IDLE_TIMEOUT_REASON,
         )
       }
-      state.timeouts[type] = undefined
-    }, duration)
-    state.timeouts[type] = timeout
+    }, this.idleTimeout)
   }
 
-  private clearTimeout(state: StreamState, type: StreamTimeout) {
-    const timeout = state.timeouts[type]
-    if (timeout) {
-      clearTimeout(timeout)
-      state.timeouts[type] = undefined
+  private clearIdleTimer(state: StreamState) {
+    if (state.idleTimer) {
+      clearTimeout(state.idleTimer)
+      state.idleTimer = undefined
     }
   }
 

--- a/packages/gateway/tests/stream-flow.spec.ts
+++ b/packages/gateway/tests/stream-flow.spec.ts
@@ -181,10 +181,14 @@ const sleep = (ms: number) =>
 describe('RPC stream flow control', () => {
   it('gates chunks on RpcStreamPull credits', async () => {
     let finished = false
+    let advanced = 0
     async function* handler() {
       try {
+        advanced++
         yield 'a'
+        advanced++
         yield 'b'
+        advanced++
         yield 'c'
       } finally {
         finished = true
@@ -199,8 +203,10 @@ describe('RPC stream flow control', () => {
     await flush()
 
     expect(sentOfType(ServerMessageType.RpcStreamResponse).length).toBe(1)
-    // no credit yet: no chunk may be sent
+    // no credit yet: no chunk may be sent and the producer must not even
+    // have been advanced (no prefetch before the first pull)
     expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(0)
+    expect(advanced).toBe(0)
 
     await send(encodeRpcStreamPull(1, 1))
     await flush()
@@ -208,10 +214,17 @@ describe('RPC stream flow control', () => {
     expect(
       JSON.parse(sentOfType(ServerMessageType.RpcStreamChunk)[0].rest as any),
     ).toBe('a')
+    // exactly one credit = exactly one producer advance
+    expect(advanced).toBe(1)
 
     await send(encodeRpcStreamPull(1, 2))
     await flush()
     expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(3)
+    // the End still needs one more credit: the consumer's final read
+    expect(sentOfType(ServerMessageType.RpcStreamEnd).length).toBe(0)
+
+    await send(encodeRpcStreamPull(1, 1))
+    await flush()
     expect(sentOfType(ServerMessageType.RpcStreamEnd).length).toBe(1)
     expect(finished).toBe(true)
 
@@ -265,8 +278,11 @@ describe('RPC stream flow control', () => {
 
     const inFlight = send(encodeRpcMessage(1, 'test', {}))
     await flush()
+    // one credit so the generator actually starts (and has cleanup to run)
+    await send(encodeRpcStreamPull(1, 1))
+    await flush()
 
-    // handler is parked waiting for credit; teardown must release it
+    // the loop is parked waiting for more credit; teardown must release it
     await gateway.stop()
     await inFlight
 
@@ -304,16 +320,16 @@ describe('RPC stream flow control', () => {
   })
 
   it('reaps a stream whose consumer never pulls via the idle timeout', async () => {
-    let finished = false
+    let advanced = false
+    // never-yielding producer + never-iterating client: without the credit
+    // gate before next() this state had no timer and leaked forever
     async function* handler() {
-      try {
-        while (true) yield 'tick'
-      } finally {
-        finished = true
-      }
+      advanced = true
+      await new Promise(() => {})
+      yield 'never'
     }
 
-    const { gateway, sentOfType, send } = await createTestGateway({
+    const { gateway, sentOfType, send, connection } = await createTestGateway({
       call: async () => () => handler(),
       streamIdleTimeout: 50,
     })
@@ -321,10 +337,12 @@ describe('RPC stream flow control', () => {
     const inFlight = send(encodeRpcMessage(1, 'test', {}))
     await inFlight
 
-    expect(finished).toBe(true)
     const aborts = sentOfType(ServerMessageType.RpcStreamAbort)
     expect(aborts.length).toBe(1)
     expect(aborts[0].rest.toString()).toBe(STREAM_IDLE_TIMEOUT_REASON)
+    // the producer was never advanced and the reservation is released
+    expect(advanced).toBe(false)
+    expect(gateway.rpcs.get(connection.id, 1)).toBeUndefined()
 
     await gateway.stop()
   })
@@ -483,9 +501,13 @@ describe('RPC stream flow control', () => {
     const { gateway, sentOfType, send } = await createTestGateway({
       call: async () => () => handler(),
       onSend: (message) => {
-        // simulate an in-process transport delivering the first pull
-        // re-entrantly, before the response send even returns
-        if (message.type === ServerMessageType.RpcStreamResponse) {
+        // simulate an in-process transport delivering pulls re-entrantly:
+        // the first before the response send even returns, the next one
+        // (the consumer's final read) inside the chunk send
+        if (
+          message.type === ServerMessageType.RpcStreamResponse ||
+          message.type === ServerMessageType.RpcStreamChunk
+        ) {
           void sendNow?.(encodeRpcStreamPull(1, 1))
         }
       },
@@ -519,6 +541,10 @@ describe('RPC stream flow control', () => {
 
     const inFlight = send(encodeRpcMessage(1, 'test', {}))
     await flush()
+    // a valid credit first, so the generator starts and has cleanup to run
+    await send(encodeRpcStreamPull(1, 1))
+    await flush()
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(1)
 
     await send(encodeRpcStreamPull(1, 0))
     await inFlight

--- a/packages/gateway/tests/stream-flow.spec.ts
+++ b/packages/gateway/tests/stream-flow.spec.ts
@@ -5,6 +5,7 @@ import { Hooks } from '@nmtjs/core'
 import {
   ClientMessageType,
   ConnectionType,
+  createProtocolBlobReference,
   ProtocolVersion,
   ServerMessageType,
 } from '@nmtjs/protocol'
@@ -114,6 +115,8 @@ async function createTestGateway(options?: {
   call?: GatewayApi['call']
   streamIdleTimeout?: number
   sendResult?: (message: SentMessage) => boolean
+  // invoked synchronously inside transport.send, after recording
+  onSend?: (message: SentMessage) => void
 }) {
   const logger = createTestLogger()
   const container = createTestContainer({ logger })
@@ -136,7 +139,9 @@ async function createTestGateway(options?: {
     send: vi.fn((_connectionId: string, buffer: ArrayBufferView) => {
       const message = decodeSent(Buffer.from(buffer as Uint8Array))
       sent.push(message)
-      return options?.sendResult?.(message) ?? true
+      const result = options?.sendResult?.(message) ?? true
+      options?.onSend?.(message)
+      return result
     }),
     close: vi.fn((_connectionId: string) => {}),
   }
@@ -167,8 +172,11 @@ async function createTestGateway(options?: {
 
   const sentOfType = (type: number) => sent.filter((m) => m.type === type)
 
-  return { gateway, api, sent, sentOfType, connection, send }
+  return { gateway, api, sent, sentOfType, connection, send, transport }
 }
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms))
 
 describe('RPC stream flow control', () => {
   it('gates chunks on RpcStreamPull credits', async () => {
@@ -320,6 +328,216 @@ describe('RPC stream flow control', () => {
 
     await gateway.stop()
   })
+
+  it('terminates a handler stalled inside next() on client abort', async () => {
+    let finished = false
+    let releaseStall!: () => void
+    const stall = new Promise<void>((resolve) => {
+      releaseStall = resolve
+    })
+    async function* handler() {
+      try {
+        yield 'first'
+        await stall
+        yield 'second'
+      } finally {
+        finished = true
+      }
+    }
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async () => () => handler(),
+    })
+
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+    await send(encodeRpcStreamPull(1, 2))
+    await flush()
+
+    // first chunk delivered, second next() is parked on the stalled await
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(1)
+
+    await send(encodeRpcAbort(1))
+    await flush()
+
+    // the abort escapes the stalled next() immediately...
+    expect(sentOfType(ServerMessageType.RpcStreamAbort).length).toBe(1)
+    // ...while the handler itself can only unwind cooperatively
+    expect(finished).toBe(false)
+
+    releaseStall()
+    await inFlight
+    expect(finished).toBe(true)
+
+    await gateway.stop()
+  })
+
+  it('terminates a handler stalled inside next() via the idle timeout', async () => {
+    let finished = false
+    let releaseStall!: () => void
+    const stall = new Promise<void>((resolve) => {
+      releaseStall = resolve
+    })
+    async function* handler() {
+      try {
+        yield 'first'
+        await stall
+        yield 'second'
+      } finally {
+        finished = true
+      }
+    }
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async () => () => handler(),
+      streamIdleTimeout: 50,
+    })
+
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+    // enough credit that the loop parks in next(), not in the credit wait
+    await send(encodeRpcStreamPull(1, 5))
+    await flush()
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(1)
+
+    await sleep(120)
+
+    const aborts = sentOfType(ServerMessageType.RpcStreamAbort)
+    expect(aborts.length).toBe(1)
+    expect(aborts[0].rest.toString()).toBe(STREAM_IDLE_TIMEOUT_REASON)
+
+    releaseStall()
+    await inFlight
+    expect(finished).toBe(true)
+
+    await gateway.stop()
+  })
+
+  it('closes the connection when the RpcStreamResponse frame is dropped', async () => {
+    let invoked = false
+    async function* handler() {
+      yield 'never'
+    }
+
+    const { gateway, sentOfType, send, transport } = await createTestGateway({
+      call: async () => () => {
+        invoked = true
+        return handler()
+      },
+      sendResult: (message) =>
+        message.type !== ServerMessageType.RpcStreamResponse,
+    })
+
+    await send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+
+    // no streaming loop ran and no stream frames followed
+    expect(invoked).toBe(false)
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(0)
+    expect(sentOfType(ServerMessageType.RpcStreamAbort).length).toBe(0)
+    expect(transport.close).toHaveBeenCalled()
+
+    await gateway.stop()
+  })
+
+  it('does not lose a grant delivered synchronously with the stream response', async () => {
+    async function* handler() {
+      yield 'a'
+    }
+
+    let sendNow: ((data: Buffer) => Promise<void>) | null = null
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async () => () => handler(),
+      onSend: (message) => {
+        // simulate an in-process transport delivering the first pull
+        // re-entrantly, before the response send even returns
+        if (message.type === ServerMessageType.RpcStreamResponse) {
+          void sendNow?.(encodeRpcStreamPull(1, 1))
+        }
+      },
+    })
+    sendNow = send
+
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(1)
+    expect(sentOfType(ServerMessageType.RpcStreamEnd).length).toBe(1)
+    expect(sentOfType(ServerMessageType.RpcStreamAbort).length).toBe(0)
+
+    await inFlight
+    await gateway.stop()
+  })
+
+  it('aborts the stream on a zero-size RpcStreamPull', async () => {
+    let finished = false
+    async function* handler() {
+      try {
+        while (true) yield 'tick'
+      } finally {
+        finished = true
+      }
+    }
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async () => () => handler(),
+    })
+
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+
+    await send(encodeRpcStreamPull(1, 0))
+    await inFlight
+
+    expect(finished).toBe(true)
+    const aborts = sentOfType(ServerMessageType.RpcStreamAbort)
+    expect(aborts.length).toBe(1)
+    expect(aborts[0].rest.toString()).toBe(STREAM_CREDIT_VIOLATION_REASON)
+
+    await gateway.stop()
+  })
+
+  it('aborts the stream when pull totals overflow the credit cap', async () => {
+    let finished = false
+    let releaseStall!: () => void
+    const stall = new Promise<void>((resolve) => {
+      releaseStall = resolve
+    })
+    async function* handler() {
+      try {
+        yield 'a'
+        await stall
+      } finally {
+        finished = true
+      }
+    }
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async () => () => handler(),
+    })
+
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+
+    await send(encodeRpcStreamPull(1, 2 ** 32 - 1))
+    await flush()
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(1)
+    expect(sentOfType(ServerMessageType.RpcStreamAbort).length).toBe(0)
+
+    await send(encodeRpcStreamPull(1, 2 ** 32 - 1))
+    await flush()
+
+    const aborts = sentOfType(ServerMessageType.RpcStreamAbort)
+    expect(aborts.length).toBe(1)
+    expect(aborts[0].rest.toString()).toBe(STREAM_CREDIT_VIOLATION_REASON)
+
+    releaseStall()
+    await inFlight
+    expect(finished).toBe(true)
+
+    await gateway.stop()
+  })
 })
 
 describe('Upload stream flow control', () => {
@@ -348,6 +566,68 @@ describe('Upload stream flow control', () => {
 
     release()
     await inFlight
+
+    // still exactly one wire abort for this stream
+    expect(sentOfType(ServerMessageType.ClientStreamAbort).length).toBe(1)
+
+    await gateway.stop()
+  })
+
+  it('rolls back the grant and aborts when the pull frame is dropped', async () => {
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async ({ container }) => {
+        const consumeBlob = await container.resolve(injectables.consumeBlob)
+        const stream = consumeBlob(
+          createProtocolBlobReference(7, { type: 'application/octet-stream' }),
+        )
+        // start consuming: _read demand triggers the (dropped) pull
+        stream.on('data', () => {})
+        stream.on('error', () => {})
+        await new Promise<void>((resolve) => setImmediate(resolve))
+        return null
+      },
+      sendResult: (message) =>
+        message.type !== ServerMessageType.ClientStreamPull,
+    })
+
+    await send(encodeRpcMessage(1, 'test', { __stream: 7 }))
+    await flush()
+
+    expect(sentOfType(ServerMessageType.ClientStreamPull).length).toBe(1)
+    const aborts = sentOfType(ServerMessageType.ClientStreamAbort)
+    expect(aborts.length).toBe(1)
+    expect(aborts[0].id).toBe(7)
+    expect(aborts[0].rest.toString()).toBe(STREAM_TRANSPORT_DROP_REASON)
+    expect(gateway.blobStreams.clientStreams.size).toBe(0)
+
+    await gateway.stop()
+  })
+
+  it('sends the idle timeout reason on the wire, exactly once', async () => {
+    let release!: () => void
+    const pending = new Promise<null>((resolve) => {
+      release = () => resolve(null)
+    })
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async () => pending,
+      streamIdleTimeout: 50,
+    })
+
+    const inFlight = send(encodeRpcMessage(1, 'test', { __stream: 9 }))
+    await sleep(120)
+
+    let aborts = sentOfType(ServerMessageType.ClientStreamAbort)
+    expect(aborts.length).toBe(1)
+    expect(aborts[0].id).toBe(9)
+    expect(aborts[0].rest.toString()).toBe(STREAM_IDLE_TIMEOUT_REASON)
+
+    // the dispose path must not send a second abort for the same stream
+    release()
+    await inFlight
+    aborts = sentOfType(ServerMessageType.ClientStreamAbort)
+    expect(aborts.length).toBe(1)
+
     await gateway.stop()
   })
 })
@@ -385,6 +665,122 @@ describe('Download stream flow control', () => {
     pushes = sentOfType(ServerMessageType.ServerStreamPush)
     expect(Buffer.concat(pushes.map((p) => p.rest)).byteLength).toBe(100)
     expect(sentOfType(ServerMessageType.ServerStreamEnd).length).toBe(1)
+    expect(gateway.blobStreams.serverStreams.size).toBe(0)
+
+    await gateway.stop()
+  })
+
+  it('closes the connection when a terminal ServerStreamEnd frame is dropped', async () => {
+    const { gateway, sentOfType, send, transport } = await createTestGateway({
+      call: async ({ container }) => {
+        const createBlob = await container.resolve(injectables.createBlob)
+        createBlob(Readable.from([Buffer.alloc(10)]), {
+          type: 'application/octet-stream',
+          size: 10,
+        })
+        return null
+      },
+      sendResult: (message) =>
+        message.type !== ServerMessageType.ServerStreamEnd,
+    })
+
+    await send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+    await send(encodeServerStreamPull(0, 100))
+    await flush()
+
+    expect(sentOfType(ServerMessageType.ServerStreamEnd).length).toBe(1)
+    // the frame was dropped after local cleanup: only a connection close can
+    // stop the client from waiting forever
+    expect(transport.close).toHaveBeenCalled()
+    expect(gateway.blobStreams.serverStreams.size).toBe(0)
+
+    await gateway.stop()
+  })
+
+  it('aborts the stream on a zero-size ServerStreamPull', async () => {
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async ({ container }) => {
+        const createBlob = await container.resolve(injectables.createBlob)
+        createBlob(Readable.from([Buffer.alloc(10)]), {
+          type: 'application/octet-stream',
+          size: 10,
+        })
+        return null
+      },
+    })
+
+    await send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+    await send(encodeServerStreamPull(0, 0))
+    await flush()
+
+    expect(sentOfType(ServerMessageType.ServerStreamPush).length).toBe(0)
+    const aborts = sentOfType(ServerMessageType.ServerStreamAbort)
+    expect(aborts.length).toBe(1)
+    expect(aborts[0].rest.toString()).toBe(STREAM_CREDIT_VIOLATION_REASON)
+    expect(gateway.blobStreams.serverStreams.size).toBe(0)
+
+    await gateway.stop()
+  })
+
+  it('aborts the stream when byte-credit grants overflow the cap', async () => {
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async ({ container }) => {
+        const createBlob = await container.resolve(injectables.createBlob)
+        // manual source: no data, credits just accumulate
+        createBlob(new Readable({ read() {} }), {
+          type: 'application/octet-stream',
+        })
+        return null
+      },
+    })
+
+    await send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+
+    await send(encodeServerStreamPull(0, 2 ** 32 - 1))
+    await flush()
+    expect(sentOfType(ServerMessageType.ServerStreamAbort).length).toBe(0)
+
+    await send(encodeServerStreamPull(0, 2 ** 32 - 1))
+    await flush()
+
+    const aborts = sentOfType(ServerMessageType.ServerStreamAbort)
+    expect(aborts.length).toBe(1)
+    expect(aborts[0].rest.toString()).toBe(STREAM_CREDIT_VIOLATION_REASON)
+    expect(gateway.blobStreams.serverStreams.size).toBe(0)
+
+    await gateway.stop()
+  })
+
+  it('does not send the abort for a pre-grant source error before the pull', async () => {
+    const source = new Readable({ read() {} })
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async ({ container }) => {
+        const createBlob = await container.resolve(injectables.createBlob)
+        createBlob(source, { type: 'application/octet-stream' })
+        return null
+      },
+    })
+
+    await send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+    expect(sentOfType(ServerMessageType.RpcResponse).length).toBe(1)
+
+    // the source dies before the client ever pulled
+    source.destroy(new Error('early failure'))
+    await flush()
+    expect(sentOfType(ServerMessageType.ServerStreamAbort).length).toBe(0)
+
+    // the abort is delivered against the first grant instead
+    await send(encodeServerStreamPull(0, 10))
+    await flush()
+
+    const aborts = sentOfType(ServerMessageType.ServerStreamAbort)
+    expect(aborts.length).toBe(1)
+    expect(aborts[0].rest.toString()).toBe('early failure')
     expect(gateway.blobStreams.serverStreams.size).toBe(0)
 
     await gateway.stop()

--- a/packages/gateway/tests/stream-flow.spec.ts
+++ b/packages/gateway/tests/stream-flow.spec.ts
@@ -1,0 +1,392 @@
+import { Buffer } from 'node:buffer'
+import { Readable } from 'node:stream'
+
+import { Hooks } from '@nmtjs/core'
+import {
+  ClientMessageType,
+  ConnectionType,
+  ProtocolVersion,
+  ServerMessageType,
+} from '@nmtjs/protocol'
+import { BaseServerFormat, ProtocolFormats } from '@nmtjs/protocol/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { GatewayApi } from '../src/api.ts'
+import { Gateway } from '../src/gateway.ts'
+import * as injectables from '../src/injectables.ts'
+import {
+  STREAM_CREDIT_VIOLATION_REASON,
+  STREAM_IDLE_TIMEOUT_REASON,
+  STREAM_TRANSPORT_DROP_REASON,
+} from '../src/streams.ts'
+import { createTestContainer, createTestLogger } from './_helpers/test-utils.ts'
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+/**
+ * JSON format that registers a client (upload) stream when the RPC payload
+ * carries a `__stream` marker, mirroring what real formats do for blobs.
+ */
+class StreamTestFormat extends BaseServerFormat {
+  accept = ['application/json']
+  contentType = 'application/json'
+
+  encode(data: unknown): ArrayBufferView {
+    return encoder.encode(JSON.stringify(data))
+  }
+
+  encodeRPC(data: unknown): ArrayBufferView {
+    return this.encode(data ?? null)
+  }
+
+  encodeBlob(streamId: number, metadata: unknown) {
+    return { streamId, metadata }
+  }
+
+  decode(buffer: ArrayBufferView) {
+    return JSON.parse(decoder.decode(buffer))
+  }
+
+  decodeRPC(buffer: ArrayBufferView, context: any) {
+    const data = this.decode(buffer)
+    if (data && typeof data === 'object' && data.__stream !== undefined) {
+      context.addStream(data.__stream, { type: 'application/octet-stream' })
+    }
+    return data
+  }
+}
+
+const encodeRpcMessage = (callId: number, procedure: string, payload: any) => {
+  const name = Buffer.from(procedure, 'utf-8')
+  const header = Buffer.alloc(7)
+  header.writeUInt8(ClientMessageType.Rpc, 0)
+  header.writeUInt32LE(callId, 1)
+  header.writeUInt16LE(name.byteLength, 5)
+  return Buffer.concat([header, name, Buffer.from(JSON.stringify(payload))])
+}
+
+const encodeRpcAbort = (callId: number) => {
+  const buffer = Buffer.alloc(5)
+  buffer.writeUInt8(ClientMessageType.RpcAbort, 0)
+  buffer.writeUInt32LE(callId, 1)
+  return buffer
+}
+
+const encodeRpcStreamPull = (callId: number, size: number) => {
+  const buffer = Buffer.alloc(9)
+  buffer.writeUInt8(ClientMessageType.RpcStreamPull, 0)
+  buffer.writeUInt32LE(callId, 1)
+  buffer.writeUInt32LE(size, 5)
+  return buffer
+}
+
+const encodeServerStreamPull = (streamId: number, size: number) => {
+  const buffer = Buffer.alloc(9)
+  buffer.writeUInt8(ClientMessageType.ServerStreamPull, 0)
+  buffer.writeUInt32LE(streamId, 1)
+  buffer.writeUInt32LE(size, 5)
+  return buffer
+}
+
+const encodeClientStreamPush = (streamId: number, chunk: Buffer) => {
+  const header = Buffer.alloc(5)
+  header.writeUInt8(ClientMessageType.ClientStreamPush, 0)
+  header.writeUInt32LE(streamId, 1)
+  return Buffer.concat([header, chunk])
+}
+
+type SentMessage = { type: number; id: number; rest: Buffer }
+
+const decodeSent = (buffer: Buffer): SentMessage => ({
+  type: buffer.readUInt8(0),
+  id: buffer.readUInt32LE(1),
+  rest: buffer.subarray(5),
+})
+
+const flush = async (rounds = 5) => {
+  for (let i = 0; i < rounds; i++) {
+    await new Promise<void>((resolve) => setImmediate(resolve))
+  }
+}
+
+async function createTestGateway(options?: {
+  call?: GatewayApi['call']
+  streamIdleTimeout?: number
+  sendResult?: (message: SentMessage) => boolean
+}) {
+  const logger = createTestLogger()
+  const container = createTestContainer({ logger })
+  const serverFormat = new StreamTestFormat()
+
+  const api: GatewayApi = {
+    resolve: vi.fn(async () => ({ name: 'test', stream: false })),
+    call: vi.fn(options?.call ?? (async () => null)),
+  }
+
+  let params: any
+  const sent: SentMessage[] = []
+
+  const transport = {
+    start: vi.fn(async (_params) => {
+      params = _params
+      return 'test://'
+    }),
+    stop: vi.fn(async () => {}),
+    send: vi.fn((_connectionId: string, buffer: ArrayBufferView) => {
+      const message = decodeSent(Buffer.from(buffer as Uint8Array))
+      sent.push(message)
+      return options?.sendResult?.(message) ?? true
+    }),
+    close: vi.fn((_connectionId: string) => {}),
+  }
+
+  const gateway = new Gateway({
+    logger,
+    container,
+    hooks: new Hooks(),
+    formats: new ProtocolFormats([serverFormat]),
+    transports: { test: { transport } },
+    api,
+    heartbeat: false,
+    streamIdleTimeout: options?.streamIdleTimeout,
+  })
+
+  await gateway.start()
+
+  const connection = await params.onConnect({
+    type: ConnectionType.Bidirectional,
+    protocolVersion: ProtocolVersion.v1,
+    accept: serverFormat.contentType,
+    contentType: serverFormat.contentType,
+    data: {},
+  })
+
+  const send = (data: Buffer) =>
+    params.onMessage({ connectionId: connection.id, data })
+
+  const sentOfType = (type: number) => sent.filter((m) => m.type === type)
+
+  return { gateway, api, sent, sentOfType, connection, send }
+}
+
+describe('RPC stream flow control', () => {
+  it('gates chunks on RpcStreamPull credits', async () => {
+    let finished = false
+    async function* handler() {
+      try {
+        yield 'a'
+        yield 'b'
+        yield 'c'
+      } finally {
+        finished = true
+      }
+    }
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async () => () => handler(),
+    })
+
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+
+    expect(sentOfType(ServerMessageType.RpcStreamResponse).length).toBe(1)
+    // no credit yet: no chunk may be sent
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(0)
+
+    await send(encodeRpcStreamPull(1, 1))
+    await flush()
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(1)
+    expect(
+      JSON.parse(sentOfType(ServerMessageType.RpcStreamChunk)[0].rest as any),
+    ).toBe('a')
+
+    await send(encodeRpcStreamPull(1, 2))
+    await flush()
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(3)
+    expect(sentOfType(ServerMessageType.RpcStreamEnd).length).toBe(1)
+    expect(finished).toBe(true)
+
+    await inFlight
+    await gateway.stop()
+  })
+
+  it('runs the handler cleanup when the client aborts mid-stream', async () => {
+    let finished = false
+    async function* handler() {
+      try {
+        while (true) yield 'tick'
+      } finally {
+        finished = true
+      }
+    }
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async () => () => handler(),
+    })
+
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+    await send(encodeRpcStreamPull(1, 1))
+    await flush()
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(1)
+
+    await send(encodeRpcAbort(1))
+    await inFlight
+
+    expect(finished).toBe(true)
+    expect(sentOfType(ServerMessageType.RpcStreamAbort).length).toBe(1)
+    expect(gateway.rpcs.get('any', 1)).toBeUndefined()
+
+    await gateway.stop()
+  })
+
+  it('runs the handler cleanup on connection teardown', async () => {
+    let finished = false
+    async function* handler() {
+      try {
+        while (true) yield 'tick'
+      } finally {
+        finished = true
+      }
+    }
+
+    const { gateway, send } = await createTestGateway({
+      call: async () => () => handler(),
+    })
+
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+
+    // handler is parked waiting for credit; teardown must release it
+    await gateway.stop()
+    await inFlight
+
+    expect(finished).toBe(true)
+  })
+
+  it('aborts the stream when a chunk frame is dropped by the transport', async () => {
+    let finished = false
+    async function* handler() {
+      try {
+        while (true) yield 'tick'
+      } finally {
+        finished = true
+      }
+    }
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async () => () => handler(),
+      sendResult: (message) =>
+        message.type !== ServerMessageType.RpcStreamChunk,
+    })
+
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+    await send(encodeRpcStreamPull(1, 10))
+    await inFlight
+
+    expect(finished).toBe(true)
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(1)
+    const aborts = sentOfType(ServerMessageType.RpcStreamAbort)
+    expect(aborts.length).toBe(1)
+    expect(aborts[0].rest.toString()).toBe(STREAM_TRANSPORT_DROP_REASON)
+
+    await gateway.stop()
+  })
+
+  it('reaps a stream whose consumer never pulls via the idle timeout', async () => {
+    let finished = false
+    async function* handler() {
+      try {
+        while (true) yield 'tick'
+      } finally {
+        finished = true
+      }
+    }
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async () => () => handler(),
+      streamIdleTimeout: 50,
+    })
+
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
+    await inFlight
+
+    expect(finished).toBe(true)
+    const aborts = sentOfType(ServerMessageType.RpcStreamAbort)
+    expect(aborts.length).toBe(1)
+    expect(aborts[0].rest.toString()).toBe(STREAM_IDLE_TIMEOUT_REASON)
+
+    await gateway.stop()
+  })
+})
+
+describe('Upload stream flow control', () => {
+  it('aborts an upload stream on a push exceeding granted credit', async () => {
+    // hold the call in flight so its streams stay alive
+    let release!: () => void
+    const pending = new Promise<null>((resolve) => {
+      release = () => resolve(null)
+    })
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async () => pending,
+    })
+
+    const inFlight = send(encodeRpcMessage(1, 'test', { __stream: 7 }))
+    await flush()
+
+    // no ClientStreamPull was ever sent: any push violates the credit
+    await send(encodeClientStreamPush(7, Buffer.from('overflow')))
+
+    const aborts = sentOfType(ServerMessageType.ClientStreamAbort)
+    expect(aborts.length).toBe(1)
+    expect(aborts[0].id).toBe(7)
+    expect(aborts[0].rest.toString()).toBe(STREAM_CREDIT_VIOLATION_REASON)
+    expect(gateway.blobStreams.clientStreams.size).toBe(0)
+
+    release()
+    await inFlight
+    await gateway.stop()
+  })
+})
+
+describe('Download stream flow control', () => {
+  it('sends pushes only against granted byte credits', async () => {
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async ({ container }) => {
+        const createBlob = await container.resolve(injectables.createBlob)
+        createBlob(Readable.from([Buffer.alloc(100, 0xcd)]), {
+          type: 'application/octet-stream',
+          size: 100,
+        })
+        return { ok: true }
+      },
+    })
+
+    await send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+
+    expect(sentOfType(ServerMessageType.RpcResponse).length).toBe(1)
+    // slow consumer: nothing in flight until the client grants credit
+    expect(sentOfType(ServerMessageType.ServerStreamPush).length).toBe(0)
+
+    await send(encodeServerStreamPull(0, 10))
+    await flush()
+
+    let pushes = sentOfType(ServerMessageType.ServerStreamPush)
+    expect(pushes.length).toBe(1)
+    expect(pushes[0].rest.byteLength).toBe(10)
+
+    await send(encodeServerStreamPull(0, 90))
+    await flush()
+
+    pushes = sentOfType(ServerMessageType.ServerStreamPush)
+    expect(Buffer.concat(pushes.map((p) => p.rest)).byteLength).toBe(100)
+    expect(sentOfType(ServerMessageType.ServerStreamEnd).length).toBe(1)
+    expect(gateway.blobStreams.serverStreams.size).toBe(0)
+
+    await gateway.stop()
+  })
+})

--- a/packages/gateway/tests/stream-flow.spec.ts
+++ b/packages/gateway/tests/stream-flow.spec.ts
@@ -372,7 +372,7 @@ describe('RPC stream flow control', () => {
     await gateway.stop()
   })
 
-  it('terminates a handler stalled inside next() via the idle timeout', async () => {
+  it('does not reap a stalled producer holding outstanding credit', async () => {
     let finished = false
     let releaseStall!: () => void
     const stall = new Promise<void>((resolve) => {
@@ -400,14 +400,47 @@ describe('RPC stream flow control', () => {
     await flush()
     expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(1)
 
+    // sparse producers (e.g. subscription streams) may be silent far longer
+    // than the idle timeout; the client is waiting, so nothing is reaped
     await sleep(120)
-
-    const aborts = sentOfType(ServerMessageType.RpcStreamAbort)
-    expect(aborts.length).toBe(1)
-    expect(aborts[0].rest.toString()).toBe(STREAM_IDLE_TIMEOUT_REASON)
+    expect(sentOfType(ServerMessageType.RpcStreamAbort).length).toBe(0)
+    expect(finished).toBe(false)
 
     releaseStall()
     await inFlight
+    expect(finished).toBe(true)
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(2)
+    expect(sentOfType(ServerMessageType.RpcStreamEnd).length).toBe(1)
+    expect(sentOfType(ServerMessageType.RpcStreamAbort).length).toBe(0)
+
+    await gateway.stop()
+  })
+
+  it('still reaps a consumer that stops pulling mid-stream', async () => {
+    let finished = false
+    async function* handler() {
+      try {
+        while (true) yield 'tick'
+      } finally {
+        finished = true
+      }
+    }
+
+    const { gateway, sentOfType, send } = await createTestGateway({
+      call: async () => () => handler(),
+      streamIdleTimeout: 50,
+    })
+
+    const inFlight = send(encodeRpcMessage(1, 'test', {}))
+    await flush()
+    // consume one chunk, then go silent
+    await send(encodeRpcStreamPull(1, 1))
+    await inFlight
+
+    expect(sentOfType(ServerMessageType.RpcStreamChunk).length).toBe(1)
+    const aborts = sentOfType(ServerMessageType.RpcStreamAbort)
+    expect(aborts.length).toBe(1)
+    expect(aborts[0].rest.toString()).toBe(STREAM_IDLE_TIMEOUT_REASON)
     expect(finished).toBe(true)
 
     await gateway.stop()

--- a/packages/gateway/tests/stream-flow.spec.ts
+++ b/packages/gateway/tests/stream-flow.spec.ts
@@ -229,7 +229,7 @@ describe('RPC stream flow control', () => {
       }
     }
 
-    const { gateway, sentOfType, send } = await createTestGateway({
+    const { gateway, sentOfType, send, connection } = await createTestGateway({
       call: async () => () => handler(),
     })
 
@@ -244,7 +244,7 @@ describe('RPC stream flow control', () => {
 
     expect(finished).toBe(true)
     expect(sentOfType(ServerMessageType.RpcStreamAbort).length).toBe(1)
-    expect(gateway.rpcs.get('any', 1)).toBeUndefined()
+    expect(gateway.rpcs.get(connection.id, 1)).toBeUndefined()
 
     await gateway.stop()
   })

--- a/packages/gateway/tests/streams.spec.ts
+++ b/packages/gateway/tests/streams.spec.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   BlobStreamsManager,
+  STREAM_CREDIT_VIOLATION_REASON,
   STREAM_IDLE_TIMEOUT_REASON,
   STREAM_TRANSPORT_DROP_REASON,
 } from '../src/streams.ts'
@@ -273,6 +274,41 @@ describe('BlobStreamsManager', () => {
       it('should do nothing for non-existent stream', () => {
         expect(() => manager.abortClientStream('conn-1', 999)).not.toThrow()
       })
+
+      it('notifies the peer at most once, with the abort reason', () => {
+        const notify = vi.fn()
+        manager.createClientStream(
+          'conn-1',
+          1,
+          100,
+          { type: 'text/plain' },
+          {},
+          notify,
+        )
+
+        manager.abortClientStream('conn-1', 100, STREAM_CREDIT_VIOLATION_REASON)
+        manager.abortClientStream('conn-1', 100, 'again')
+
+        expect(notify).toHaveBeenCalledTimes(1)
+        expect(notify).toHaveBeenCalledWith(STREAM_CREDIT_VIOLATION_REASON)
+      })
+
+      it('does not echo peer-originated aborts back', () => {
+        const notify = vi.fn()
+        manager.createClientStream(
+          'conn-1',
+          1,
+          100,
+          { type: 'text/plain' },
+          {},
+          notify,
+        )
+
+        manager.abortClientStream('conn-1', 100, 'client cancelled', false)
+
+        expect(notify).not.toHaveBeenCalled()
+        expect(manager.clientStreams.size).toBe(0)
+      })
     })
 
     describe('consumeClientStream / getClientCallStreamIds', () => {
@@ -537,7 +573,7 @@ describe('BlobStreamsManager', () => {
     })
 
     describe('source errors', () => {
-      it('propagates a source error through the sink', async () => {
+      it('propagates a source error through the sink once granted', async () => {
         const test = createTestSink()
         const source = new Readable({ read() {} })
         manager.createServerStream(
@@ -548,11 +584,66 @@ describe('BlobStreamsManager', () => {
           test.sink,
         )
 
+        manager.pullServerStream('conn-1', 100, 10)
         source.destroy(new Error('source blew up'))
         await flush()
 
         expect(test.sink.error).toHaveBeenCalledWith(
           expect.objectContaining({ message: 'source blew up' }),
+        )
+        expect(manager.serverStreams.size).toBe(0)
+      })
+
+      it('holds a pre-grant source error until the first grant', async () => {
+        const test = createTestSink()
+        const source = new Readable({ read() {} })
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          new ProtocolBlob({ source, type: 'text/plain' }),
+          test.sink,
+        )
+
+        // source blows up before any grant: the abort frame must not be able
+        // to overtake the RpcResponse referencing this stream
+        source.destroy(new Error('early failure'))
+        await flush()
+        await flush()
+
+        expect(test.sink.error).not.toHaveBeenCalled()
+        // the stream stays registered so the client's pull still lands
+        expect(manager.serverStreams.size).toBe(1)
+
+        manager.pullServerStream('conn-1', 100, 10)
+        await flush()
+
+        expect(test.sink.error).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'early failure' }),
+        )
+        expect(manager.serverStreams.size).toBe(0)
+      })
+    })
+
+    describe('credit overflow', () => {
+      it('aborts the stream when grants exceed the credit cap', () => {
+        const test = createTestSink()
+        const source = new Readable({ read() {} })
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          new ProtocolBlob({ source, type: 'text/plain' }),
+          test.sink,
+        )
+
+        manager.pullServerStream('conn-1', 100, 2 ** 32 - 1)
+        expect(test.sink.error).not.toHaveBeenCalled()
+
+        manager.pullServerStream('conn-1', 100, 1)
+
+        expect(test.sink.error).toHaveBeenCalledWith(
+          expect.objectContaining({ message: STREAM_CREDIT_VIOLATION_REASON }),
         )
         expect(manager.serverStreams.size).toBe(0)
       })
@@ -766,14 +857,12 @@ describe('BlobStreamsManager', () => {
 
         manager.cleanupConnection('conn-1')
 
-        expect(test1.sink.error).toHaveBeenCalledWith(
-          expect.objectContaining({ message: 'Connection closed' }),
-        )
-        expect(test2.sink.error).toHaveBeenCalledWith(
-          expect.objectContaining({ message: 'Connection closed' }),
-        )
+        // teardown must not fire peer notifications into a dying transport
+        expect(test1.sink.error).not.toHaveBeenCalled()
+        expect(test2.sink.error).not.toHaveBeenCalled()
         expect(test3.sink.error).not.toHaveBeenCalled()
         expect(manager.serverStreams.size).toBe(1)
+        expect(manager.serverStreams.keys().next().value).toBe('conn-2:100')
       })
 
       it('should handle mixed client and server streams', () => {
@@ -798,7 +887,8 @@ describe('BlobStreamsManager', () => {
         manager.cleanupConnection('conn-1')
 
         expect(destroyClient).toHaveBeenCalled()
-        expect(test.sink.error).toHaveBeenCalled()
+        expect(manager.serverStreams.size).toBe(0)
+        expect(manager.clientStreams.size).toBe(0)
       })
 
       it('should do nothing for non-existent connection', () => {

--- a/packages/gateway/tests/streams.spec.ts
+++ b/packages/gateway/tests/streams.spec.ts
@@ -1,46 +1,79 @@
 import { Readable } from 'node:stream'
 
+import type { Mock } from 'vitest'
 import { ProtocolBlob } from '@nmtjs/protocol'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { StreamTimeout } from '../src/enums.ts'
-import { BlobStreamsManager } from '../src/streams.ts'
+import {
+  BlobStreamsManager,
+  STREAM_IDLE_TIMEOUT_REASON,
+  STREAM_TRANSPORT_DROP_REASON,
+} from '../src/streams.ts'
 
-const TEST_TIMEOUTS = {
-  [StreamTimeout.Pull]: 5000,
-  [StreamTimeout.Consume]: 5000,
-  [StreamTimeout.Finish]: 10000,
+const IDLE_TIMEOUT = 5000
+
+// stream data flows on nextTick ('readable' emission), which fake timers do
+// not intercept
+const flush = () => new Promise<void>((resolve) => process.nextTick(resolve))
+
+type TestSink = {
+  chunks: Buffer[]
+  ended: boolean
+  errors: Error[]
+  sendResult: boolean
+  sink: {
+    chunk: Mock<(chunk: Buffer) => boolean>
+    end: Mock<() => void>
+    error: Mock<(error: Error) => void>
+  }
 }
+
+const createTestSink = (): TestSink => {
+  const state: TestSink = {
+    chunks: [],
+    ended: false,
+    errors: [],
+    sendResult: true,
+    sink: {
+      chunk: vi.fn((chunk: Buffer): boolean => {
+        state.chunks.push(Buffer.from(chunk))
+        return state.sendResult
+      }),
+      end: vi.fn((): void => {
+        state.ended = true
+      }),
+      error: vi.fn((error: Error): void => {
+        state.errors.push(error)
+      }),
+    },
+  }
+  return state
+}
+
+const blobFromBytes = (bytes: Buffer | null) =>
+  new ProtocolBlob({
+    source: new Readable({
+      read() {
+        if (bytes) this.push(bytes)
+        this.push(null)
+      },
+    }),
+    type: 'application/octet-stream',
+    size: bytes?.byteLength,
+  })
+
+const receivedBytes = (sink: TestSink) => Buffer.concat(sink.chunks).byteLength
 
 describe('BlobStreamsManager', () => {
   let manager: BlobStreamsManager
 
   beforeEach(() => {
     vi.useFakeTimers()
-    manager = new BlobStreamsManager({ timeouts: TEST_TIMEOUTS })
+    manager = new BlobStreamsManager({ idleTimeout: IDLE_TIMEOUT })
   })
 
   afterEach(() => {
     vi.useRealTimers()
-  })
-
-  describe('constructor', () => {
-    it('should use default timeout durations', () => {
-      const mgr = new BlobStreamsManager({ timeouts: TEST_TIMEOUTS })
-      // We can't directly check private fields, but we can verify behavior
-      expect(mgr).toBeInstanceOf(BlobStreamsManager)
-    })
-
-    it('should accept custom timeout durations', () => {
-      const mgr = new BlobStreamsManager({
-        timeouts: {
-          [StreamTimeout.Pull]: 1000,
-          [StreamTimeout.Consume]: 2000,
-          [StreamTimeout.Finish]: 3000,
-        },
-      })
-      expect(mgr).toBeInstanceOf(BlobStreamsManager)
-    })
   })
 
   describe('Client Streams (Upload)', () => {
@@ -81,29 +114,10 @@ describe('BlobStreamsManager', () => {
         expect(stream1.id).toBe(100)
         expect(stream2.id).toBe(101)
       })
-
-      it('should start consume timeout on creation', () => {
-        const stream = manager.createClientStream(
-          'conn-1',
-          1,
-          100,
-          { type: 'text/plain' },
-          {},
-        )
-
-        const destroySpy = vi.spyOn(stream, 'destroy')
-
-        // Default consume timeout is 5000ms
-        vi.advanceTimersByTime(5000)
-
-        expect(destroySpy).toHaveBeenCalledWith(
-          expect.objectContaining({ message: 'Consume timeout' }),
-        )
-      })
     })
 
-    describe('pushToClientStream', () => {
-      it('should write chunk to stream', () => {
+    describe('credit accounting', () => {
+      it('accepts a push within the outstanding grant and writes it', () => {
         const stream = manager.createClientStream(
           'conn-1',
           1,
@@ -111,16 +125,17 @@ describe('BlobStreamsManager', () => {
           { type: 'text/plain' },
           {},
         )
-
         const writeSpy = vi.spyOn(stream, 'write')
+
+        manager.grantClientStream('conn-1', 100, 10)
         const chunk = new Uint8Array([1, 2, 3])
+        const accepted = manager.pushToClientStream('conn-1', 100, chunk)
 
-        manager.pushToClientStream('conn-1', 100, chunk)
-
+        expect(accepted).toBe(true)
         expect(writeSpy).toHaveBeenCalledWith(chunk)
       })
 
-      it('should reset consume timeout and start pull timeout', () => {
+      it('rejects a push with no outstanding grant', () => {
         const stream = manager.createClientStream(
           'conn-1',
           1,
@@ -128,28 +143,55 @@ describe('BlobStreamsManager', () => {
           { type: 'text/plain' },
           {},
         )
+        const writeSpy = vi.spyOn(stream, 'write')
 
-        const destroySpy = vi.spyOn(stream, 'destroy')
-
-        // Push data after 3000ms (before consume timeout)
-        vi.advanceTimersByTime(3000)
-        manager.pushToClientStream('conn-1', 100, new Uint8Array([1]))
-
-        // Wait 3000ms more (would have been 6000ms total, past consume timeout)
-        vi.advanceTimersByTime(3000)
-        expect(destroySpy).not.toHaveBeenCalled()
-
-        // Pull timeout should fire at 5000ms after last push
-        vi.advanceTimersByTime(2000)
-        expect(destroySpy).toHaveBeenCalledWith(
-          expect.objectContaining({ message: 'Pull timeout' }),
+        const accepted = manager.pushToClientStream(
+          'conn-1',
+          100,
+          new Uint8Array([1]),
         )
+
+        expect(accepted).toBe(false)
+        expect(writeSpy).not.toHaveBeenCalled()
       })
 
-      it('should do nothing for non-existent stream', () => {
-        expect(() =>
+      it('rejects a push exceeding the remaining grant', () => {
+        manager.createClientStream('conn-1', 1, 100, { type: 'text/plain' }, {})
+
+        manager.grantClientStream('conn-1', 100, 4)
+        expect(
+          manager.pushToClientStream('conn-1', 100, new Uint8Array(3)),
+        ).toBe(true)
+        // 1 byte of credit left
+        expect(
+          manager.pushToClientStream('conn-1', 100, new Uint8Array(2)),
+        ).toBe(false)
+        expect(
+          manager.pushToClientStream('conn-1', 100, new Uint8Array(1)),
+        ).toBe(true)
+      })
+
+      it('keeps leftover credit valid across grants', () => {
+        manager.createClientStream('conn-1', 1, 100, { type: 'text/plain' }, {})
+
+        manager.grantClientStream('conn-1', 100, 10)
+        expect(
+          manager.pushToClientStream('conn-1', 100, new Uint8Array(4)),
+        ).toBe(true)
+        manager.grantClientStream('conn-1', 100, 10)
+        // 6 + 10 outstanding
+        expect(
+          manager.pushToClientStream('conn-1', 100, new Uint8Array(16)),
+        ).toBe(true)
+        expect(
+          manager.pushToClientStream('conn-1', 100, new Uint8Array(1)),
+        ).toBe(false)
+      })
+
+      it('ignores pushes for non-existent streams', () => {
+        expect(
           manager.pushToClientStream('conn-1', 999, new Uint8Array([1])),
-        ).not.toThrow()
+        ).toBe(true)
       })
     })
 
@@ -170,18 +212,7 @@ describe('BlobStreamsManager', () => {
         expect(endSpy).toHaveBeenCalledWith(null)
       })
 
-      it('should remove the stream', () => {
-        manager.createClientStream('conn-1', 1, 100, { type: 'text/plain' }, {})
-
-        manager.endClientStream('conn-1', 100)
-
-        // Verify by trying to push (should be no-op)
-        expect(() =>
-          manager.pushToClientStream('conn-1', 100, new Uint8Array([1])),
-        ).not.toThrow()
-      })
-
-      it('should clear timeouts', () => {
+      it('should remove the stream and clear the idle timer', () => {
         const stream = manager.createClientStream(
           'conn-1',
           1,
@@ -189,14 +220,11 @@ describe('BlobStreamsManager', () => {
           { type: 'text/plain' },
           {},
         )
-
         const destroySpy = vi.spyOn(stream, 'destroy')
 
         manager.endClientStream('conn-1', 100)
 
-        // Advance past all timeouts
-        vi.advanceTimersByTime(15000)
-
+        vi.advanceTimersByTime(IDLE_TIMEOUT * 3)
         expect(destroySpy).not.toHaveBeenCalled()
       })
 
@@ -247,18 +275,7 @@ describe('BlobStreamsManager', () => {
       })
     })
 
-    describe('consumeClientStream', () => {
-      it('should untrack stream from call', () => {
-        manager.createClientStream('conn-1', 1, 100, { type: 'text/plain' }, {})
-
-        // Consuming should not throw
-        expect(() =>
-          manager.consumeClientStream('conn-1', 1, 100),
-        ).not.toThrow()
-      })
-    })
-
-    describe('getClientCallStreamIds', () => {
+    describe('consumeClientStream / getClientCallStreamIds', () => {
       it('should return only still-unconsumed stream ids for a call', () => {
         manager.createClientStream('conn-1', 1, 100, { type: 'text/plain' }, {})
         manager.createClientStream('conn-1', 1, 101, { type: 'text/plain' }, {})
@@ -271,116 +288,245 @@ describe('BlobStreamsManager', () => {
         expect(manager.getClientCallStreamIds('conn-1', 999)).toEqual([])
       })
     })
+
+    describe('idle timeout', () => {
+      it('aborts a stream with no activity', () => {
+        const stream = manager.createClientStream(
+          'conn-1',
+          1,
+          100,
+          { type: 'text/plain' },
+          {},
+        )
+        const destroySpy = vi.spyOn(stream, 'destroy')
+
+        vi.advanceTimersByTime(IDLE_TIMEOUT)
+
+        expect(destroySpy).toHaveBeenCalledWith(
+          expect.objectContaining({ message: STREAM_IDLE_TIMEOUT_REASON }),
+        )
+      })
+
+      it('resets on grants and pushes', () => {
+        const stream = manager.createClientStream(
+          'conn-1',
+          1,
+          100,
+          { type: 'text/plain' },
+          {},
+        )
+        const destroySpy = vi.spyOn(stream, 'destroy')
+
+        // grant (outgoing activity) resets the timer
+        vi.advanceTimersByTime(IDLE_TIMEOUT - 1000)
+        manager.grantClientStream('conn-1', 100, 100)
+        vi.advanceTimersByTime(IDLE_TIMEOUT - 1000)
+        expect(destroySpy).not.toHaveBeenCalled()
+
+        // push (incoming activity) resets the timer
+        manager.pushToClientStream('conn-1', 100, new Uint8Array(1))
+        vi.advanceTimersByTime(IDLE_TIMEOUT - 1000)
+        expect(destroySpy).not.toHaveBeenCalled()
+
+        // true inactivity finally aborts
+        vi.advanceTimersByTime(1000)
+        expect(destroySpy).toHaveBeenCalledWith(
+          expect.objectContaining({ message: STREAM_IDLE_TIMEOUT_REASON }),
+        )
+      })
+    })
   })
 
   describe('Server Streams (Download)', () => {
-    const createMockBlob = () => {
-      const readable = new Readable({
-        read() {
-          this.push(Buffer.from('test data'))
-          this.push(null)
-        },
-      })
-      return new ProtocolBlob({ source: readable, size: 9, type: 'text/plain' })
-    }
-
     describe('createServerStream', () => {
       it('should create a server stream', () => {
-        const blob = createMockBlob()
-        const stream = manager.createServerStream('conn-1', 1, 100, blob)
+        const { sink } = createTestSink()
+        const stream = manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          blobFromBytes(Buffer.from('test data')),
+          sink,
+        )
 
         expect(stream).toBeDefined()
         expect(stream.id).toBe(100)
         expect(stream.metadata).toEqual({
           size: 9,
-          type: 'text/plain',
+          type: 'application/octet-stream',
           filename: undefined,
         })
       })
 
-      it('should start paused', () => {
-        const blob = createMockBlob()
-        const stream = manager.createServerStream('conn-1', 1, 100, blob)
-
-        expect(stream.isPaused()).toBe(true)
-      })
-
-      it('should start consume and finish timeouts', () => {
-        const blob = createMockBlob()
-        const stream = manager.createServerStream('conn-1', 1, 100, blob)
-
-        const destroySpy = vi.spyOn(stream, 'destroy')
-
-        // Consume timeout is 5000ms
-        vi.advanceTimersByTime(5000)
-
-        expect(destroySpy).toHaveBeenCalledWith(
-          expect.objectContaining({ message: 'Consume timeout' }),
+      it('emits nothing before the first grant, even for an ended source', async () => {
+        const test = createTestSink()
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          blobFromBytes(Buffer.from('test data')),
+          test.sink,
         )
+
+        await flush()
+        await flush()
+
+        expect(test.sink.chunk).not.toHaveBeenCalled()
+        expect(test.sink.end).not.toHaveBeenCalled()
+        expect(test.sink.error).not.toHaveBeenCalled()
       })
     })
 
-    describe('pullServerStream', () => {
-      it('should resume the stream', () => {
-        const blob = createMockBlob()
-        const stream = manager.createServerStream('conn-1', 1, 100, blob)
+    describe('pullServerStream (credits)', () => {
+      it('delivers exactly the granted bytes and slices larger chunks', async () => {
+        const test = createTestSink()
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          blobFromBytes(Buffer.alloc(100, 0xab)),
+          test.sink,
+        )
 
-        const resumeSpy = vi.spyOn(stream, 'resume')
+        manager.pullServerStream('conn-1', 100, 10)
+        await flush()
+        await flush()
 
-        manager.pullServerStream('conn-1', 100)
+        expect(receivedBytes(test)).toBe(10)
+        expect(test.sink.end).not.toHaveBeenCalled()
 
-        expect(resumeSpy).toHaveBeenCalled()
+        // remainder flows after the next grant
+        manager.pullServerStream('conn-1', 100, 90)
+        await flush()
+        await flush()
+
+        expect(receivedBytes(test)).toBe(100)
+        expect(Buffer.concat(test.chunks)).toEqual(Buffer.alloc(100, 0xab))
+        expect(test.sink.end).toHaveBeenCalledTimes(1)
       })
 
-      it('should reset consume timeout and start pull timeout', () => {
-        const blob = createMockBlob()
-        const stream = manager.createServerStream('conn-1', 1, 100, blob)
-
-        const destroySpy = vi.spyOn(stream, 'destroy')
-
-        // Pull after 3000ms
-        vi.advanceTimersByTime(3000)
-        manager.pullServerStream('conn-1', 100)
-
-        // Wait 3000ms more
-        vi.advanceTimersByTime(3000)
-        expect(destroySpy).not.toHaveBeenCalled()
-
-        // Pull timeout fires at 5000ms after pull
-        vi.advanceTimersByTime(2000)
-        expect(destroySpy).toHaveBeenCalledWith(
-          expect.objectContaining({ message: 'Pull timeout' }),
+      it('accumulates credits from multiple grants', async () => {
+        const test = createTestSink()
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          blobFromBytes(Buffer.alloc(30)),
+          test.sink,
         )
+
+        manager.pullServerStream('conn-1', 100, 5)
+        manager.pullServerStream('conn-1', 100, 5)
+        await flush()
+        await flush()
+
+        expect(receivedBytes(test)).toBe(10)
+      })
+
+      it('completes the stream and cleans up when the source ends', async () => {
+        const test = createTestSink()
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          blobFromBytes(Buffer.from('abc')),
+          test.sink,
+        )
+
+        manager.pullServerStream('conn-1', 100, 100)
+        await flush()
+        await flush()
+
+        expect(Buffer.concat(test.chunks).toString()).toBe('abc')
+        expect(test.sink.end).toHaveBeenCalledTimes(1)
+        expect(manager.serverStreams.size).toBe(0)
+        // idle timer is gone: nothing left to abort
+        expect(() => vi.advanceTimersByTime(IDLE_TIMEOUT * 3)).not.toThrow()
+        expect(test.sink.error).not.toHaveBeenCalled()
+      })
+
+      it('completes an empty source after the first grant', async () => {
+        const test = createTestSink()
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          blobFromBytes(null),
+          test.sink,
+        )
+
+        await flush()
+        expect(test.sink.end).not.toHaveBeenCalled()
+
+        manager.pullServerStream('conn-1', 100, 10)
+        await flush()
+
+        expect(test.sink.chunk).not.toHaveBeenCalled()
+        expect(test.sink.end).toHaveBeenCalledTimes(1)
       })
 
       it('should do nothing for non-existent stream', () => {
-        expect(() => manager.pullServerStream('conn-1', 999)).not.toThrow()
+        expect(() => manager.pullServerStream('conn-1', 999, 10)).not.toThrow()
+      })
+    })
+
+    describe('transport drop', () => {
+      it('aborts the stream and cleans up local state on a dropped frame', async () => {
+        const test = createTestSink()
+        test.sendResult = false
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          blobFromBytes(Buffer.alloc(50)),
+          test.sink,
+        )
+
+        manager.pullServerStream('conn-1', 100, 50)
+        await flush()
+        await flush()
+
+        expect(test.sink.chunk).toHaveBeenCalledTimes(1)
+        expect(test.sink.error).toHaveBeenCalledWith(
+          expect.objectContaining({ message: STREAM_TRANSPORT_DROP_REASON }),
+        )
+        expect(test.sink.end).not.toHaveBeenCalled()
+        expect(manager.serverStreams.size).toBe(0)
       })
     })
 
     describe('abortServerStream', () => {
-      it('should destroy stream with error', () => {
-        const blob = createMockBlob()
-        const stream = manager.createServerStream('conn-1', 1, 100, blob)
-
-        const destroySpy = vi.spyOn(stream, 'destroy')
+      it('reports the error through the sink and cleans up', () => {
+        const test = createTestSink()
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          blobFromBytes(Buffer.from('abc')),
+          test.sink,
+        )
 
         manager.abortServerStream('conn-1', 100, 'Custom error')
 
-        expect(destroySpy).toHaveBeenCalledWith(
+        expect(test.sink.error).toHaveBeenCalledWith(
           expect.objectContaining({ message: 'Custom error' }),
         )
+        expect(manager.serverStreams.size).toBe(0)
       })
 
       it('should use default error message', () => {
-        const blob = createMockBlob()
-        const stream = manager.createServerStream('conn-1', 1, 100, blob)
-
-        const destroySpy = vi.spyOn(stream, 'destroy')
+        const test = createTestSink()
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          blobFromBytes(Buffer.from('abc')),
+          test.sink,
+        )
 
         manager.abortServerStream('conn-1', 100)
 
-        expect(destroySpy).toHaveBeenCalledWith(
+        expect(test.sink.error).toHaveBeenCalledWith(
           expect.objectContaining({ message: 'Aborted' }),
         )
       })
@@ -390,24 +536,99 @@ describe('BlobStreamsManager', () => {
       })
     })
 
-    describe('finish timeout', () => {
-      it('should abort stream after finish timeout', () => {
-        const blob = createMockBlob()
-        const stream = manager.createServerStream('conn-1', 1, 100, blob)
-
-        const destroySpy = vi.spyOn(stream, 'destroy')
-
-        // Keep pulling to avoid consume/pull timeouts
-        for (let i = 0; i < 5; i++) {
-          vi.advanceTimersByTime(2000)
-          manager.pullServerStream('conn-1', 100)
-        }
-
-        // Finish timeout is 10000ms from creation
-        // We've advanced 10000ms, so it should fire
-        expect(destroySpy).toHaveBeenCalledWith(
-          expect.objectContaining({ message: 'Finish timeout' }),
+    describe('source errors', () => {
+      it('propagates a source error through the sink', async () => {
+        const test = createTestSink()
+        const source = new Readable({ read() {} })
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          new ProtocolBlob({ source, type: 'text/plain' }),
+          test.sink,
         )
+
+        source.destroy(new Error('source blew up'))
+        await flush()
+
+        expect(test.sink.error).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'source blew up' }),
+        )
+        expect(manager.serverStreams.size).toBe(0)
+      })
+    })
+
+    describe('idle timeout', () => {
+      it('aborts a stream that is never pulled', () => {
+        const test = createTestSink()
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          blobFromBytes(Buffer.from('abc')),
+          test.sink,
+        )
+
+        vi.advanceTimersByTime(IDLE_TIMEOUT)
+
+        expect(test.sink.error).toHaveBeenCalledWith(
+          expect.objectContaining({ message: STREAM_IDLE_TIMEOUT_REASON }),
+        )
+        expect(manager.serverStreams.size).toBe(0)
+      })
+
+      it('resets on pulls and on chunks sent', async () => {
+        const test = createTestSink()
+        // manual source: data appears long after the grant
+        const source = new Readable({ read() {} })
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          new ProtocolBlob({ source, type: 'text/plain' }),
+          test.sink,
+        )
+
+        // pull (incoming activity) resets the timer
+        vi.advanceTimersByTime(IDLE_TIMEOUT - 1000)
+        manager.pullServerStream('conn-1', 100, 1000)
+        vi.advanceTimersByTime(IDLE_TIMEOUT - 1000)
+        expect(test.sink.error).not.toHaveBeenCalled()
+
+        // chunk sent (outgoing activity) resets the timer
+        source.push(Buffer.from('x'))
+        await flush()
+        expect(test.sink.chunk).toHaveBeenCalledTimes(1)
+        vi.advanceTimersByTime(IDLE_TIMEOUT - 1000)
+        expect(test.sink.error).not.toHaveBeenCalled()
+
+        // true inactivity finally aborts
+        vi.advanceTimersByTime(1000)
+        expect(test.sink.error).toHaveBeenCalledWith(
+          expect.objectContaining({ message: STREAM_IDLE_TIMEOUT_REASON }),
+        )
+      })
+    })
+
+    describe('getServerStreamsMetadata', () => {
+      it('returns metadata for the call streams', () => {
+        const test = createTestSink()
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          blobFromBytes(Buffer.from('abc')),
+          test.sink,
+        )
+
+        expect(manager.getServerStreamsMetadata('conn-1', 1)).toEqual({
+          100: {
+            size: 3,
+            type: 'application/octet-stream',
+            filename: undefined,
+          },
+        })
+        expect(manager.getServerStreamsMetadata('conn-1', 2)).toEqual({})
       })
     })
   })
@@ -517,48 +738,42 @@ describe('BlobStreamsManager', () => {
       })
 
       it('should abort all server streams for connection', () => {
-        const blob1 = new ProtocolBlob({
-          source: new Readable({
-            read() {
-              this.push(null)
-            },
-          }),
-          type: 'text/plain',
-        })
-        const blob2 = new ProtocolBlob({
-          source: new Readable({
-            read() {
-              this.push(null)
-            },
-          }),
-          type: 'text/plain',
-        })
-        const blob3 = new ProtocolBlob({
-          source: new Readable({
-            read() {
-              this.push(null)
-            },
-          }),
-          type: 'text/plain',
-        })
+        const test1 = createTestSink()
+        const test2 = createTestSink()
+        const test3 = createTestSink()
 
-        const stream1 = manager.createServerStream('conn-1', 1, 100, blob1)
-        const stream2 = manager.createServerStream('conn-1', 2, 101, blob2)
-        const stream3 = manager.createServerStream('conn-2', 1, 100, blob3)
-
-        const destroy1 = vi.spyOn(stream1, 'destroy')
-        const destroy2 = vi.spyOn(stream2, 'destroy')
-        const destroy3 = vi.spyOn(stream3, 'destroy')
+        manager.createServerStream(
+          'conn-1',
+          1,
+          100,
+          blobFromBytes(null),
+          test1.sink,
+        )
+        manager.createServerStream(
+          'conn-1',
+          2,
+          101,
+          blobFromBytes(null),
+          test2.sink,
+        )
+        manager.createServerStream(
+          'conn-2',
+          1,
+          100,
+          blobFromBytes(null),
+          test3.sink,
+        )
 
         manager.cleanupConnection('conn-1')
 
-        expect(destroy1).toHaveBeenCalledWith(
+        expect(test1.sink.error).toHaveBeenCalledWith(
           expect.objectContaining({ message: 'Connection closed' }),
         )
-        expect(destroy2).toHaveBeenCalledWith(
+        expect(test2.sink.error).toHaveBeenCalledWith(
           expect.objectContaining({ message: 'Connection closed' }),
         )
-        expect(destroy3).not.toHaveBeenCalled()
+        expect(test3.sink.error).not.toHaveBeenCalled()
+        expect(manager.serverStreams.size).toBe(1)
       })
 
       it('should handle mixed client and server streams', () => {
@@ -569,23 +784,21 @@ describe('BlobStreamsManager', () => {
           { type: 'text/plain' },
           {},
         )
-        const blob = new ProtocolBlob({
-          source: new Readable({
-            read() {
-              this.push(null)
-            },
-          }),
-          type: 'text/plain',
-        })
-        const serverStream = manager.createServerStream('conn-1', 1, 101, blob)
+        const test = createTestSink()
+        manager.createServerStream(
+          'conn-1',
+          1,
+          101,
+          blobFromBytes(null),
+          test.sink,
+        )
 
         const destroyClient = vi.spyOn(clientStream, 'destroy')
-        const destroyServer = vi.spyOn(serverStream, 'destroy')
 
         manager.cleanupConnection('conn-1')
 
         expect(destroyClient).toHaveBeenCalled()
-        expect(destroyServer).toHaveBeenCalled()
+        expect(test.sink.error).toHaveBeenCalled()
       })
 
       it('should do nothing for non-existent connection', () => {
@@ -594,11 +807,9 @@ describe('BlobStreamsManager', () => {
     })
   })
 
-  describe('Custom Timeouts', () => {
-    it('should use custom pull timeout', () => {
-      const customManager = new BlobStreamsManager({
-        timeouts: { ...TEST_TIMEOUTS, [StreamTimeout.Pull]: 1000 },
-      })
+  describe('Custom idle timeout', () => {
+    it('uses the configured duration', () => {
+      const customManager = new BlobStreamsManager({ idleTimeout: 1000 })
 
       const stream = customManager.createClientStream(
         'conn-1',
@@ -610,63 +821,12 @@ describe('BlobStreamsManager', () => {
 
       const destroySpy = vi.spyOn(stream, 'destroy')
 
-      // Push to start pull timeout
-      customManager.pushToClientStream('conn-1', 100, new Uint8Array([1]))
+      vi.advanceTimersByTime(999)
+      expect(destroySpy).not.toHaveBeenCalled()
 
-      vi.advanceTimersByTime(1000)
-
+      vi.advanceTimersByTime(1)
       expect(destroySpy).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'Pull timeout' }),
-      )
-    })
-
-    it('should use custom consume timeout', () => {
-      const customManager = new BlobStreamsManager({
-        timeouts: { ...TEST_TIMEOUTS, [StreamTimeout.Consume]: 2000 },
-      })
-
-      const stream = customManager.createClientStream(
-        'conn-1',
-        1,
-        100,
-        { type: 'text/plain' },
-        {},
-      )
-
-      const destroySpy = vi.spyOn(stream, 'destroy')
-
-      vi.advanceTimersByTime(2000)
-
-      expect(destroySpy).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'Consume timeout' }),
-      )
-    })
-
-    it('should use custom finish timeout', () => {
-      const customManager = new BlobStreamsManager({
-        timeouts: {
-          [StreamTimeout.Finish]: 3000,
-          [StreamTimeout.Consume]: 10000, // Set high to avoid interference
-          [StreamTimeout.Pull]: 10000,
-        },
-      })
-
-      const blob = new ProtocolBlob({
-        source: new Readable({
-          read() {
-            this.push(null)
-          },
-        }),
-        type: 'text/plain',
-      })
-      const stream = customManager.createServerStream('conn-1', 1, 100, blob)
-
-      const destroySpy = vi.spyOn(stream, 'destroy')
-
-      vi.advanceTimersByTime(3000)
-
-      expect(destroySpy).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'Finish timeout' }),
+        expect.objectContaining({ message: STREAM_IDLE_TIMEOUT_REASON }),
       )
     })
   })

--- a/packages/gateway/tests/streams.spec.ts
+++ b/packages/gateway/tests/streams.spec.ts
@@ -189,6 +189,15 @@ describe('BlobStreamsManager', () => {
         ).toBe(false)
       })
 
+      it('rejects zero-byte pushes as violations', () => {
+        manager.createClientStream('conn-1', 1, 100, { type: 'text/plain' }, {})
+        manager.grantClientStream('conn-1', 100, 10)
+        // an empty push consumes no credit but would refresh the idle timer
+        expect(
+          manager.pushToClientStream('conn-1', 100, new Uint8Array(0)),
+        ).toBe(false)
+      })
+
       it('ignores pushes for non-existent streams', () => {
         expect(
           manager.pushToClientStream('conn-1', 999, new Uint8Array([1])),

--- a/packages/protocol/src/client/protocol.ts
+++ b/packages/protocol/src/client/protocol.ts
@@ -28,6 +28,7 @@ export type MessageContext = {
 export type ClientMessageTypePayload = {
   [ClientMessageType.Rpc]: { callId: number; procedure: string; payload: any }
   [ClientMessageType.RpcAbort]: { callId: number; reason?: string }
+  [ClientMessageType.RpcStreamPull]: { callId: number; size: number }
   [ClientMessageType.Ping]: { nonce: number }
   [ClientMessageType.Pong]: { nonce: number }
   [ClientMessageType.ClientStreamPush]: {

--- a/packages/protocol/src/client/stream.ts
+++ b/packages/protocol/src/client/stream.ts
@@ -65,9 +65,13 @@ export class ProtocolClientBlobStream
   }
 
   async abort(reason = 'Stream aborted') {
-    await this.#reader.cancel(reason)
-    this.#reader.releaseLock()
-    this.#sourceReader?.releaseLock()
+    try {
+      await this.#reader.cancel(reason)
+    } finally {
+      // a rejecting source cancel() must not leave the readers locked
+      this.#reader.releaseLock()
+      this.#sourceReader?.releaseLock()
+    }
   }
 
   async end() {

--- a/packages/protocol/src/client/versions/v1.ts
+++ b/packages/protocol/src/client/versions/v1.ts
@@ -152,6 +152,15 @@ export class ProtocolVersion1 extends ProtocolVersionInterface {
           reason ? encodeText(reason) : new Uint8Array(0),
         )
       }
+      case ClientMessageType.RpcStreamPull: {
+        const { callId, size } =
+          payload as ClientMessageTypePayload[ClientMessageType.RpcStreamPull]
+        return this.encode(
+          encodeNumber(messageType, 'Uint8'),
+          encodeNumber(callId, 'Uint32'),
+          encodeNumber(size, 'Uint32'),
+        )
+      }
       case ClientMessageType.Ping: {
         const { nonce } =
           payload as ClientMessageTypePayload[ClientMessageType.Ping]

--- a/packages/protocol/src/common/enums.ts
+++ b/packages/protocol/src/common/enums.ts
@@ -5,6 +5,7 @@ export enum ProtocolVersion {
 export enum ClientMessageType {
   Rpc = 10,
   RpcAbort = 11,
+  RpcStreamPull = 12,
 
   Ping = 13,
   Pong = 14,

--- a/packages/protocol/src/server/protocol.ts
+++ b/packages/protocol/src/server/protocol.ts
@@ -90,6 +90,7 @@ export type ClientMessageTypePayload = {
     }
   }
   [ClientMessageType.RpcAbort]: { callId: number; reason?: string }
+  [ClientMessageType.RpcStreamPull]: { callId: number; size: number }
   [ClientMessageType.Ping]: { nonce: number }
   [ClientMessageType.Pong]: { nonce: number }
   [ClientMessageType.ClientStreamPush]: {

--- a/packages/protocol/src/server/stream.ts
+++ b/packages/protocol/src/server/stream.ts
@@ -158,6 +158,13 @@ export class ProtocolServerStream {
         this.#buffered = null
 
         if (chunk === null) {
+          // never advance the producer without credit to spend its output on;
+          // an ended-and-drained source may still signal End (frees no data)
+          if (this.#credits <= 0) {
+            if (this.#sourceEnded && this.#source.readableLength === 0)
+              this.#end()
+            return
+          }
           const read = this.#source.read()
           if (read === null) {
             // source drained: either truly finished or waiting for 'readable'

--- a/packages/protocol/src/server/stream.ts
+++ b/packages/protocol/src/server/stream.ts
@@ -2,7 +2,17 @@ import type { ReadableOptions } from 'node:stream'
 import { PassThrough, Readable } from 'node:stream'
 import { ReadableStream } from 'node:stream/web'
 
+import { MAX_UINT32 } from '@nmtjs/common'
+
 import type { ProtocolBlob, ProtocolBlobMetadata } from '../common/blob.ts'
+
+/**
+ * Upper bound for outstanding stream credit. Far above any sane consumer's
+ * demand (our client pulls 64KB of bytes / 1 chunk per read) but low enough
+ * that additive grants can never reach unsafe-integer territory where
+ * decrements would silently stop working.
+ */
+export const MAX_STREAM_CREDITS = MAX_UINT32
 
 export class ProtocolClientStream extends PassThrough {
   readonly #read?: ReadableOptions['read']
@@ -52,6 +62,9 @@ export class ProtocolServerStream {
   #granted = false
   // remainder of a source chunk larger than the credits available at the time
   #buffered: Buffer | null = null
+  // source error that arrived before the first grant: held back so the abort
+  // frame cannot precede the RpcResponse referencing this stream
+  #pendingError: Error | null = null
   #sourceEnded = false
   #finished = false
   // sink callbacks may re-enter (abort -> destroy) while the loop is running
@@ -79,6 +92,11 @@ export class ProtocolServerStream {
       this.#pump()
     })
     this.#source.on('error', (error) => {
+      if (!this.#granted && !this.#finished) {
+        this.#pendingError = error
+        this.#source.destroy?.()
+        return
+      }
       this.#fail(error)
     })
   }
@@ -87,12 +105,23 @@ export class ProtocolServerStream {
     return this.#credits
   }
 
-  grant(size: number): void {
-    if (this.#finished) return
-    if (size <= 0) return
+  /**
+   * Adds byte credits and kicks the pump. Returns `false` when the grant
+   * would overflow the credit cap — a protocol violation the owner must
+   * abort on.
+   */
+  grant(size: number): boolean {
+    if (this.#finished) return true
+    if (size <= 0) return true
+    if (this.#credits + size > MAX_STREAM_CREDITS) return false
     this.#granted = true
+    if (this.#pendingError) {
+      this.#fail(this.#pendingError)
+      return true
+    }
     this.#credits += size
     this.#pump()
+    return true
   }
 
   destroy(error?: Error | null): void {
@@ -109,6 +138,7 @@ export class ProtocolServerStream {
     if (this.#finished) return
     this.#finished = true
     this.#buffered = null
+    this.#pendingError = null
     this.#source.destroy?.(error)
     this.#sink.error(error)
   }

--- a/packages/protocol/src/server/stream.ts
+++ b/packages/protocol/src/server/stream.ts
@@ -25,13 +25,39 @@ export class ProtocolClientStream extends PassThrough {
   }
 }
 
-export class ProtocolServerStream extends PassThrough {
+export type ProtocolServerStreamSink = {
+  /**
+   * Delivery of one chunk; returning `false` signals the transport dropped
+   * the frame and the stream must be aborted by the owner.
+   */
+  chunk: (chunk: Buffer) => boolean | null | undefined | void
+  end: () => void
+  error: (error: Error) => void
+}
+
+/**
+ * Credit-driven pump for server->client blob downloads: the source is never
+ * piped/flowed; bytes are read and emitted to the sink only against credits
+ * granted by the consumer (`grant`), so in-flight data is bounded by what the
+ * peer explicitly asked for. Nothing (not even `end`) is emitted before the
+ * first grant, which preserves the RpcResponse-before-stream-frames ordering.
+ */
+export class ProtocolServerStream {
   public readonly id: number
   public readonly metadata: ProtocolBlobMetadata
   readonly #source: Readable
-  #piped = false
+  readonly #sink: ProtocolServerStreamSink
 
-  constructor(id: number, blob: ProtocolBlob) {
+  #credits = 0
+  #granted = false
+  // remainder of a source chunk larger than the credits available at the time
+  #buffered: Buffer | null = null
+  #sourceEnded = false
+  #finished = false
+  // sink callbacks may re-enter (abort -> destroy) while the loop is running
+  #pumping = false
+
+  constructor(id: number, blob: ProtocolBlob, sink: ProtocolServerStreamSink) {
     let readable: Readable
 
     if (blob.source instanceof Readable) {
@@ -42,31 +68,90 @@ export class ProtocolServerStream extends PassThrough {
       throw new Error('Invalid source type')
     }
 
-    super()
-
-    this.pause()
-    this.#source = readable
-    this.#source.on('error', (error) => {
-      this.destroy(error)
-    })
-
     this.id = id
     this.metadata = blob.metadata
+    this.#sink = sink
+    this.#source = readable
+
+    this.#source.on('readable', () => this.#pump())
+    this.#source.on('end', () => {
+      this.#sourceEnded = true
+      this.#pump()
+    })
+    this.#source.on('error', (error) => {
+      this.#fail(error)
+    })
   }
 
-  resume(): this {
-    if (!this.#piped) {
-      this.#piped = true
-      this.#source.pipe(this)
-    }
-    return super.resume()
+  get credits() {
+    return this.#credits
   }
 
-  destroy(error?: Error | null) {
-    if (!this.#piped) {
-      this.#piped = true
+  grant(size: number): void {
+    if (this.#finished) return
+    if (size <= 0) return
+    this.#granted = true
+    this.#credits += size
+    this.#pump()
+  }
+
+  destroy(error?: Error | null): void {
+    if (error) {
+      this.#fail(error)
+    } else {
+      this.#finished = true
+      this.#buffered = null
+      this.#source.destroy?.()
     }
-    this.#source.destroy?.(error ?? undefined)
-    return super.destroy(error ?? undefined)
+  }
+
+  #fail(error: Error): void {
+    if (this.#finished) return
+    this.#finished = true
+    this.#buffered = null
+    this.#source.destroy?.(error)
+    this.#sink.error(error)
+  }
+
+  #end(): void {
+    if (this.#finished) return
+    this.#finished = true
+    this.#sink.end()
+  }
+
+  #pump(): void {
+    if (this.#pumping || this.#finished || !this.#granted) return
+    this.#pumping = true
+    try {
+      while (!this.#finished) {
+        let chunk = this.#buffered
+        this.#buffered = null
+
+        if (chunk === null) {
+          const read = this.#source.read()
+          if (read === null) {
+            // source drained: either truly finished or waiting for 'readable'
+            if (this.#sourceEnded) this.#end()
+            return
+          }
+          chunk = Buffer.isBuffer(read) ? read : Buffer.from(read)
+        }
+
+        if (this.#credits <= 0) {
+          this.#buffered = chunk
+          return
+        }
+
+        if (chunk.byteLength > this.#credits) {
+          this.#buffered = chunk.subarray(this.#credits)
+          chunk = chunk.subarray(0, this.#credits)
+        }
+
+        this.#credits -= chunk.byteLength
+        this.#sink.chunk(chunk)
+      }
+    } finally {
+      this.#pumping = false
+    }
   }
 }

--- a/packages/protocol/src/server/versions/v1.ts
+++ b/packages/protocol/src/server/versions/v1.ts
@@ -54,6 +54,23 @@ export class ProtocolVersion1 extends ProtocolVersionInterface {
           reasonPayload.byteLength > 0 ? decodeText(reasonPayload) : undefined
         return { type: messageType, callId, reason }
       }
+      case ClientMessageType.RpcStreamPull: {
+        // readUInt32LE would silently succeed on an oversized frame; reject
+        // anything that isn't exactly callId+size so garbage can't smuggle in
+        if (
+          messagePayload.byteLength !==
+          MessageByteLength.CallId + MessageByteLength.ChunkSize
+        ) {
+          throw new Error(
+            `Malformed RpcStreamPull message: expected ${
+              MessageByteLength.CallId + MessageByteLength.ChunkSize
+            } bytes, got ${messagePayload.byteLength}`,
+          )
+        }
+        const callId = messagePayload.readUInt32LE(0)
+        const size = messagePayload.readUInt32LE(MessageByteLength.CallId)
+        return { type: messageType, callId, size }
+      }
       case ClientMessageType.Ping: {
         const nonce = messagePayload.readUInt32LE(0)
         return { type: messageType, nonce }

--- a/packages/protocol/tests/client/protocol-v1.spec.ts
+++ b/packages/protocol/tests/client/protocol-v1.spec.ts
@@ -318,6 +318,19 @@ describe('ProtocolVersion1 (client) - encodeMessage', () => {
     expect(buffer.readUInt32LE(1)).toBe(55)
   })
 
+  it('encodes RpcStreamPull', () => {
+    const buffer = toBuffer(
+      version.encodeMessage(context, ClientMessageType.RpcStreamPull, {
+        callId: 42,
+        size: 1,
+      }),
+    )
+    expect(buffer[0]).toBe(ClientMessageType.RpcStreamPull)
+    expect(buffer.byteLength).toBe(9)
+    expect(buffer.readUInt32LE(1)).toBe(42)
+    expect(buffer.readUInt32LE(5)).toBe(1)
+  })
+
   it('encodes client stream push/end/abort', () => {
     const pushBuffer = toBuffer(
       version.encodeMessage(context, ClientMessageType.ClientStreamPush, {

--- a/packages/protocol/tests/server/protocol-v1.spec.ts
+++ b/packages/protocol/tests/server/protocol-v1.spec.ts
@@ -20,8 +20,6 @@ const encodeUInt16 = (value: number) => {
   return buffer
 }
 
-const LEGACY_RPC_PULL_MESSAGE_TYPE = 12
-
 function createMockServerContext(version: ProtocolVersion1): MessageContext {
   return {
     connectionId: 'conn',
@@ -122,14 +120,37 @@ describe('ProtocolVersion1 - decodeMessage', () => {
     })
   })
 
-  it('throws on legacy RpcPull payload', () => {
+  it('decodes RpcStreamPull payload', () => {
     const buffer = Buffer.concat([
-      Buffer.from([LEGACY_RPC_PULL_MESSAGE_TYPE]),
+      Buffer.from([ClientMessageType.RpcStreamPull]),
       encodeUInt32(99),
+      encodeUInt32(5),
     ])
 
-    expect(() => version.decodeMessage(context, buffer)).toThrow(
-      /Unsupported message type/,
+    expect(version.decodeMessage(context, buffer)).toEqual({
+      type: ClientMessageType.RpcStreamPull,
+      callId: 99,
+      size: 5,
+    })
+  })
+
+  it('rejects RpcStreamPull frames with unexpected length', () => {
+    const truncated = Buffer.concat([
+      Buffer.from([ClientMessageType.RpcStreamPull]),
+      encodeUInt32(99),
+    ])
+    expect(() => version.decodeMessage(context, truncated)).toThrow(
+      /Malformed RpcStreamPull message/,
+    )
+
+    const oversized = Buffer.concat([
+      Buffer.from([ClientMessageType.RpcStreamPull]),
+      encodeUInt32(99),
+      encodeUInt32(5),
+      Buffer.from([0xff]),
+    ])
+    expect(() => version.decodeMessage(context, oversized)).toThrow(
+      /Malformed RpcStreamPull message/,
     )
   })
 

--- a/packages/ws-transport/package.json
+++ b/packages/ws-transport/package.json
@@ -55,8 +55,12 @@
     "@nmtjs/application": "workspace:*",
     "@nmtjs/client": "workspace:*",
     "@nmtjs/common": "workspace:*",
+    "@nmtjs/contract": "workspace:*",
     "@nmtjs/gateway": "workspace:*",
+    "@nmtjs/json-format": "workspace:*",
     "@nmtjs/protocol": "workspace:*",
+    "@nmtjs/type": "workspace:*",
+    "@nmtjs/ws-client": "workspace:*",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0"
   },
   "peerDependencies": {

--- a/packages/ws-transport/src/runtimes/node.ts
+++ b/packages/ws-transport/src/runtimes/node.ts
@@ -33,6 +33,10 @@ function adapterFactory(params: WsAdapterParams<'node'>): WsAdapterServer {
       // magnitude as outstanding stream credit; raise the ceiling so
       // abort-on-drop stays a safety net (user-provided options still win)
       maxBackpressure: 1024 * 1024,
+      // uWS defaults to 16KB and CLOSES the socket on larger frames — the
+      // gateway's own upload credit grants (16KiB) plus the 5-byte frame
+      // header already exceed that, killing every blob upload
+      maxPayloadLength: 1024 * 1024,
       ...params.runtime?.ws,
       ...adapter.websocket,
     })

--- a/packages/ws-transport/src/runtimes/node.ts
+++ b/packages/ws-transport/src/runtimes/node.ts
@@ -8,6 +8,7 @@ import type {
   WsAdapterParams,
   WsAdapterServer,
   WsTransportOptions,
+  WsTransportRuntimeNode,
 } from '../types.ts'
 import * as injectables from '../injectables.ts'
 import { createWSTransportWorker } from '../server.ts'
@@ -15,6 +16,34 @@ import { StatusResponse } from '../utils.ts'
 
 const statusResponse = StatusResponse()
 const statusResponseBuffer = await statusResponse.arrayBuffer()
+
+/**
+ * uWS defaults to 16KiB and CLOSES the socket on larger frames — the
+ * gateway's own upload credit grants (64KiB) plus the 5-byte frame header
+ * already exceed that, killing every blob upload. Inline WS payloads are
+ * capped here at 1 MiB by design: larger data should ride blob streams,
+ * which are chunked at credit size.
+ */
+export const DEFAULT_WS_MAX_PAYLOAD = 1024 * 1024
+/**
+ * uWS defaults to 64KiB and DROPS frames above it — the same order of
+ * magnitude as outstanding stream credit; a higher ceiling keeps
+ * abort-on-drop a safety net, not a common path.
+ */
+export const DEFAULT_WS_MAX_BACKPRESSURE = 1024 * 1024
+
+/**
+ * ?? per field instead of spread-defaults: an explicitly-undefined user
+ * value (e.g. from an optional env var) must not erase the framework
+ * defaults and resurrect uWS's frame-killing 16KiB/64KiB limits.
+ */
+export function resolveUwsWsOptions(ws?: WsTransportRuntimeNode['ws']) {
+  return {
+    ...ws,
+    maxPayloadLength: ws?.maxPayloadLength ?? DEFAULT_WS_MAX_PAYLOAD,
+    maxBackpressure: ws?.maxBackpressure ?? DEFAULT_WS_MAX_BACKPRESSURE,
+  }
+}
 
 function adapterFactory(params: WsAdapterParams<'node'>): WsAdapterServer {
   const adapter = createAdapter({ hooks: params.wsHooks })
@@ -29,15 +58,7 @@ function adapterFactory(params: WsAdapterParams<'node'>): WsAdapterServer {
 
   server
     .ws('/*', {
-      // uWS defaults to 64KB and DROPS frames above it — the same order of
-      // magnitude as outstanding stream credit; raise the ceiling so
-      // abort-on-drop stays a safety net (user-provided options still win)
-      maxBackpressure: 1024 * 1024,
-      // uWS defaults to 16KB and CLOSES the socket on larger frames — the
-      // gateway's own upload credit grants (16KiB) plus the 5-byte frame
-      // header already exceed that, killing every blob upload
-      maxPayloadLength: 1024 * 1024,
-      ...params.runtime?.ws,
+      ...resolveUwsWsOptions(params.runtime?.ws),
       ...adapter.websocket,
     })
     .get('/healthy', (res) => {

--- a/packages/ws-transport/src/runtimes/node.ts
+++ b/packages/ws-transport/src/runtimes/node.ts
@@ -28,7 +28,14 @@ function adapterFactory(params: WsAdapterParams<'node'>): WsAdapterServer {
     : App()
 
   server
-    .ws('/*', { ...params.runtime?.ws, ...adapter.websocket })
+    .ws('/*', {
+      // uWS defaults to 64KB and DROPS frames above it — the same order of
+      // magnitude as outstanding stream credit; raise the ceiling so
+      // abort-on-drop stays a safety net (user-provided options still win)
+      maxBackpressure: 1024 * 1024,
+      ...params.runtime?.ws,
+      ...adapter.websocket,
+    })
     .get('/healthy', (res) => {
       res.cork(() => {
         res

--- a/packages/ws-transport/src/types.ts
+++ b/packages/ws-transport/src/types.ts
@@ -66,6 +66,15 @@ export type WsTransportRuntimeBun = {
 }
 
 export type WsTransportRuntimeNode = {
+  /**
+   * Raw uWS websocket behavior overrides. Unless set, the transport applies
+   * its own defaults for `maxPayloadLength` and `maxBackpressure` (1 MiB
+   * each): inline WS payloads are capped at 1 MiB — larger data should ride
+   * blob streams, which are chunked at credit size — and the value is
+   * deliberately above the largest upload frame (64KiB credit grant plus the
+   * frame header), since uWS closes the socket on oversized frames and drops
+   * frames over the backpressure limit.
+   */
   ws?: Partial<
     Pick<
       import('uWebSockets.js').WebSocketBehavior<import('crossws').PeerContext>,

--- a/packages/ws-transport/tests/node-runtime-options.spec.ts
+++ b/packages/ws-transport/tests/node-runtime-options.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_WS_MAX_BACKPRESSURE,
+  DEFAULT_WS_MAX_PAYLOAD,
+  resolveUwsWsOptions,
+} from '../src/runtimes/node.ts'
+
+describe('resolveUwsWsOptions', () => {
+  it('applies both defaults when no runtime options are given', () => {
+    expect(resolveUwsWsOptions(undefined)).toEqual({
+      maxPayloadLength: DEFAULT_WS_MAX_PAYLOAD,
+      maxBackpressure: DEFAULT_WS_MAX_BACKPRESSURE,
+    })
+  })
+
+  it('applies both defaults when the fields are explicitly undefined', () => {
+    // e.g. populated from optional env vars — must not erase the framework
+    // defaults and resurrect uWS's socket-killing 16KiB payload cap
+    const resolved = resolveUwsWsOptions({
+      maxPayloadLength: undefined,
+      maxBackpressure: undefined,
+    })
+
+    expect(resolved.maxPayloadLength).toBe(DEFAULT_WS_MAX_PAYLOAD)
+    expect(resolved.maxBackpressure).toBe(DEFAULT_WS_MAX_BACKPRESSURE)
+  })
+
+  it('lets explicit user values win over the defaults', () => {
+    const resolved = resolveUwsWsOptions({
+      maxPayloadLength: 2048,
+      maxBackpressure: 4096,
+      idleTimeout: 60,
+    })
+
+    expect(resolved.maxPayloadLength).toBe(2048)
+    expect(resolved.maxBackpressure).toBe(4096)
+    expect(resolved.idleTimeout).toBe(60)
+  })
+})

--- a/packages/ws-transport/tests/stream-e2e.spec.ts
+++ b/packages/ws-transport/tests/stream-e2e.spec.ts
@@ -374,10 +374,6 @@ describe('stream flow control over a real WS transport', () => {
 
     const { client } = await createHarness({
       plugins: [pacingObserver],
-      // uWS's default maxPayloadLength (16KiB) is smaller than a granted
-      // 16KiB pull chunk plus the 5-byte frame header, so the connection
-      // would be closed on the first push — raise the receive ceiling
-      runtimeWs: { maxPayloadLength: 1024 * 1024 },
       handlers: {
         upload: async ({ payload, container }) => {
           const consumeBlob = await container.resolve(

--- a/packages/ws-transport/tests/stream-e2e.spec.ts
+++ b/packages/ws-transport/tests/stream-e2e.spec.ts
@@ -1,0 +1,453 @@
+import { Buffer } from 'node:buffer'
+import { Readable } from 'node:stream'
+
+import type { ClientPlugin } from '@nmtjs/client'
+import type {
+  GatewayApi,
+  GatewayApiCallOptions,
+  GatewayResolvedProcedure,
+  TransportWorker,
+} from '@nmtjs/gateway'
+import type { ConnectionType } from '@nmtjs/protocol'
+import { RuntimeClient } from '@nmtjs/client'
+import { blobType, c } from '@nmtjs/contract'
+import { Container, createLogger, Hooks } from '@nmtjs/core'
+import {
+  Gateway,
+  GatewayInjectables,
+  ProxyableTransportType,
+} from '@nmtjs/gateway'
+import { JsonFormat as ClientJsonFormat } from '@nmtjs/json-format/client'
+import { JsonFormat as ServerJsonFormat } from '@nmtjs/json-format/server'
+import {
+  ClientMessageType,
+  getProtocolBlobStreamId,
+  ProtocolVersion,
+} from '@nmtjs/protocol'
+import { ProtocolFormats } from '@nmtjs/protocol/server'
+import { t } from '@nmtjs/type'
+import { WsTransportFactory } from '@nmtjs/ws-client'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { WsTransportRuntimeNode } from '../src/types.ts'
+import { WsTransport } from '../src/runtimes/node.ts'
+
+/**
+ * End-to-end flow control suite: a real Gateway behind the real uWS transport
+ * on an ephemeral loopback port, consumed by the real client stack over TCP.
+ * Routing is not under test, so the API is a plain per-procedure dispatch.
+ */
+
+// mirrors the client stream layer's DEFAULT_PULL_SIZE byte-credit grant
+const PULL_SIZE = 65535
+
+const contract = c.router({
+  routes: {
+    download: c.procedure({ input: t.object({}), output: blobType() }),
+    chunks: c.procedure({
+      input: t.object({}),
+      output: t.string(),
+      stream: true,
+    }),
+    sparse: c.procedure({
+      input: t.object({}),
+      output: t.string(),
+      stream: true,
+    }),
+    ticks: c.procedure({
+      input: t.object({}),
+      output: t.string(),
+      stream: true,
+    }),
+    upload: c.procedure({
+      input: t.object({ blob: blobType() }),
+      output: t.object({ bytes: t.number(), ok: t.boolean() }),
+    }),
+  },
+})
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+const withDeadline = async <T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+) => {
+  let timer!: ReturnType<typeof setTimeout>
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms)
+  })
+  try {
+    return await Promise.race([promise, deadline])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+const buildPattern = (size: number) => {
+  const buffer = Buffer.alloc(size)
+  for (let i = 0; i < size; i++) buffer[i] = (i + (i >> 8) * 7) & 0xff
+  return buffer
+}
+
+/**
+ * Fixed-size-chunk source that reports how far the server has advanced into
+ * the payload. hwm 1 keeps Node's own read-ahead at a single chunk so the
+ * credit gate — not internal buffering — is what paces source consumption.
+ */
+const trackedSource = (
+  pattern: Buffer,
+  chunkSize: number,
+  onRead: (totalBytes: number) => void,
+) => {
+  let offset = 0
+  return new Readable({
+    highWaterMark: 1,
+    read() {
+      if (offset >= pattern.byteLength) {
+        this.push(null)
+        return
+      }
+      const chunk = pattern.subarray(offset, offset + chunkSize)
+      offset += chunk.byteLength
+      onRead(offset)
+      this.push(chunk)
+    },
+  })
+}
+
+type Handlers = Record<
+  string,
+  (options: GatewayApiCallOptions) => Promise<unknown>
+>
+
+const teardowns: Array<() => Promise<void>> = []
+
+afterEach(async () => {
+  while (teardowns.length) await teardowns.pop()!()
+})
+
+async function createHarness(options: {
+  handlers: Handlers
+  streamIdleTimeout?: number
+  runtimeWs?: WsTransportRuntimeNode['ws']
+  plugins?: ClientPlugin[]
+}) {
+  const logger = createLogger({ pinoOptions: { enabled: false } }, 'stream-e2e')
+  const container = new Container({ logger })
+
+  const api: GatewayApi = {
+    resolve: async ({ procedure }) => ({ name: procedure, stream: false }),
+    call: async (callOptions) => {
+      const handler = options.handlers[callOptions.procedure]
+      if (!handler)
+        throw new Error(`Unknown procedure ${callOptions.procedure}`)
+      return handler(callOptions)
+    },
+  }
+
+  const transport = WsTransport.factory({
+    listen: { port: 0, hostname: '127.0.0.1' },
+    runtime: options.runtimeWs ? { ws: options.runtimeWs } : undefined,
+  })
+
+  const gateway = new Gateway({
+    logger,
+    container,
+    hooks: new Hooks(),
+    formats: new ProtocolFormats([new ServerJsonFormat()]),
+    transports: {
+      ws: {
+        // variance-only cast: the WS worker never calls resolve(), which is
+        // the sole member typed against ApplicationResolvedProcedure
+        transport: transport as unknown as TransportWorker<
+          ConnectionType,
+          GatewayResolvedProcedure
+        >,
+        proxyable: ProxyableTransportType.WS,
+      },
+    },
+    api,
+    heartbeat: false,
+    streamIdleTimeout: options.streamIdleTimeout,
+  })
+
+  // listening on port 0: the uWS listen callback reports the real bound port
+  // through the returned host url
+  const hosts = await gateway.start()
+  const url = hosts[0].url
+
+  const client = new RuntimeClient(
+    {
+      contract,
+      protocol: ProtocolVersion.v1,
+      format: new ClientJsonFormat(),
+      plugins: options.plugins,
+    },
+    WsTransportFactory,
+    { url },
+  )
+
+  teardowns.push(async () => {
+    await client.disconnect().catch(() => {})
+    client.dispose()
+    await gateway.stop()
+  })
+
+  await client.connect()
+
+  return { gateway, client }
+}
+
+describe('stream flow control over a real WS transport', () => {
+  it('paces a blob download to a slow consumer and delivers it intact', async () => {
+    const CHUNKS = 12
+    const BLOB_SIZE = PULL_SIZE * CHUNKS
+    const pattern = buildPattern(BLOB_SIZE)
+    let sourceBytes = 0
+
+    const { client } = await createHarness({
+      handlers: {
+        download: async ({ container }) => {
+          const createBlob = await container.resolve(
+            GatewayInjectables.createBlob,
+          )
+          return createBlob(
+            trackedSource(pattern, PULL_SIZE, (total) => {
+              sourceBytes = total
+            }),
+            { type: 'application/octet-stream', size: BLOB_SIZE },
+          )
+        },
+      },
+    })
+
+    const blob = await client.call.download({})
+    const stream = client.consumeBlob(blob)
+
+    const received: Uint8Array[] = []
+    let consumed = 0
+    let maxLead = 0
+    let checkedMidway = false
+    for await (const chunk of stream) {
+      received.push(chunk as Uint8Array)
+      consumed += chunk.byteLength
+      maxLead = Math.max(maxLead, sourceBytes - consumed)
+      if (!checkedMidway && consumed >= BLOB_SIZE / 2) {
+        checkedMidway = true
+        // pacing: halfway through, the server must not have drained the source
+        expect(sourceBytes).toBeLessThan(BLOB_SIZE)
+      }
+      await sleep(5)
+    }
+
+    const data = Buffer.concat(received)
+    expect(data.byteLength).toBe(BLOB_SIZE)
+    expect(data.equals(pattern)).toBe(true)
+    expect(checkedMidway).toBe(true)
+    // socket buffers blur exact in-flight counts: assert bounded lead only
+    expect(maxLead).toBeLessThanOrEqual(5 * PULL_SIZE)
+  })
+
+  it('never lets an RPC stream producer run ahead of the consumer', async () => {
+    const TOTAL = 30
+    let yielded = 0
+    let finished = false
+
+    const { client } = await createHarness({
+      handlers: {
+        chunks: async () => () =>
+          (async function* () {
+            try {
+              for (let i = 0; i < TOTAL; i++) {
+                yielded++
+                yield `chunk-${i}`
+              }
+            } finally {
+              finished = true
+            }
+          })(),
+      },
+    })
+
+    const stream = await client.stream.chunks({})
+    const received: string[] = []
+    for await (const chunk of stream) {
+      received.push(chunk)
+      // one chunk credit per consumer read: the generator may only ever be
+      // marginally ahead of what the client has consumed
+      expect(yielded).toBeLessThanOrEqual(received.length + 2)
+      if (received.length % 5 === 0) await sleep(10)
+    }
+
+    expect(received).toEqual(
+      Array.from({ length: TOTAL }, (_, i) => `chunk-${i}`),
+    )
+    expect(finished).toBe(true)
+  })
+
+  it('keeps a sparse producer alive across silences beyond the idle timeout', async () => {
+    const IDLE_TIMEOUT = 300
+
+    const { client } = await createHarness({
+      streamIdleTimeout: IDLE_TIMEOUT,
+      handlers: {
+        sparse: async () => () =>
+          (async function* () {
+            yield 'first'
+            // the consumer is waiting, so producer silence is not idleness
+            await sleep(IDLE_TIMEOUT * 3)
+            yield 'second'
+          })(),
+      },
+    })
+
+    const stream = await client.stream.sparse({})
+    const received: string[] = []
+    for await (const chunk of stream) received.push(chunk)
+
+    expect(received).toEqual(['first', 'second'])
+  })
+
+  it('runs the server handler cleanup when the client aborts mid-stream', async () => {
+    let handlerFinished!: () => void
+    const handlerFinishedPromise = new Promise<void>((resolve) => {
+      handlerFinished = resolve
+    })
+
+    const { client } = await createHarness({
+      handlers: {
+        ticks: async () => () =>
+          (async function* () {
+            try {
+              let i = 0
+              while (true) yield `tick-${i++}`
+            } finally {
+              handlerFinished()
+            }
+          })(),
+      },
+    })
+
+    const controller = new AbortController()
+    const stream = await client.stream.ticks({}, { signal: controller.signal })
+    const iterator = stream[Symbol.asyncIterator]()
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: 'tick-0',
+    })
+
+    controller.abort(new Error('consumer done'))
+
+    await expect(iterator.next()).rejects.toThrow('consumer done')
+    await withDeadline(
+      handlerFinishedPromise,
+      5000,
+      'server handler cleanup did not run after client abort',
+    )
+  })
+
+  it('paces a blob upload to a slow server consumer and delivers it intact', async () => {
+    const BLOB_SIZE = 8 * 65536
+    const pattern = buildPattern(BLOB_SIZE)
+    let pushedBytes = 0
+    let serverConsumed = 0
+    let maxLead = 0
+
+    // observes outgoing pushes on the wire; sampling at push time catches the
+    // widest client-ahead-of-server window
+    const pacingObserver: ClientPlugin = () => ({
+      onClientEvent: (event) => {
+        if (
+          event.kind === 'stream_event' &&
+          event.direction === 'outgoing' &&
+          event.streamType === 'client_blob' &&
+          event.action === 'push'
+        ) {
+          pushedBytes += event.byteLength ?? 0
+          maxLead = Math.max(maxLead, pushedBytes - serverConsumed)
+        }
+      },
+    })
+
+    const { client } = await createHarness({
+      plugins: [pacingObserver],
+      // uWS's default maxPayloadLength (16KiB) is smaller than a granted
+      // 16KiB pull chunk plus the 5-byte frame header, so the connection
+      // would be closed on the first push — raise the receive ceiling
+      runtimeWs: { maxPayloadLength: 1024 * 1024 },
+      handlers: {
+        upload: async ({ payload, container }) => {
+          const consumeBlob = await container.resolve(
+            GatewayInjectables.consumeBlob,
+          )
+          const stream = consumeBlob(payload.blob)
+          const parts: Buffer[] = []
+          for await (const chunk of stream) {
+            parts.push(chunk)
+            serverConsumed += chunk.byteLength
+            await sleep(2)
+          }
+          const data = Buffer.concat(parts)
+          return { bytes: data.byteLength, ok: data.equals(pattern) }
+        },
+      },
+    })
+
+    const blob = client.createBlob(new Blob([pattern]), {
+      type: 'application/octet-stream',
+    })
+    const result = await client.call.upload({ blob })
+
+    expect(result).toEqual({ bytes: BLOB_SIZE, ok: true })
+    expect(pushedBytes).toBe(BLOB_SIZE)
+    // pushes are gated by server-granted byte credits; allow generous slack
+    // for the server-side stream buffer and frames in flight
+    expect(maxLead).toBeLessThanOrEqual(4 * 65536)
+  })
+
+  it('aborts a download instead of corrupting it when uWS drops a frame', async () => {
+    const BLOB_SIZE = 8 * 1024 * 1024
+    const data = Buffer.alloc(BLOB_SIZE, 0xab)
+
+    const { client } = await createHarness({
+      // any buffered backpressure beyond 1KiB makes uWS drop the frame
+      runtimeWs: { maxBackpressure: 1024 },
+      handlers: {
+        download: async ({ container }) => {
+          const createBlob = await container.resolve(
+            GatewayInjectables.createBlob,
+          )
+          // single in-memory chunk: the credit pump emits it as one 8MiB
+          // frame the moment credit arrives, far beyond what the kernel
+          // socket buffer absorbs synchronously
+          return createBlob(Readable.from([data]), {
+            type: 'application/octet-stream',
+            size: BLOB_SIZE,
+          })
+        },
+      },
+    })
+
+    const blob = await client.call.download({})
+    const stream = client.consumeBlob(blob)
+
+    // grant the whole blob in a single pull so the server sends it in one
+    // synchronous burst; the client's own per-read pulls would pace it out
+    const core = client.core
+    const pull = core.protocol.encodeMessage(
+      core.messageContext!,
+      ClientMessageType.ServerStreamPull,
+      { streamId: getProtocolBlobStreamId(blob), size: BLOB_SIZE },
+    )
+    await core.send(pull)
+
+    // the dropped frame must surface as a stream error (transport drop abort
+    // or connection close), never as truncated/corrupt data
+    await expect(
+      withDeadline(stream.bytes(), 10_000, 'download neither failed nor ended'),
+    ).rejects.toBeDefined()
+  })
+})

--- a/packages/ws-transport/tests/stream-e2e.spec.ts
+++ b/packages/ws-transport/tests/stream-e2e.spec.ts
@@ -69,6 +69,10 @@ const contract = c.router({
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms))
 
+// distinguishable from real failures, so a test can tell "the operation
+// hung" apart from "the operation failed as expected"
+class DeadlineExceededError extends Error {}
+
 const withDeadline = async <T>(
   promise: Promise<T>,
   ms: number,
@@ -76,12 +80,39 @@ const withDeadline = async <T>(
 ) => {
   let timer!: ReturnType<typeof setTimeout>
   const deadline = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(message)), ms)
+    timer = setTimeout(() => reject(new DeadlineExceededError(message)), ms)
   })
   try {
     return await Promise.race([promise, deadline])
   } finally {
     clearTimeout(timer)
+  }
+}
+
+/**
+ * Deadline-polled quiescence: resolves once the sampled value has stopped
+ * changing for `stableMs`. Used instead of fixed sleeps so pacing asserts
+ * observe a settled network, not a lucky race.
+ */
+const waitQuiescent = async (
+  sample: () => unknown,
+  { stableMs = 200, deadlineMs = 5000 } = {},
+) => {
+  const deadline = Date.now() + deadlineMs
+  let last = sample()
+  let stableSince = Date.now()
+  while (true) {
+    await sleep(20)
+    const current = sample()
+    if (current !== last) {
+      last = current
+      stableSince = Date.now()
+    } else if (Date.now() - stableSince >= stableMs) {
+      return
+    }
+    if (Date.now() > deadline) {
+      throw new Error('waitQuiescent: value never settled')
+    }
   }
 }
 
@@ -225,29 +256,35 @@ describe('stream flow control over a real WS transport', () => {
 
     const blob = await client.call.download({})
     const stream = client.consumeBlob(blob)
+    const iterator = stream[Symbol.asyncIterator]()
 
-    const received: Uint8Array[] = []
-    let consumed = 0
-    let maxLead = 0
-    let checkedMidway = false
-    for await (const chunk of stream) {
-      received.push(chunk as Uint8Array)
-      consumed += chunk.byteLength
-      maxLead = Math.max(maxLead, sourceBytes - consumed)
-      if (!checkedMidway && consumed >= BLOB_SIZE / 2) {
-        checkedMidway = true
-        // pacing: halfway through, the server must not have drained the source
-        expect(sourceBytes).toBeLessThan(BLOB_SIZE)
-      }
-      await sleep(5)
+    // consume exactly one chunk, then pause behind the barrier
+    const first = await iterator.next()
+    expect(first.done).toBe(false)
+    const firstChunk = first.value as Uint8Array
+    const received: Uint8Array[] = [firstChunk]
+    expect(firstChunk.byteLength).toBe(PULL_SIZE)
+
+    // with the consumer paused, the source lead is exact and deterministic:
+    // the granted chunk (sent) plus exactly two chunks of read-ahead —
+    // source.read() drains-and-tops-off in one call (the pump keeps the
+    // un-credited remainder sliced off in its own buffer) and Node's hwm-1
+    // refill stages one more. sourceBytes is server-internal
+    // instrumentation, no socket buffering blurs it.
+    await waitQuiescent(() => sourceBytes)
+    expect(sourceBytes).toBe(firstChunk.byteLength + 2 * PULL_SIZE)
+
+    // release the consumer and drain the rest
+    while (true) {
+      const { done, value } = await iterator.next()
+      if (done) break
+      received.push(value as Uint8Array)
     }
 
     const data = Buffer.concat(received)
     expect(data.byteLength).toBe(BLOB_SIZE)
     expect(data.equals(pattern)).toBe(true)
-    expect(checkedMidway).toBe(true)
-    // socket buffers blur exact in-flight counts: assert bounded lead only
-    expect(maxLead).toBeLessThanOrEqual(5 * PULL_SIZE)
+    expect(sourceBytes).toBe(BLOB_SIZE)
   })
 
   it('never lets an RPC stream producer run ahead of the consumer', async () => {
@@ -272,13 +309,24 @@ describe('stream flow control over a real WS transport', () => {
     })
 
     const stream = await client.stream.chunks({})
-    const received: string[] = []
-    for await (const chunk of stream) {
-      received.push(chunk)
-      // one chunk credit per consumer read: the generator may only ever be
-      // marginally ahead of what the client has consumed
-      expect(yielded).toBeLessThanOrEqual(received.length + 2)
-      if (received.length % 5 === 0) await sleep(10)
+    const iterator = stream[Symbol.asyncIterator]()
+
+    // consume one chunk, then pause: the producer must have advanced exactly
+    // once — one credit, one yield, no prefetch (yielded is server-internal
+    // instrumentation, exact by construction)
+    const first = await iterator.next()
+    expect(first.value).toBe('chunk-0')
+    await waitQuiescent(() => yielded)
+    expect(yielded).toBe(1)
+
+    const received: string[] = [first.value]
+    while (true) {
+      const { done, value } = await iterator.next()
+      if (done) break
+      received.push(value)
+      // strict lockstep: the next credit is only granted by the next read,
+      // so the generator can never be ahead of what the client consumed
+      expect(yielded).toBe(received.length)
     }
 
     expect(received).toEqual(
@@ -353,23 +401,33 @@ describe('stream flow control over a real WS transport', () => {
     const BLOB_SIZE = 8 * 65536
     const pattern = buildPattern(BLOB_SIZE)
     let pushedBytes = 0
+    let grantedBytes = 0
+    let maxPullSize = 0
     let serverConsumed = 0
-    let maxLead = 0
 
-    // observes outgoing pushes on the wire; sampling at push time catches the
-    // widest client-ahead-of-server window
+    // counts wire-level credit traffic on the client: grants received
+    // (incoming pulls) and pushes sent against them
     const pacingObserver: ClientPlugin = () => ({
       onClientEvent: (event) => {
-        if (
-          event.kind === 'stream_event' &&
-          event.direction === 'outgoing' &&
-          event.streamType === 'client_blob' &&
-          event.action === 'push'
-        ) {
+        if (event.kind !== 'stream_event') return
+        if (event.streamType !== 'client_blob') return
+        if (event.direction === 'outgoing' && event.action === 'push') {
           pushedBytes += event.byteLength ?? 0
-          maxLead = Math.max(maxLead, pushedBytes - serverConsumed)
+        }
+        if (event.direction === 'incoming' && event.action === 'pull') {
+          grantedBytes += event.byteLength ?? 0
+          maxPullSize = Math.max(maxPullSize, event.byteLength ?? 0)
         }
       },
+    })
+
+    let releaseServer!: () => void
+    const serverBarrier = new Promise<void>((resolve) => {
+      releaseServer = resolve
+    })
+    let firstChunkConsumed!: () => void
+    const firstChunk = new Promise<void>((resolve) => {
+      firstChunkConsumed = resolve
     })
 
     const { client } = await createHarness({
@@ -381,10 +439,16 @@ describe('stream flow control over a real WS transport', () => {
           )
           const stream = consumeBlob(payload.blob)
           const parts: Buffer[] = []
+          let first = true
           for await (const chunk of stream) {
             parts.push(chunk)
             serverConsumed += chunk.byteLength
-            await sleep(2)
+            if (first) {
+              first = false
+              firstChunkConsumed()
+              // consumer pauses behind the barrier: grants must dry up
+              await serverBarrier
+            }
           }
           const data = Buffer.concat(parts)
           return { bytes: data.byteLength, ok: data.equals(pattern) }
@@ -395,18 +459,34 @@ describe('stream flow control over a real WS transport', () => {
     const blob = client.createBlob(new Blob([pattern]), {
       type: 'application/octet-stream',
     })
-    const result = await client.call.upload({ blob })
+    const resultPromise = client.call.upload({ blob })
+
+    await withDeadline(firstChunk, 5000, 'server never consumed a chunk')
+    // wait for the credit traffic to settle with the consumer paused
+    await waitQuiescent(() => `${grantedBytes}:${pushedBytes}`)
+
+    // credit conformance is exact: both counters live on the client, so no
+    // kernel buffering is in the measurement path — every granted byte was
+    // answered, and not one byte more was pushed
+    expect(pushedBytes).toBe(grantedBytes)
+    expect(pushedBytes).toBeGreaterThan(0)
+    expect(pushedBytes).toBeLessThan(BLOB_SIZE)
+    // outstanding grants are bounded by the server-side stream buffers
+    // (readable + writable high-water marks plus one in-flight grant) — the
+    // only slack in this assert is Node's own buffering, not the network
+    expect(grantedBytes - serverConsumed).toBeLessThanOrEqual(3 * maxPullSize)
+
+    releaseServer()
+    const result = await resultPromise
 
     expect(result).toEqual({ bytes: BLOB_SIZE, ok: true })
     expect(pushedBytes).toBe(BLOB_SIZE)
-    // pushes are gated by server-granted byte credits; allow generous slack
-    // for the server-side stream buffer and frames in flight
-    expect(maxLead).toBeLessThanOrEqual(4 * 65536)
   })
 
   it('aborts a download instead of corrupting it when uWS drops a frame', async () => {
     const BLOB_SIZE = 8 * 1024 * 1024
     const data = Buffer.alloc(BLOB_SIZE, 0xab)
+    let sourceBytes = 0
 
     const { client } = await createHarness({
       // any buffered backpressure beyond 1KiB makes uWS drop the frame
@@ -419,10 +499,12 @@ describe('stream flow control over a real WS transport', () => {
           // single in-memory chunk: the credit pump emits it as one 8MiB
           // frame the moment credit arrives, far beyond what the kernel
           // socket buffer absorbs synchronously
-          return createBlob(Readable.from([data]), {
-            type: 'application/octet-stream',
-            size: BLOB_SIZE,
-          })
+          return createBlob(
+            trackedSource(data, BLOB_SIZE, (total) => {
+              sourceBytes = total
+            }),
+            { type: 'application/octet-stream', size: BLOB_SIZE },
+          )
         },
       },
     })
@@ -440,10 +522,39 @@ describe('stream flow control over a real WS transport', () => {
     )
     await core.send(pull)
 
-    // the dropped frame must surface as a stream error (transport drop abort
-    // or connection close), never as truncated/corrupt data
-    await expect(
-      withDeadline(stream.bytes(), 10_000, 'download neither failed nor ended'),
-    ).rejects.toBeDefined()
+    // the dropped frame must surface as a stream error, never as truncated /
+    // corrupt data and never as a silent hang
+    const outcome = await withDeadline(
+      stream.bytes(),
+      10_000,
+      'download neither failed nor ended',
+    ).then(
+      () => ({ failed: false as const }),
+      (error: unknown) => ({ failed: true as const, error }),
+    )
+
+    if (!outcome.failed) {
+      expect.unreachable('download completed despite the dropped frame')
+    }
+    if (outcome.error instanceof DeadlineExceededError) {
+      expect.unreachable(
+        'download hung: neither a transport-drop abort nor a connection close surfaced',
+      )
+    }
+
+    // the oversized push was actually attempted: the pump drained the source
+    expect(sourceBytes).toBe(BLOB_SIZE)
+
+    // and the failure is the real surface: the transport-drop abort reason,
+    // or the connection-close/disconnect error when the abort frame itself
+    // was also dropped
+    const message =
+      outcome.error instanceof Error
+        ? outcome.error.message
+        : String(outcome.error)
+    expect(
+      message.includes('transport backpressure overflow') ||
+        /disconnect|closed|server/i.test(message),
+    ).toBe(true)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,12 +448,24 @@ importers:
       '@nmtjs/common':
         specifier: workspace:*
         version: link:../common
+      '@nmtjs/contract':
+        specifier: workspace:*
+        version: link:../contract
       '@nmtjs/gateway':
         specifier: workspace:*
         version: link:../gateway
+      '@nmtjs/json-format':
+        specifier: workspace:*
+        version: link:../json-format
       '@nmtjs/protocol':
         specifier: workspace:*
         version: link:../protocol
+      '@nmtjs/type':
+        specifier: workspace:*
+        version: link:../type
+      '@nmtjs/ws-client':
+        specifier: workspace:*
+        version: link:../ws-client
       uWebSockets.js:
         specifier: github:uNetworking/uWebSockets.js#v20.67.0
         version: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/e0f56ebb4b349017f006e14d1cd29052f2a7121d


### PR DESCRIPTION
Closes #208. Refs #211 (in-band stream refs stay there; they share only the `addStream` seam and are untouched here).

The pull-based streaming protocol existed on the wire but no layer enforced it. This makes credits the single source of truth for every stream kind.

## Design

- **Blob downloads (server→client)** — byte credits, no wire change: the `ServerStreamPull` size (previously dropped on the floor) is now an additive credit grant. `ProtocolServerStream` is rewritten as a credit pump: the source is never piped and stays paused; a single-flight pump sends exactly `min(credits, chunk)` per push, slicing oversized chunks; nothing (including `End` and buffered pre-grant source errors) is emitted before the first grant, so no stream frame can ever precede the `RpcResponse` that references it.
- **Blob uploads (client→server)** — granted bytes are counted (grant recorded before the pull frame is sent, so a synchronous-transport push can't be falsely flagged; rolled back if the pull frame fails to send) and each push debits them. A push exceeding outstanding credit, a zero-size pull, or a grant total overflowing `MAX_STREAM_CREDITS` is a protocol violation → abort with `stream credit violation`.
- **RPC streams** — chunk-count credits via the one wire addition, `ClientMessageType.RpcStreamPull` (`u8 | u32 callId | u32 size`). The gateway drives the handler's iterator explicitly: every chunk waits for credit; the client sends `pull{size:1}` per consumer read (hwm 0), with no initial credit. `iterator.next()` races the call abort signal — a producer stalled on an upstream await no longer survives client abort or connection teardown, and `iterator.return()` runs timeboxed on every exit path. The idle timer deliberately does **not** run while awaiting the producer: a silent producer with a live, waiting client (sparse streams — e.g. pubsub subscriptions) is not a fault; only consumer inactivity (chunk ready, client not pulling) is reaped.
- **Send results consumed** — a dropped frame (uWS status 2 / Bun status 0, via the per-runtime mapping from #264) aborts the stream with `transport backpressure overflow`; a dropped *terminal* frame (End/Abort/StreamResponse) forces connection teardown, since no stream-level protocol can recover once the peer can no longer learn the stream died. uWS `maxBackpressure` now defaults to 1 MiB (user config wins) so drops are a safety net, not a common path.
- **Timeouts** — the Pull/Consume/Finish trio (with its documented semantic ambiguity) is replaced by a single `streamIdleTimeout` (default 30s) reset on any stream activity. Long downloads no longer die at the 120s Finish cap; healthy-but-slow uploads no longer die at the 15s Pull timeout.
- **Client correctness** — `DuplexStream.write()` now parks on `desiredSize <= 0` (resolved by `pull()`, released on close/abort/cancel so teardown can't deadlock), transform errors propagate to the readable side, all previously `void`-ed push paths route rejections into stream aborts (no unhandled rejections), an `RpcStreamAbort` arriving before the stream response now rejects the pending call instead of stranding it, and server abort reasons reach consumers.

## Breaking changes (lockstep)

- **Wire**: new `RpcStreamPull` message. Old clients never send it, so a new server would hold RPC stream chunks until the idle timeout. Client and server ship together (single protocol version) — deploy in lockstep.
- **Gateway options**: `streamTimeouts` (pull/consume/finish) is replaced by `streamIdleTimeout?: number` (default 30 000 ms).
- **`@nmtjs/protocol/server`**: `ProtocolServerStream` is no longer a `Readable` (it's a credit pump with a sink interface). The gateway is the only in-repo consumer.
- **`@nmtjs/common`**: an awaited `DuplexStream` `writer.write()` with no consumer now waits (that is the point); repo-internal call sites were audited.

## Verification

Full workspace suite: 1235 passed / 6 skipped (the lone `nmtjs/exports.spec.ts` failure under full parallel load is the known 5s barrel-import flake; passes in isolation). New coverage includes: credit-exact delivery with chunk slicing and multi-grant accumulation, nothing-before-first-grant (including pre-grant source errors), drop→abort and dropped-terminal→teardown, upload credit violations and phantom-grant rollback, zero-size-pull and overflow violations, exactly-one-reasoned-abort per stream, stalled-producer interruption by abort/teardown with guaranteed `finally`, sparse-producer survival past the idle timeout, consumer-stops-pulling reaping, synchronous first-pull delivery, DuplexStream parking/FIFO/error-propagation, and the updated client pull choreography (one `RpcStreamPull` per consumed chunk).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `streamIdleTimeout` for terminating inactive streams (replacing the prior multi-timeout behavior).
  - Introduced credit-based RPC stream flow control, including support for `RpcStreamPull`.
- **Bug Fixes**
  - Improved client/server stream push, end, and abort handling to avoid hangs, reduce “stuck” termination, and prevent unhandled promise rejections.
  - Enhanced failure handling so stream aborts propagate reliably when local sends or transport delivery fail, including correct cleanup behavior.
- **Chores / Tests**
  - Updated and expanded protocol, unit, and end-to-end streaming tests; refined WebSocket backpressure/maximum payload settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->