### PR TITLE
http-transport: fix fixed-length response backpressure and abort handling

### DIFF
--- a/packages/http-transport/src/runtimes/node.ts
+++ b/packages/http-transport/src/runtimes/node.ts
@@ -201,12 +201,41 @@ async function handleResponseBody(
   await handleChunkedStream(res, response.body)
 }
 
-async function handleFixedLengthStream(
+// uWS honors only the first onWritable registration per response, so a
+// single handler dispatches drain (and abort) events to the pending waiter
+function createWritableWaiter(res: UwsResponse): () => Promise<void> {
+  let writableHandlerRegistered = false
+  return () =>
+    new Promise<void>((resolve, reject) => {
+      if (!writableHandlerRegistered) {
+        writableHandlerRegistered = true
+        res.onWritable(() => {
+          res.wakeWritable?.()
+          return true
+        })
+      }
+      res.wakeWritable = () => {
+        res.wakeWritable = undefined
+        if (res.aborted) reject(new Error('Response aborted'))
+        else resolve()
+      }
+    })
+}
+
+// exported for tests: the waiter dispatch is timing-sensitive and needs
+// deterministic coverage against a controlled response double
+export async function handleFixedLengthStream(
   res: UwsResponse,
   body: ReadableStream<Uint8Array>,
   totalSize: number,
 ): Promise<void> {
   const reader = body.getReader()
+  // abort must also cancel a pending read(): a stalled source would otherwise
+  // keep the pump and the reader lock alive forever
+  res.cancelBody = () => {
+    reader.cancel().catch(() => {})
+  }
+  const waitWritable = createWritableWaiter(res)
   try {
     if (totalSize === 0) {
       if (!res.aborted) res.cork(() => res.endWithoutBody(0))
@@ -218,11 +247,12 @@ async function handleFixedLengthStream(
       const { done, value } = await reader.read()
       if (done) break
       if (value.byteLength === 0) continue
-      responded = await handleFixedChunk(res, value, totalSize)
+      responded = await handleFixedChunk(res, value, totalSize, waitWritable)
     }
 
     if (!responded && !res.aborted) res.cork(() => res.close())
   } finally {
+    res.cancelBody = undefined
     reader.releaseLock()
   }
 }
@@ -239,24 +269,7 @@ export async function handleChunkedStream(
   res.cancelBody = () => {
     reader.cancel().catch(() => {})
   }
-  // uWS honors only the first onWritable registration per response, so a
-  // single handler dispatches drain (and abort) events to the pending waiter
-  let writableHandlerRegistered = false
-  const waitWritable = () =>
-    new Promise<void>((resolve, reject) => {
-      if (!writableHandlerRegistered) {
-        writableHandlerRegistered = true
-        res.onWritable(() => {
-          res.wakeWritable?.()
-          return true
-        })
-      }
-      res.wakeWritable = () => {
-        res.wakeWritable = undefined
-        if (res.aborted) reject(new Error('Response aborted'))
-        else resolve()
-      }
-    })
+  const waitWritable = createWritableWaiter(res)
   try {
     while (!res.aborted) {
       const { done, value } = await reader.read()
@@ -278,41 +291,33 @@ export async function handleChunkedStream(
   }
 }
 
-function handleFixedChunk(
+async function handleFixedChunk(
   res: UwsResponse,
   chunk: Uint8Array,
   totalSize: number,
+  waitWritable: () => Promise<void>,
 ): Promise<boolean> {
-  return new Promise((resolve, reject) => {
-    const chunkOffset = res.getWriteOffset()
+  const chunkOffset = res.getWriteOffset()
 
-    const write = (offset: number) => {
-      if (res.aborted) {
-        reject(new Error('Response aborted'))
-        return false
-      }
+  while (true) {
+    if (res.aborted) throw new Error('Response aborted')
 
-      const relativeOffset = offset - chunkOffset
-      const remaining =
-        relativeOffset > 0 ? chunk.subarray(relativeOffset) : chunk
+    // on retry after a drain the write offset tells how much of this chunk
+    // uWS already buffered
+    const relativeOffset = res.getWriteOffset() - chunkOffset
+    const remaining =
+      relativeOffset > 0 ? chunk.subarray(relativeOffset) : chunk
 
-      let ok = false
-      let done = false
-      res.cork(() => {
-        ;[ok, done] = res.tryEnd(remaining, totalSize)
-      })
+    // cork() returns the response object, not tryEnd()'s flags
+    let ok = false
+    let done = false
+    res.cork(() => {
+      ;[ok, done] = res.tryEnd(remaining, totalSize)
+    })
 
-      if (done || ok) {
-        resolve(done)
-        return ok
-      }
-
-      res.onWritable(write)
-      return ok
-    }
-
-    write(chunkOffset)
-  })
+    if (done || ok) return done
+    await waitWritable()
+  }
 }
 
 function getContentLength(headers: Headers): number | undefined {

--- a/packages/http-transport/src/runtimes/node.ts
+++ b/packages/http-transport/src/runtimes/node.ts
@@ -253,6 +253,10 @@ export async function handleFixedLengthStream(
     if (!responded && !res.aborted) res.cork(() => res.close())
   } finally {
     res.cancelBody = undefined
+    // non-abort early exits (zero-length response, tryEnd done while the
+    // source is still open) must also cancel the source so its resources are
+    // released; no-op when the stream already closed or was cancelled on abort
+    reader.cancel().catch(() => {})
     reader.releaseLock()
   }
 }

--- a/packages/http-transport/tests/node-runtime.spec.ts
+++ b/packages/http-transport/tests/node-runtime.spec.ts
@@ -467,5 +467,38 @@ describe('node runtime adapter', () => {
       expect(cancelled).toBe(true)
       expect(double.counts()).toEqual({ registrations: 0, closes: 0 })
     })
+
+    it('zero-length response cancels the source stream', async () => {
+      const double = createResDouble([])
+      let cancelled = false
+      const body = new ReadableStream<Uint8Array>({
+        cancel() {
+          cancelled = true
+        },
+      })
+
+      await handleFixedLengthStream(double.res, body, 0)
+      expect(cancelled).toBe(true)
+      expect(() => body.getReader()).not.toThrow()
+    })
+
+    it('response done before the source closes cancels the source', async () => {
+      // app stream longer than its content-length: tryEnd reports done on the
+      // first chunk while the source is still open
+      const double = createResDouble([{ accept: 8, ok: true, done: true }])
+      let cancelled = false
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(8))
+        },
+        cancel() {
+          cancelled = true
+        },
+      })
+
+      await handleFixedLengthStream(double.res, body, 8)
+      expect(cancelled).toBe(true)
+      expect(() => body.getReader()).not.toThrow()
+    })
   })
 })

