### PR TITLE
client: scope request timeout to the pending phase, tear down call signals without abort()

### DIFF
--- a/packages/client/src/layers/rpc.ts
+++ b/packages/client/src/layers/rpc.ts
@@ -22,6 +22,9 @@ export type ProtocolClientCall = Future<any> & {
   procedure: string
   signal?: AbortSignal
   cleanup?: () => void
+  // releases the composed per-call signal from its sources; exposed on the
+  // call so response handling can defer it past settle (HTTP blob bodies)
+  detachSignals?: () => void
 }
 
 export interface RpcLayerApi {
@@ -508,6 +511,10 @@ export const createRpcLayer = (
 
       const { blob } = streams.addServerBlobStream(response.metadata, {
         source: response.source,
+        // once the body settles nothing is left for the call signal to
+        // abort — release its source listeners (kept wired past settle so
+        // an abort can still kill the in-flight fetch body)
+        onSourceSettled: () => call.detachSignals?.(),
       })
       call.resolve(blob)
       return
@@ -691,12 +698,16 @@ export const createRpcLayer = (
     const detachAll = () => {
       for (const detach of [...detachers]) detach()
     }
+    // an aborted composed signal can never abort again: whatever path aborts
+    // it, the source listeners are dead weight from that point on
+    signal.addEventListener('abort', detachAll, { once: true })
     let removePendingAbortListener = noopFn
 
     const currentCallId = nextCallId()
     const call = createFuture() as ProtocolClientCall
     call.procedure = procedure
     call.signal = signal
+    call.detachSignals = detachAll
 
     calls.set(currentCallId, call)
     core.emitClientEvent({
@@ -844,11 +855,16 @@ export const createRpcLayer = (
         }
 
         if (isBlobInterface(value)) {
-          // the blob body may still be downloading: keep cancel sources wired
-          // (e.g. HTTP aborts the fetch body), but drop the pending-phase
-          // listener and timeout — the call itself has settled
           removePendingAbortListener()
           detachTimeout()
+          if (core.transportType === ConnectionType.Bidirectional) {
+            // WS blob consumption is message-driven with its own subscription
+            // signal — the call signal guards nothing once the call settled
+            detachAll()
+          }
+          // HTTP: sources stay wired so an abort can still kill the in-flight
+          // fetch body; detached when the pumped body settles (onSourceSettled
+          // in handleCallResponse) or when the composed signal aborts
           return value
         }
 

--- a/packages/client/src/layers/rpc.ts
+++ b/packages/client/src/layers/rpc.ts
@@ -1,6 +1,6 @@
 import type { Future } from '@nmtjs/common'
 import type { ServerMessageTypePayload } from '@nmtjs/protocol/client'
-import { anyAbortSignal, createFuture, MAX_UINT32, noopFn } from '@nmtjs/common'
+import { createFuture, MAX_UINT32, noopFn } from '@nmtjs/common'
 import {
   ClientMessageType,
   ConnectionType,
@@ -162,11 +162,18 @@ const createManagedAsyncIterable = <T>(
 
       return {
         async next() {
-          const result = await iterator.next()
-          if (result.done) {
+          try {
+            const result = await iterator.next()
+            if (result.done) {
+              finish()
+            }
+            return result
+          } catch (error) {
+            // a failed read ends the iteration too: lifecycle cleanup
+            // (listener teardown) must not depend on a graceful end
             finish()
+            throw error
           }
-          return result
         },
         async return(value) {
           options.onReturn?.(value)
@@ -648,15 +655,44 @@ export const createRpcLayer = (
     callOptions: ClientCallOptions = {},
   ) => {
     const timeout = callOptions.timeout ?? options.timeout
-    const controller = new AbortController()
+    // genuine cancel channel: aborting it must reach the server as a real
+    // RpcAbort (early consumer exit from a stream), unlike lifecycle cleanup
+    const cancelController = new AbortController()
 
-    const signals: AbortSignal[] = [controller.signal]
+    // the per-call signal is composed by hand instead of AbortSignal.any so
+    // inputs are detachable: the request timeout must cover only the pending
+    // phase, and a settled call must tear down without abort()ing
+    const composed = new AbortController()
+    const detachers = new Set<() => void>()
+    const attach = (source: AbortSignal) => {
+      if (composed.signal.aborted) return noopFn
+      if (source.aborted) {
+        composed.abort(source.reason)
+        return noopFn
+      }
+      const onAbort = () => composed.abort(source.reason)
+      source.addEventListener('abort', onAbort, { once: true })
+      const detach = () => {
+        source.removeEventListener('abort', onAbort)
+        detachers.delete(detach)
+      }
+      detachers.add(detach)
+      return detach
+    }
 
-    if (timeout) signals.push(AbortSignal.timeout(timeout))
-    if (callOptions.signal) signals.push(callOptions.signal)
-    if (core.connectionSignal) signals.push(core.connectionSignal)
+    attach(cancelController.signal)
+    const detachTimeout = timeout
+      ? attach(AbortSignal.timeout(timeout))
+      : noopFn
+    if (callOptions.signal) attach(callOptions.signal)
+    if (core.connectionSignal) attach(core.connectionSignal)
 
-    const signal = signals.length ? anyAbortSignal(...signals) : undefined
+    const signal = composed.signal
+    const detachAll = () => {
+      for (const detach of [...detachers]) detach()
+    }
+    let removePendingAbortListener = noopFn
+
     const currentCallId = nextCallId()
     const call = createFuture() as ProtocolClientCall
     call.procedure = procedure
@@ -683,28 +719,31 @@ export const createRpcLayer = (
           throw toAbortError(signal)
         }
 
-        signal?.addEventListener(
-          'abort',
-          () => {
-            call.reject(toAbortError(signal))
+        // pending phase only: once the call settles this listener is removed
+        // explicitly — for streams the stream-specific listener takes over
+        const onPendingAbort = () => {
+          call.reject(toAbortError(signal))
 
-            if (
-              core.transportType === ConnectionType.Bidirectional &&
-              core.messageContext
-            ) {
-              const buffer = core.protocol.encodeMessage(
-                core.messageContext,
-                ClientMessageType.RpcAbort,
-                {
-                  callId: currentCallId,
-                  reason: toReasonString(signal.reason),
-                },
-              )
-              core.send(buffer).catch(noopFn)
-            }
-          },
-          { once: true },
-        )
+          if (
+            core.transportType === ConnectionType.Bidirectional &&
+            core.messageContext
+          ) {
+            const buffer = core.protocol.encodeMessage(
+              core.messageContext,
+              ClientMessageType.RpcAbort,
+              {
+                callId: currentCallId,
+                reason: toReasonString(signal.reason),
+              },
+            )
+            core.send(buffer).catch(noopFn)
+          }
+        }
+
+        signal.addEventListener('abort', onPendingAbort, { once: true })
+        removePendingAbortListener = () => {
+          signal.removeEventListener('abort', onPendingAbort)
+        }
 
         const transformedPayload = transformer.encode(procedure, payload)
 
@@ -769,15 +808,22 @@ export const createRpcLayer = (
     return call.promise
       .then((value) => {
         if (value instanceof ProtocolServerRPCStream) {
+          // streaming phase: the stream-specific abort listener owns aborts
+          // from here on, and the request timeout must not outlive pending —
+          // a configured timeout would otherwise kill a healthy stream
+          removePendingAbortListener()
+          detachTimeout()
+
           const stream = createManagedAsyncIterable(value, {
             onDone: () => {
               call.cleanup?.()
+              detachAll()
             },
             onReturn: (reason) => {
-              controller.abort(reason)
+              cancelController.abort(reason)
             },
             onThrow: (error) => {
-              controller.abort(error)
+              cancelController.abort(error)
             },
           })
 
@@ -798,14 +844,24 @@ export const createRpcLayer = (
         }
 
         if (isBlobInterface(value)) {
+          // the blob body may still be downloading: keep cancel sources wired
+          // (e.g. HTTP aborts the fetch body), but drop the pending-phase
+          // listener and timeout — the call itself has settled
+          removePendingAbortListener()
+          detachTimeout()
           return value
         }
 
-        controller.abort()
+        // settled unary call: nothing left for the signal to guard — tear
+        // down by removing listeners; abort()ing here used to emit one stale
+        // RpcAbort frame per settled call
+        removePendingAbortListener()
+        detachAll()
         return value
       })
       .catch((error) => {
-        controller.abort()
+        removePendingAbortListener()
+        detachAll()
         throw error
       })
       .finally(() => {

--- a/packages/client/src/layers/rpc.ts
+++ b/packages/client/src/layers/rpc.ts
@@ -705,6 +705,21 @@ export const createRpcLayer = (
 
     const currentCallId = nextCallId()
     const call = createFuture() as ProtocolClientCall
+    // pending-phase wiring must be released synchronously at settle: a
+    // response can be processed while send() is still in flight, and in that
+    // window the pending listener would race the stream's own (double
+    // RpcAbort) and a stale request timeout could kill the established stream
+    const { resolve, reject } = call
+    call.resolve = (value) => {
+      removePendingAbortListener()
+      detachTimeout()
+      resolve(value)
+    }
+    call.reject = (reason) => {
+      removePendingAbortListener()
+      detachTimeout()
+      reject(reason)
+    }
     call.procedure = procedure
     call.signal = signal
     call.detachSignals = detachAll
@@ -819,12 +834,8 @@ export const createRpcLayer = (
     return call.promise
       .then((value) => {
         if (value instanceof ProtocolServerRPCStream) {
-          // streaming phase: the stream-specific abort listener owns aborts
-          // from here on, and the request timeout must not outlive pending —
-          // a configured timeout would otherwise kill a healthy stream
-          removePendingAbortListener()
-          detachTimeout()
-
+          // streaming phase: pending wiring was released at settle, the
+          // stream-specific abort listener owns aborts from here on
           const stream = createManagedAsyncIterable(value, {
             onDone: () => {
               call.cleanup?.()
@@ -855,8 +866,6 @@ export const createRpcLayer = (
         }
 
         if (isBlobInterface(value)) {
-          removePendingAbortListener()
-          detachTimeout()
           if (core.transportType === ConnectionType.Bidirectional) {
             // WS blob consumption is message-driven with its own subscription
             // signal — the call signal guards nothing once the call settled
@@ -871,12 +880,10 @@ export const createRpcLayer = (
         // settled unary call: nothing left for the signal to guard — tear
         // down by removing listeners; abort()ing here used to emit one stale
         // RpcAbort frame per settled call
-        removePendingAbortListener()
         detachAll()
         return value
       })
       .catch((error) => {
-        removePendingAbortListener()
         detachAll()
         throw error
       })

--- a/packages/client/src/layers/streams.ts
+++ b/packages/client/src/layers/streams.ts
@@ -55,6 +55,9 @@ export interface StreamLayerApi {
         stream: ProtocolServerBlobStream,
         options?: { signal?: AbortSignal },
       ) => void
+      // fires when the pumped source settles (end or abort): the body can no
+      // longer be aborted, so callers may release abort wiring tied to it
+      onSourceSettled?: () => void
     },
   ) => {
     blob: ProtocolBlobInterface
@@ -153,6 +156,7 @@ export const createStreamLayer = (core: ClientCore): StreamLayerApi => {
         stream: ProtocolServerBlobStream,
         options?: { signal?: AbortSignal },
       ) => void
+      onSourceSettled?: () => void
     },
   ) => {
     const id = getStreamId()
@@ -171,7 +175,13 @@ export const createStreamLayer = (core: ClientCore): StreamLayerApi => {
       serverBlobInitializers.set(id, (subscriptionOptions) => {
         if (started) return
         started = true
-        void pumpServerBlobSource(id, options.source!, subscriptionOptions)
+        // pump never rejects (errors abort the stream inside), so finally
+        // here means "the body settled" for both graceful and failed ends
+        void pumpServerBlobSource(
+          id,
+          options.source!,
+          subscriptionOptions,
+        ).finally(() => options.onSourceSettled?.())
       })
     }
 

--- a/packages/client/tests/rpc-call-lifecycle.spec.ts
+++ b/packages/client/tests/rpc-call-lifecycle.spec.ts
@@ -2,6 +2,7 @@ import type { BaseClientFormat } from '@nmtjs/protocol/client'
 import {
   ClientMessageType,
   ConnectionType,
+  createProtocolBlobReference,
   ServerMessageType,
 } from '@nmtjs/protocol'
 import { describe, expect, it, vi } from 'vitest'
@@ -57,12 +58,33 @@ class MockCore extends EventEmitter<{
   }
 }
 
-const createLayer = (core: MockCore) =>
+const createLayer = (core: MockCore, streams?: unknown) =>
   createRpcLayer(
     core as any,
-    { addServerBlobStream: vi.fn() } as any,
+    (streams ?? { addServerBlobStream: vi.fn() }) as any,
     new BaseClientTransformer(),
   )
+
+// net 'abort' listeners currently registered on the signal; once-listeners
+// never fire in these tests, so adds/removes account for everything
+const trackAbortListeners = (signal: AbortSignal) => {
+  const listeners = new Set<unknown>()
+  const add = signal.addEventListener.bind(signal)
+  const remove = signal.removeEventListener.bind(signal)
+  vi.spyOn(signal, 'addEventListener').mockImplementation(
+    (type, listener, options) => {
+      listeners.add(listener)
+      add(type, listener as any, options)
+    },
+  )
+  vi.spyOn(signal, 'removeEventListener').mockImplementation(
+    (type, listener, options) => {
+      listeners.delete(listener)
+      remove(type, listener as any, options)
+    },
+  )
+  return () => listeners.size
+}
 
 describe('RPC call signal lifecycle', () => {
   it('sends no RpcAbort for settled unary calls, even with a timeout configured', async () => {
@@ -292,5 +314,134 @@ describe('RPC call signal lifecycle', () => {
       value: { n: 1 },
     })
     expect(core.countSentAborts()).toBe(0)
+  })
+
+  it('still cancels the fetch reader when the user signal aborts mid-stream (unidirectional)', async () => {
+    let bodyController!: ReadableStreamDefaultController<Uint8Array>
+    let cancelled: unknown = null
+    const body = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        bodyController = controller
+      },
+      cancel: (reason) => {
+        cancelled = reason ?? 'cancelled'
+      },
+    })
+
+    const core = new MockCore(ConnectionType.Unidirectional)
+    core.transportCall.mockResolvedValue({ type: 'rpc_stream', stream: body })
+    const rpcLayer = createLayer(core)
+    const abortController = new AbortController()
+
+    const iterable = await rpcLayer.call(
+      'users/feed',
+      {},
+      { _stream_response: true, signal: abortController.signal },
+    )
+    const iterator = iterable[Symbol.asyncIterator]()
+
+    const chunkPromise = iterator.next()
+    bodyController.enqueue(encodeJson({ n: 1 }))
+    await expect(chunkPromise).resolves.toEqual({
+      done: false,
+      value: { n: 1 },
+    })
+
+    // a genuine abort must still reach the fetch body reader
+    abortController.abort('user cancelled')
+    await wait(10)
+    expect(cancelled).toBe('user cancelled')
+  })
+
+  it('still cancels the fetch reader when the consumer returns early (unidirectional)', async () => {
+    let cancelled: unknown = null
+    const body = new ReadableStream<Uint8Array>({
+      cancel: (reason) => {
+        cancelled = reason ?? 'cancelled'
+      },
+    })
+
+    const core = new MockCore(ConnectionType.Unidirectional)
+    core.transportCall.mockResolvedValue({ type: 'rpc_stream', stream: body })
+    const rpcLayer = createLayer(core)
+
+    const iterable = await rpcLayer.call(
+      'users/feed',
+      {},
+      { _stream_response: true },
+    )
+    const iterator = iterable[Symbol.asyncIterator]()
+
+    await iterator.return?.(undefined)
+    await wait(10)
+    expect(cancelled).not.toBeNull()
+  })
+
+  it('detaches user-signal listeners once a unidirectional blob body settles', async () => {
+    let onSourceSettled: (() => void) | undefined
+    const streams = {
+      addServerBlobStream: vi.fn((metadata: any, options: any) => {
+        onSourceSettled = options?.onSourceSettled
+        return {
+          blob: createProtocolBlobReference(0, metadata),
+          streamId: 0,
+          stream: {},
+        }
+      }),
+    }
+
+    const core = new MockCore(ConnectionType.Unidirectional)
+    core.transportCall.mockResolvedValue({
+      type: 'blob',
+      metadata: { type: 'application/octet-stream' },
+      source: new ReadableStream(),
+    })
+    const rpcLayer = createLayer(core, streams)
+
+    const abortController = new AbortController()
+    const activeListeners = trackAbortListeners(abortController.signal)
+
+    await rpcLayer.call(
+      'files/download',
+      {},
+      { signal: abortController.signal },
+    )
+
+    // the body may still be downloading: the user signal must stay wired so
+    // it can abort the in-flight fetch body
+    expect(activeListeners()).toBeGreaterThan(0)
+
+    onSourceSettled?.()
+    expect(activeListeners()).toBe(0)
+  })
+
+  it('detaches user-signal listeners as soon as a bidirectional call settles with a blob', async () => {
+    const core = new MockCore()
+    const rpcLayer = createLayer(core)
+
+    const abortController = new AbortController()
+    const activeListeners = trackAbortListeners(abortController.signal)
+
+    const promise = rpcLayer.call(
+      'files/download',
+      {},
+      { signal: abortController.signal },
+    )
+    core.emit(
+      'message',
+      {
+        type: ServerMessageType.RpcResponse,
+        callId: 0,
+        result: createProtocolBlobReference(0, {
+          type: 'application/octet-stream',
+        }),
+      },
+      new Uint8Array([1]),
+    )
+    await promise
+
+    // WS blob consumption has its own subscription signal: nothing of this
+    // call may keep listening on the reused user signal
+    expect(activeListeners()).toBe(0)
   })
 })

--- a/packages/client/tests/rpc-call-lifecycle.spec.ts
+++ b/packages/client/tests/rpc-call-lifecycle.spec.ts
@@ -1,0 +1,296 @@
+import type { BaseClientFormat } from '@nmtjs/protocol/client'
+import {
+  ClientMessageType,
+  ConnectionType,
+  ServerMessageType,
+} from '@nmtjs/protocol'
+import { describe, expect, it, vi } from 'vitest'
+
+import { EventEmitter } from '../src/events.ts'
+import { createRpcLayer } from '../src/layers/rpc.ts'
+import { BaseClientTransformer } from '../src/transformers.ts'
+
+const encodeJson = (value: unknown) =>
+  new TextEncoder().encode(JSON.stringify(value))
+
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+class MockCore extends EventEmitter<{
+  message: [message: unknown, raw: ArrayBufferView]
+  connected: []
+  disconnected: [reason: string]
+  state_changed: [state: string, previous: string]
+  pong: [nonce: number]
+}> {
+  readonly state = 'connected'
+  readonly application = undefined
+  readonly auth = undefined
+  readonly connectionSignal = undefined
+  readonly messageContext = {} as any
+
+  constructor(readonly transportType = ConnectionType.Bidirectional) {
+    super()
+  }
+
+  readonly format: BaseClientFormat = {
+    contentType: 'application/json',
+    encode: vi.fn(encodeJson),
+    decode: vi.fn((chunk) => JSON.parse(new TextDecoder().decode(chunk))),
+    encodeRPC: vi.fn(encodeJson),
+    decodeRPC: vi.fn((chunk) => JSON.parse(new TextDecoder().decode(chunk))),
+  } as BaseClientFormat
+
+  readonly protocol = {
+    encodeMessage: vi.fn((_context, type) => new Uint8Array([type])),
+  } as any
+
+  readonly send = vi.fn(async () => {})
+  readonly transportCall = vi.fn()
+  readonly emitClientEvent = vi.fn()
+  readonly emitStreamEvent = vi.fn()
+
+  countSentAborts() {
+    return this.protocol.encodeMessage.mock.calls.filter(
+      ([, type]: [unknown, number]) => type === ClientMessageType.RpcAbort,
+    ).length
+  }
+}
+
+const createLayer = (core: MockCore) =>
+  createRpcLayer(
+    core as any,
+    { addServerBlobStream: vi.fn() } as any,
+    new BaseClientTransformer(),
+  )
+
+describe('RPC call signal lifecycle', () => {
+  it('sends no RpcAbort for settled unary calls, even with a timeout configured', async () => {
+    const core = new MockCore()
+    const rpcLayer = createLayer(core)
+
+    // success path
+    const okPromise = rpcLayer.call('users/get', { id: 1 }, { timeout: 30 })
+    core.emit(
+      'message',
+      { type: ServerMessageType.RpcResponse, callId: 0, result: { ok: true } },
+      new Uint8Array([1]),
+    )
+    await expect(okPromise).resolves.toEqual({ ok: true })
+
+    // failure path
+    const failPromise = rpcLayer.call('users/get', { id: 2 }, { timeout: 30 })
+    core.emit(
+      'message',
+      {
+        type: ServerMessageType.RpcResponse,
+        callId: 1,
+        error: { code: 'INTERNAL_SERVER_ERROR', message: 'boom' },
+      },
+      new Uint8Array([1]),
+    )
+    await expect(failPromise).rejects.toThrow('boom')
+
+    // let the configured timeout elapse: neither settlement cleanup nor the
+    // stale timer may produce an abort frame
+    await wait(60)
+    expect(core.countSentAborts()).toBe(0)
+  })
+
+  it('does not kill a healthy stream after the request timeout elapses (bidirectional)', async () => {
+    const core = new MockCore()
+    const rpcLayer = createLayer(core)
+
+    const streamPromise = rpcLayer.call(
+      'users/feed',
+      {},
+      { _stream_response: true, timeout: 30 },
+    )
+
+    core.emit(
+      'message',
+      { type: ServerMessageType.RpcStreamResponse, callId: 0 },
+      new Uint8Array([1]),
+    )
+
+    const iterable = await streamPromise
+    const iterator = iterable[Symbol.asyncIterator]()
+
+    // the request timeout covers only the pending phase — the live stream
+    // must survive well past it
+    await wait(60)
+
+    const chunkPromise = iterator.next()
+    await Promise.resolve()
+    core.emit(
+      'message',
+      {
+        type: ServerMessageType.RpcStreamChunk,
+        callId: 0,
+        chunk: encodeJson({ n: 1 }),
+      },
+      new Uint8Array([2]),
+    )
+
+    await expect(chunkPromise).resolves.toEqual({
+      done: false,
+      value: { n: 1 },
+    })
+    expect(core.countSentAborts()).toBe(0)
+  })
+
+  it('does not kill a healthy stream after the request timeout elapses (unidirectional)', async () => {
+    let bodyController!: ReadableStreamDefaultController<Uint8Array>
+    let cancelled: unknown = null
+    const body = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        bodyController = controller
+      },
+      cancel: (reason) => {
+        cancelled = reason ?? 'cancelled'
+      },
+    })
+
+    const core = new MockCore(ConnectionType.Unidirectional)
+    core.transportCall.mockResolvedValue({ type: 'rpc_stream', stream: body })
+    const rpcLayer = createLayer(core)
+
+    const iterable = await rpcLayer.call(
+      'users/feed',
+      {},
+      { _stream_response: true, timeout: 30 },
+    )
+    const iterator = iterable[Symbol.asyncIterator]()
+
+    await wait(60)
+
+    const chunkPromise = iterator.next()
+    bodyController.enqueue(encodeJson({ n: 1 }))
+    await expect(chunkPromise).resolves.toEqual({
+      done: false,
+      value: { n: 1 },
+    })
+
+    // the fetch body reader must not have been cancelled by the stale timer
+    expect(cancelled).toBeNull()
+
+    bodyController.close()
+    await expect(iterator.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    })
+  })
+
+  it('sends exactly one RpcAbort when the consumer cancels a stream', async () => {
+    const core = new MockCore()
+    const rpcLayer = createLayer(core)
+
+    const streamPromise = rpcLayer.call(
+      'users/feed',
+      {},
+      { _stream_response: true, timeout: 30 },
+    )
+
+    core.emit(
+      'message',
+      { type: ServerMessageType.RpcStreamResponse, callId: 0 },
+      new Uint8Array([1]),
+    )
+
+    const iterable = await streamPromise
+    const iterator = iterable[Symbol.asyncIterator]()
+
+    await iterator.return?.(undefined)
+    expect(core.countSentAborts()).toBe(1)
+
+    // no second frame later from the timeout or leftover listeners
+    await wait(60)
+    expect(core.countSentAborts()).toBe(1)
+  })
+
+  it('aborts a call that times out while still pending', async () => {
+    const core = new MockCore()
+    const rpcLayer = createLayer(core)
+
+    const promise = rpcLayer.call('users/get', { id: 1 }, { timeout: 20 })
+
+    await expect(promise).rejects.toThrow()
+    expect(core.countSentAborts()).toBe(1)
+  })
+
+  it('sends no RpcAbort when the user signal fires after the stream completed', async () => {
+    const core = new MockCore()
+    const rpcLayer = createLayer(core)
+    const abortController = new AbortController()
+
+    const streamPromise = rpcLayer.call(
+      'users/feed',
+      {},
+      { _stream_response: true, signal: abortController.signal },
+    )
+
+    core.emit(
+      'message',
+      { type: ServerMessageType.RpcStreamResponse, callId: 0 },
+      new Uint8Array([1]),
+    )
+
+    const iterable = await streamPromise
+    const iterator = iterable[Symbol.asyncIterator]()
+    const endPromise = iterator.next()
+    await Promise.resolve()
+
+    core.emit(
+      'message',
+      { type: ServerMessageType.RpcStreamEnd, callId: 0 },
+      new Uint8Array([2]),
+    )
+    await expect(endPromise).resolves.toEqual({ done: true, value: undefined })
+
+    // the call is fully done: an abort of the (reused) user signal must not
+    // emit a frame for the already-deleted callId
+    abortController.abort('done with all calls')
+    await wait(10)
+    expect(core.countSentAborts()).toBe(0)
+  })
+
+  it('does not kill an autoReconnect stream via the initial attempt timeout', async () => {
+    const core = new MockCore()
+    const rpcLayer = createLayer(core)
+
+    const streamPromise = rpcLayer.call(
+      'users/feed',
+      {},
+      { _stream_response: true, autoReconnect: true, timeout: 30 },
+    )
+
+    core.emit(
+      'message',
+      { type: ServerMessageType.RpcStreamResponse, callId: 0 },
+      new Uint8Array([1]),
+    )
+
+    const iterable = await streamPromise
+    const iterator = iterable[Symbol.asyncIterator]()
+
+    await wait(60)
+
+    const chunkPromise = iterator.next()
+    await Promise.resolve()
+    core.emit(
+      'message',
+      {
+        type: ServerMessageType.RpcStreamChunk,
+        callId: 0,
+        chunk: encodeJson({ n: 1 }),
+      },
+      new Uint8Array([2]),
+    )
+
+    await expect(chunkPromise).resolves.toEqual({
+      done: false,
+      value: { n: 1 },
+    })
+    expect(core.countSentAborts()).toBe(0)
+  })
+})

--- a/packages/client/tests/rpc-call-lifecycle.spec.ts
+++ b/packages/client/tests/rpc-call-lifecycle.spec.ts
@@ -56,6 +56,22 @@ class MockCore extends EventEmitter<{
       ([, type]: [unknown, number]) => type === ClientMessageType.RpcAbort,
     ).length
   }
+
+  countSentRpcCalls() {
+    return this.protocol.encodeMessage.mock.calls.filter(
+      ([, type]: [unknown, number]) => type === ClientMessageType.Rpc,
+    ).length
+  }
+
+  // send() that stays in flight until released, so a server response can be
+  // processed before the send promise settles
+  deferNextSend() {
+    let release!: () => void
+    this.send.mockImplementationOnce(
+      () => new Promise<void>((resolve) => (release = resolve)),
+    )
+    return () => release()
+  }
 }
 
 const createLayer = (core: MockCore, streams?: unknown) =>
@@ -273,6 +289,134 @@ describe('RPC call signal lifecycle', () => {
     // emit a frame for the already-deleted callId
     abortController.abort('done with all calls')
     await wait(10)
+    expect(core.countSentAborts()).toBe(0)
+  })
+
+  it('does not kill a stream established while send() is still in flight', async () => {
+    const core = new MockCore()
+    const releaseSend = core.deferNextSend()
+    const rpcLayer = createLayer(core)
+
+    const streamPromise = rpcLayer.call(
+      'users/feed',
+      {},
+      { _stream_response: true, timeout: 30 },
+    )
+
+    // response is processed before the send promise settles
+    core.emit(
+      'message',
+      { type: ServerMessageType.RpcStreamResponse, callId: 0 },
+      new Uint8Array([1]),
+    )
+
+    // the request timeout elapses inside that window: the already-established
+    // stream must survive and no abort frame may be emitted
+    await wait(60)
+    releaseSend()
+
+    const iterable = await streamPromise
+    const iterator = iterable[Symbol.asyncIterator]()
+
+    const chunkPromise = iterator.next()
+    await Promise.resolve()
+    core.emit(
+      'message',
+      {
+        type: ServerMessageType.RpcStreamChunk,
+        callId: 0,
+        chunk: encodeJson({ n: 1 }),
+      },
+      new Uint8Array([2]),
+    )
+
+    await expect(chunkPromise).resolves.toEqual({
+      done: false,
+      value: { n: 1 },
+    })
+    expect(core.countSentAborts()).toBe(0)
+  })
+
+  it('sends a single RpcAbort for an abort landing after the response but before send() settles', async () => {
+    const core = new MockCore()
+    const releaseSend = core.deferNextSend()
+    const rpcLayer = createLayer(core)
+    const abortController = new AbortController()
+
+    const streamPromise = rpcLayer.call(
+      'users/feed',
+      {},
+      { _stream_response: true, signal: abortController.signal },
+    )
+
+    core.emit(
+      'message',
+      { type: ServerMessageType.RpcStreamResponse, callId: 0 },
+      new Uint8Array([1]),
+    )
+
+    // only the stream-specific listener may emit a frame here: the pending
+    // one must be gone the moment the call settled with a stream
+    abortController.abort('user cancelled')
+    releaseSend()
+    await streamPromise
+
+    await wait(10)
+    expect(core.countSentAborts()).toBe(1)
+  })
+
+  it('retries with fresh lifecycle wiring when autoReconnect kicks in after a disconnect', async () => {
+    const core = new MockCore()
+    const rpcLayer = createLayer(core)
+
+    const streamPromise = rpcLayer.call(
+      'users/feed',
+      {},
+      { _stream_response: true, autoReconnect: true, timeout: 30 },
+    )
+
+    core.emit(
+      'message',
+      { type: ServerMessageType.RpcStreamResponse, callId: 0 },
+      new Uint8Array([1]),
+    )
+
+    const iterable = await streamPromise
+    const iterator = iterable[Symbol.asyncIterator]()
+    const chunkPromise = iterator.next()
+    await Promise.resolve()
+
+    // drop the connection mid-stream: the wrapper must issue a second call;
+    // poll fast enough that the retry cannot time out while we wait
+    core.emit('disconnected', 'connection lost')
+    await vi.waitFor(() => expect(core.countSentRpcCalls()).toBe(2), {
+      interval: 1,
+    })
+
+    core.emit(
+      'message',
+      { type: ServerMessageType.RpcStreamResponse, callId: 1 },
+      new Uint8Array([1]),
+    )
+
+    // past the initial attempt's timeout: neither the stale initial timer nor
+    // a reused signal may kill the retried stream
+    await wait(60)
+
+    core.emit(
+      'message',
+      {
+        type: ServerMessageType.RpcStreamChunk,
+        callId: 1,
+        chunk: encodeJson({ n: 1 }),
+      },
+      new Uint8Array([2]),
+    )
+
+    await expect(chunkPromise).resolves.toEqual({
+      done: false,
+      value: { n: 1 },
+    })
     expect(core.countSentAborts()).toBe(0)
   })
 


### PR DESCRIPTION
Closes #210

## What was broken

`callInternal` composed one `AbortSignal` (per-call controller + timeout + user signal + connection signal via `AbortSignal.any`) and used it for request timeout, user abort, connection loss **and** internal cleanup:

- every settled WS unary call (success and failure) ran `controller.abort()` as cleanup, firing the armed abort listener and sending one stale `RpcAbort` frame per call
- a configured `timeout` was never detached once the stream response arrived, so at T+timeout it killed healthy stream RPCs mid-iteration on both transports (WS via the stream abort listener, HTTP by cancelling the fetch reader)
- a stream timeout fired both the global and the stream-specific listener on the same signal, sending duplicate `RpcAbort` frames
- after a stream completed normally the global listener stayed armed until timeout/disconnect eventually fired it, emitting a frame for an already-deleted callId

## The fix

The per-call signal is now composed by hand with detachable inputs, giving each call an explicit lifecycle (pending → settled | streaming → done):

- the request timeout is attached only for the pending phase and detached at the first response (unary result, stream response, or blob)
- the global abort listener is pending-phase only and removed explicitly once the call settles; during streaming the stream-specific listener owns aborts — exactly one `RpcAbort` per genuine cancel
- cleanup is listener removal, never `abort()`; a dedicated cancel controller keeps the genuine cancel channel for early consumer exit (`return`/`throw` on the iterable still send a real `RpcAbort`)
- all sources are detached when the iteration finishes (including on a failed read), so nothing stays armed on long-lived user/connection signals
- `autoReconnect` re-invokes `callInternal` per attempt, so each attempt gets its own pending-phase timeout and no stale timer survives a reconnect

## Tests

New `packages/client/tests/rpc-call-lifecycle.spec.ts` (6 of 7 fail before the fix): settled unary calls send no `RpcAbort` even with a timeout configured, streams survive past the timeout on both transports (HTTP fetch reader not cancelled), exactly one `RpcAbort` on consumer cancel, timeout during pending still aborts, no frame when the user signal fires after normal stream completion, and an `autoReconnect` stream is not killed by the initial attempt's timeout. Full suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RPC cancellation and timeout handling for unary and streaming calls.
  * Prevented unnecessary abort requests after calls complete or fail.
  * Streaming calls now remain active when appropriate during request timeouts and reconnects.
  * Improved cancellation when consumers stop reading streams or abort downloads.
  * Fixed cleanup of signal listeners after blob transfers settle, reducing lingering resources.
* **Reliability**
  * Improved handling of errors and race conditions during streaming and request completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->