--- a/packages/http-transport/tests/node-runtime.spec.ts
+++ b/packages/http-transport/tests/node-runtime.spec.ts
@@ -4,7 +4,11 @@ import { BaseServerFormat, ProtocolFormats } from '@nmtjs/protocol/server'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { HttpTransportServerRequest } from '../src/types.ts'
-import { handleChunkedStream, HttpTransport } from '../src/runtimes/node.ts'
+import {
+  handleChunkedStream,
+  handleFixedLengthStream,
+  HttpTransport,
+} from '../src/runtimes/node.ts'
 
 class TestJsonFormat extends BaseServerFormat {
   accept = ['application/json']
@@ -129,6 +133,48 @@ describe('node runtime adapter', () => {
       try {
         const response = await fetch(`${url}/test`)
         expect(response.status).toBe(200)
+
+        // give the server time to push as much as buffers allow while the
+        // client is not reading the body yet
+        await delay(500)
+        expect(pulled).toBeLessThan(totalChunks)
+
+        const body = new Uint8Array(await response.arrayBuffer())
+        expect(pulled).toBe(totalChunks)
+        expect(body.byteLength).toBe(chunkSize * totalChunks)
+      } finally {
+        await stop()
+      }
+    })
+  })
+
+  describe('fixed-length stream backpressure', () => {
+    it('pauses reading the source stream when the client does not consume', async () => {
+      const chunkSize = 256 * 1024
+      const totalChunks = 100
+      const chunk = new Uint8Array(chunkSize).fill(97)
+      let pulled = 0
+
+      const { url, stop } = await startServer(async () => {
+        // explicit content-length -> exercises the fixed-length tryEnd path
+        const stream = new ReadableStream<Uint8Array>({
+          pull(controller) {
+            pulled++
+            controller.enqueue(chunk)
+            if (pulled >= totalChunks) controller.close()
+          },
+        })
+        return new Response(stream, {
+          headers: { 'content-length': String(chunkSize * totalChunks) },
+        })
+      })
+
+      try {
+        const response = await fetch(`${url}/test`)
+        expect(response.status).toBe(200)
+        expect(response.headers.get('content-length')).toBe(
+          String(chunkSize * totalChunks),
+        )
 
         // give the server time to push as much as buffers allow while the
         // client is not reading the body yet
@@ -283,6 +329,143 @@ describe('node runtime adapter', () => {
       await pump
       expect(cancelled).toBe(true)
       expect(double.counts()).toEqual({ writes: 0, ends: 0, registrations: 0 })
+    })
+  })
+
+  describe('handleFixedLengthStream writable dispatcher', () => {
+    // scripted stand-in for uWS HttpResponse: only the first onWritable
+    // registration takes effect, matching real uWS behavior; each tryEnd
+    // buffers a scripted amount of bytes so partial writes advance the offset
+    function createResDouble(
+      script: Array<{ accept: number; ok: boolean; done: boolean }>,
+    ) {
+      const steps = [...script]
+      let offset = 0
+      let registrations = 0
+      let closes = 0
+      let handler: ((offset: number) => boolean) | undefined
+      const written: Uint8Array[] = []
+      const res: any = {
+        aborted: false,
+        wakeWritable: undefined,
+        cork(cb: () => void) {
+          cb()
+          return res
+        },
+        getWriteOffset: () => offset,
+        tryEnd(data: Uint8Array, _totalSize: number) {
+          const step = steps.shift() ?? {
+            accept: data.byteLength,
+            ok: true,
+            done: false,
+          }
+          written.push(data.subarray(0, step.accept))
+          offset += step.accept
+          return [step.ok, step.done]
+        },
+        close() {
+          closes++
+          return res
+        },
+        endWithoutBody() {
+          return res
+        },
+        onWritable(h: (offset: number) => boolean) {
+          registrations++
+          handler ??= h
+          return res
+        },
+      }
+      return {
+        res,
+        fireWritable: () => handler!(offset),
+        counts: () => ({ registrations, closes }),
+        written: () => Buffer.concat(written),
+        // mirrors what the route's onAborted handler does
+        abort: () => {
+          res.aborted = true
+          res.wakeWritable?.()
+          res.cancelBody?.()
+        },
+      }
+    }
+
+    const streamOf = (...parts: Uint8Array[]) =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const part of parts) controller.enqueue(part)
+          controller.close()
+        },
+      })
+
+    const tick = () => new Promise((resolve) => setImmediate(resolve))
+
+    it('drains backpressure on two different chunks with one registration', async () => {
+      // both chunks hit backpressure mid-write: each retry must resume from
+      // where uWS stopped buffering that chunk, via a single drain handler
+      const double = createResDouble([
+        { accept: 3, ok: false, done: false },
+        { accept: 5, ok: true, done: false },
+        { accept: 4, ok: false, done: false },
+        { accept: 4, ok: true, done: true },
+      ])
+      const chunk1 = Uint8Array.from({ length: 8 }, (_, i) => i)
+      const chunk2 = Uint8Array.from({ length: 8 }, (_, i) => i + 8)
+      const pump = handleFixedLengthStream(
+        double.res,
+        streamOf(chunk1, chunk2),
+        16,
+      )
+
+      await tick()
+      expect(double.counts().registrations).toBe(1)
+
+      double.fireWritable()
+      await tick()
+      // chunk 1 finished, chunk 2 parked a new waiter without re-registering
+      expect(double.counts().registrations).toBe(1)
+
+      double.fireWritable()
+      await pump
+      expect(double.counts()).toEqual({ registrations: 1, closes: 0 })
+      expect([...double.written()]).toEqual(
+        Array.from({ length: 16 }, (_, i) => i),
+      )
+    })
+
+    it('abort while a waiter is pending settles the wait and exits the pump', async () => {
+      const double = createResDouble([{ accept: 0, ok: false, done: false }])
+      const body = streamOf(new Uint8Array(8), new Uint8Array(8))
+      const pump = handleFixedLengthStream(double.res, body, 16)
+
+      await tick()
+      expect(double.counts().registrations).toBe(1)
+
+      double.abort()
+      await expect(pump).rejects.toThrow('Response aborted')
+      // reader lock is released on exit
+      expect(() => body.getReader()).not.toThrow()
+    })
+
+    it('abort while read() is stalled cancels the reader and exits the pump', async () => {
+      const double = createResDouble([])
+      let cancelled = false
+      const body = new ReadableStream<Uint8Array>({
+        // source never produces: the pump parks inside reader.read()
+        pull: () => new Promise<never>(() => {}),
+        cancel() {
+          cancelled = true
+        },
+      })
+      const pump = handleFixedLengthStream(double.res, body, 16)
+
+      await tick()
+      double.abort()
+      // reader.cancel() resolves the pending read as done and the pump exits
+      // without closing the aborted response
+      await pump
+      expect(cancelled).toBe(true)
+      expect(double.counts()).toEqual({ registrations: 0, closes: 0 })
     })
   })
 })


### PR DESCRIPTION
Closes #271

## What was broken

Two defects in the fixed-length (known `Content-Length`) response path in `packages/http-transport/src/runtimes/node.ts`:

- `handleFixedChunk` registered `res.onWritable(write)` per chunk, but uWS honors only the first `onWritable` registration per response. When backpressure hit two different chunks, the first chunk's stale closure kept firing with wrong `chunkOffset` math while the second chunk's promise never resolved — the response hung forever.
- `handleFixedLengthStream` awaited `reader.read()` with no abort-side cancel, so a client abort while the source was stalled left the pump and reader lock alive forever. #267 fixed this for the chunked path only.

## The fix

- Extracted the single-lazily-registered `onWritable` handler + swappable `wakeWritable` waiter dispatch that #267 introduced for the chunked path into `createWritableWaiter`, shared by both paths. `handleFixedChunk` is now a retry loop that resumes each chunk from the current write offset and parks on the shared waiter under backpressure.
- Gave the fixed-length pump the same `cancelBody` hook the chunked pump has, so a client abort cancels a pending `read()`.

## Tests

- e2e: fixed-length response backpressure against real uWS (hangs on the previous code, passes with the fix).
- Deterministic dispatcher tests against a scripted response double (mirroring the existing chunked-path tests): backpressure hitting two different chunks with a single registration and correct resume offsets, abort while a waiter is pending, abort while `read()` is stalled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability under network backpressure for both fixed-length and chunked responses.
  * Prevented duplicate “writable” notifications per response to avoid missed or repeated writes.
  * Strengthened abort handling so pending reads/writes are cancelled and aborted responses are handled correctly.
  * Updated partial-write retry logic to safely continue until the stream completes.
* **Tests**
  * Added Node runtime coverage for fixed-length backpressure, zero-length payloads, and multiple abort edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->