### PR TITLE
http-transport: tie connection teardown to response-body lifetime

### DIFF
--- a/packages/gateway/src/connections.ts
+++ b/packages/gateway/src/connections.ts
@@ -17,6 +17,9 @@ export interface GatewayConnection {
   readonly encoder: BaseServerEncoder
   readonly decoder: BaseServerDecoder
   readonly abortController: AbortController
+  // call scopes deferred past onRpc (streamed HTTP bodies): teardown awaits
+  // these so call-scoped disposers finish before the connection container
+  readonly deferredCallDisposals: Set<Promise<void>>
 }
 
 export class ConnectionManager {

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -494,6 +494,7 @@ export class Gateway<
           encoder,
           decoder,
           abortController,
+          deferredCallDisposals: new Set(),
         }
 
         this.connections.add(connection)
@@ -749,15 +750,25 @@ export class Gateway<
           return result(async () => {
             await rpcContext[Symbol.asyncDispose]()
           })
-        } else if (result instanceof ProtocolBlob) {
-          // the blob body streams after onRpc returns: disposing the call
-          // scope now would kill the source (DI-scoped handles, abort wiring)
-          // mid-stream. The transport ties connection teardown to the response
-          // body's terminal state, so the connection abort doubles as the
-          // body-done signal for the call scope.
+        } else if (
+          result instanceof ProtocolBlob ||
+          (result instanceof Response && result.body !== null)
+        ) {
+          // blob and handler-built Response bodies stream after onRpc
+          // returns: disposing the call scope now would kill the source
+          // (DI-scoped handles, abort wiring) mid-stream. The transport ties
+          // connection teardown to the response body's terminal state, so the
+          // connection abort doubles as the body-done signal for the call
+          // scope; teardown awaits the tracked promise so the call scope
+          // settles before the connection container is disposed.
           const dispose = () => {
-            rpcContext[Symbol.asyncDispose]().catch((error) =>
-              logger.error({ error }, 'Error disposing blob call context'),
+            connection.deferredCallDisposals.add(
+              rpcContext[Symbol.asyncDispose]().catch((error) =>
+                logger.error(
+                  { error },
+                  'Error disposing streamed call context',
+                ),
+              ),
             )
           }
           const { signal } = connection.abortController
@@ -1070,6 +1081,10 @@ export class Gateway<
       await guard(() => transportWorker?.close?.(connectionId, close))
     }
     await guard(() => connection.abortController.abort())
+    // the abort above triggers deferred call-scope disposal (streamed HTTP
+    // bodies); await it so call-scoped disposers finish before their parent
+    // connection container goes down
+    await guard(() => Promise.all(connection.deferredCallDisposals))
     await guard(() => this.rpcs.close(connectionId))
     await guard(() => this.releaseRpcStreamCredits(connectionId))
     await guard(() => this.blobStreams.cleanupConnection(connectionId))

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -749,6 +749,21 @@ export class Gateway<
           return result(async () => {
             await rpcContext[Symbol.asyncDispose]()
           })
+        } else if (result instanceof ProtocolBlob) {
+          // the blob body streams after onRpc returns: disposing the call
+          // scope now would kill the source (DI-scoped handles, abort wiring)
+          // mid-stream. The transport ties connection teardown to the response
+          // body's terminal state, so the connection abort doubles as the
+          // body-done signal for the call scope.
+          const dispose = () => {
+            rpcContext[Symbol.asyncDispose]().catch((error) =>
+              logger.error({ error }, 'Error disposing blob call context'),
+            )
+          }
+          const { signal } = connection.abortController
+          if (signal.aborted) dispose()
+          else signal.addEventListener('abort', dispose, { once: true })
+          return result
         } else {
           await rpcContext[Symbol.asyncDispose]()
           return result

--- a/packages/gateway/tests/connections.spec.ts
+++ b/packages/gateway/tests/connections.spec.ts
@@ -18,6 +18,7 @@ const createMockConnection = (
   encoder: {} as GatewayConnection['encoder'],
   decoder: {} as GatewayConnection['decoder'],
   abortController: new AbortController(),
+  deferredCallDisposals: new Set(),
   ...overrides,
 })
 

--- a/packages/gateway/tests/gateway.spec.ts
+++ b/packages/gateway/tests/gateway.spec.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'node:buffer'
+import { setTimeout as delay } from 'node:timers/promises'
 
 import { createFactoryInjectable, Hooks, Scope } from '@nmtjs/core'
 import {
@@ -252,6 +253,82 @@ describe('Gateway HTTP onRpc call-scope lifetime', () => {
 
     await params.onDisconnect(connection.id)
     await vi.waitFor(() => expect(disposeSpy).toHaveBeenCalledTimes(1))
+
+    await gateway.stop()
+  })
+
+  it('keeps the call scope alive for streamed Response results until connection teardown', async () => {
+    const disposeSpy = vi.fn()
+    const callScoped = createFactoryInjectable({
+      scope: Scope.Call,
+      create: () => 'resource',
+      dispose: disposeSpy,
+    })
+
+    const { gateway, params, connection } = await createHttpGateway(
+      async (container) => {
+        await container.resolve(callScoped)
+        // a handler-built Response whose body streams from a call-scoped
+        // resource — same lifetime class as a blob download
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array(8))
+              controller.close()
+            },
+          }),
+        )
+      },
+    )
+
+    const result = await params.onRpc(
+      connection,
+      rpc,
+      new AbortController().signal,
+    )
+
+    expect(result).toBeInstanceOf(Response)
+    expect(disposeSpy).not.toHaveBeenCalled()
+
+    await params.onDisconnect(connection.id)
+    await vi.waitFor(() => expect(disposeSpy).toHaveBeenCalledTimes(1))
+
+    await gateway.stop()
+  })
+
+  it('finishes deferred call-scope disposal before the connection container', async () => {
+    const order: string[] = []
+    const callScoped = createFactoryInjectable({
+      scope: Scope.Call,
+      create: () => 'call',
+      dispose: async () => {
+        order.push('call:start')
+        await delay(20)
+        order.push('call:end')
+      },
+    })
+    const connectionScoped = createFactoryInjectable({
+      scope: Scope.Connection,
+      create: () => 'connection',
+      dispose: () => {
+        order.push('connection')
+      },
+    })
+
+    const { gateway, params, connection } = await createHttpGateway(
+      async (container) => {
+        await container.resolve(callScoped)
+        await container.resolve(connectionScoped)
+        return ProtocolBlob.from('data')
+      },
+    )
+
+    await params.onRpc(connection, rpc, new AbortController().signal)
+    await params.onDisconnect(connection.id)
+
+    // a call-scoped disposer may still be using connection-scoped deps:
+    // teardown must not dispose the connection container underneath it
+    expect(order).toEqual(['call:start', 'call:end', 'connection'])
 
     await gateway.stop()
   })

--- a/packages/gateway/tests/gateway.spec.ts
+++ b/packages/gateway/tests/gateway.spec.ts
@@ -1,10 +1,11 @@
 import { Buffer } from 'node:buffer'
 
-import { Hooks } from '@nmtjs/core'
+import { createFactoryInjectable, Hooks, Scope } from '@nmtjs/core'
 import {
   ClientMessageType,
   ConnectionType,
   createProtocolBlobReference,
+  ProtocolBlob,
   ProtocolVersion,
   ServerMessageType,
 } from '@nmtjs/protocol'
@@ -174,6 +175,107 @@ describe('Gateway RPC handling', () => {
 
     expect(sent.length).toBe(2)
 
+    await gateway.stop()
+  })
+})
+
+describe('Gateway HTTP onRpc call-scope lifetime', () => {
+  async function createHttpGateway(call: (container: any) => Promise<unknown>) {
+    const logger = createTestLogger()
+    const container = createTestContainer({ logger })
+    const serverFormat = createTestServerFormat()
+
+    const api: GatewayApi = {
+      resolve: vi.fn(async () => ({ name: 'test', stream: false })),
+      call: vi.fn(async ({ container }) => await call(container)),
+    }
+
+    let params: any
+    const transport = {
+      start: vi.fn(async (_params) => {
+        params = _params
+        return 'test://'
+      }),
+      stop: vi.fn(async () => {}),
+    }
+
+    const gateway = new Gateway({
+      logger,
+      container,
+      hooks: new Hooks(),
+      formats: new ProtocolFormats([serverFormat]),
+      transports: { test: { transport } },
+      api,
+      heartbeat: false,
+    })
+
+    await gateway.start()
+
+    const connection = await params.onConnect({
+      type: ConnectionType.Unidirectional,
+      protocolVersion: ProtocolVersion.v1,
+      accept: serverFormat.contentType,
+      contentType: serverFormat.contentType,
+      data: {},
+    })
+
+    return { gateway, params, connection }
+  }
+
+  const rpc = { callId: 0, payload: undefined, procedure: 'test' }
+
+  it('keeps the call scope alive for blob results until connection teardown', async () => {
+    const disposeSpy = vi.fn()
+    const callScoped = createFactoryInjectable({
+      scope: Scope.Call,
+      create: () => 'resource',
+      dispose: disposeSpy,
+    })
+
+    const { gateway, params, connection } = await createHttpGateway(
+      async (container) => {
+        await container.resolve(callScoped)
+        return ProtocolBlob.from('data')
+      },
+    )
+
+    const result = await params.onRpc(
+      connection,
+      rpc,
+      new AbortController().signal,
+    )
+
+    expect(result).toBeInstanceOf(ProtocolBlob)
+    // the blob body streams after onRpc returns — disposing the call scope
+    // here would kill DI-scoped sources mid-stream
+    expect(disposeSpy).not.toHaveBeenCalled()
+
+    await params.onDisconnect(connection.id)
+    await vi.waitFor(() => expect(disposeSpy).toHaveBeenCalledTimes(1))
+
+    await gateway.stop()
+  })
+
+  it('still disposes the call scope immediately for buffered results', async () => {
+    const disposeSpy = vi.fn()
+    const callScoped = createFactoryInjectable({
+      scope: Scope.Call,
+      create: () => 'resource',
+      dispose: disposeSpy,
+    })
+
+    const { gateway, params, connection } = await createHttpGateway(
+      async (container) => {
+        await container.resolve(callScoped)
+        return { ok: true }
+      },
+    )
+
+    await params.onRpc(connection, rpc, new AbortController().signal)
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+
+    await params.onDisconnect(connection.id)
     await gateway.stop()
   })
 })

--- a/packages/http-transport/src/runtimes/node.ts
+++ b/packages/http-transport/src/runtimes/node.ts
@@ -201,7 +201,9 @@ async function handleResponseBody(
   await handleChunkedStream(res, response.body)
 }
 
-async function handleFixedLengthStream(
+// exported for tests: the abort-during-backpressure path needs deterministic
+// coverage against a controlled response double
+export async function handleFixedLengthStream(
   res: UwsResponse,
   body: ReadableStream<Uint8Array>,
   totalSize: number,
@@ -290,6 +292,7 @@ function handleFixedChunk(
 
     const write = (offset: number) => {
       if (res.aborted) {
+        res.wakeWritable = undefined
         reject(new Error('Response aborted'))
         return false
       }
@@ -305,11 +308,18 @@ function handleFixedChunk(
       })
 
       if (done || ok) {
+        res.wakeWritable = undefined
         resolve(done)
         return ok
       }
 
       res.onWritable(write)
+      // uWS never fires onWritable after abort: hook the abort waker so a
+      // disconnect settles the wait instead of leaking the pump forever
+      res.wakeWritable = () => {
+        res.wakeWritable = undefined
+        reject(new Error('Response aborted'))
+      }
       return ok
     }
 

--- a/packages/http-transport/src/runtimes/node.ts
+++ b/packages/http-transport/src/runtimes/node.ts
@@ -223,7 +223,9 @@ async function handleFixedLengthStream(
 
     if (!responded && !res.aborted) res.cork(() => res.close())
   } finally {
-    reader.releaseLock()
+    // tryEnd reports done without draining the source's final read, so
+    // cancel (not just release) — body finalizers rely on a terminal state
+    reader.cancel().catch(() => {})
   }
 }
 

--- a/packages/http-transport/src/server.ts
+++ b/packages/http-transport/src/server.ts
@@ -4,7 +4,12 @@ import { pipeline } from 'node:stream/promises'
 
 import type { ApplicationResolvedProcedure } from '@nmtjs/application'
 import type { TransportWorker, TransportWorkerParams } from '@nmtjs/gateway'
-import { anyAbortSignal, isAbortError, isAsyncIterable } from '@nmtjs/common'
+import {
+  anyAbortSignal,
+  isAbortError,
+  isAsyncIterable,
+  noopFn,
+} from '@nmtjs/common'
 import { provision } from '@nmtjs/core'
 import {
   ConnectionType,
@@ -159,15 +164,31 @@ export class HttpTransportServer implements TransportWorker<
         ? accept
         : '*/*'
 
-    await using connection = await this.params.onConnect({
-      accept: negotiableAccept,
-      contentType: isBlob || !contentType ? '*/*' : contentType,
-      data: request,
-      protocolVersion: ProtocolVersion.v1,
-      type: ConnectionType.Unidirectional,
-    })
+    // The connection scope (abort signal + connection-scoped DI) must outlive
+    // streamed response bodies, which are consumed after this handler
+    // returns. Buffered paths dispose in the finally below; streamed paths
+    // hand ownership to a body finalizer instead.
+    let connection: Awaited<ReturnType<typeof this.params.onConnect>> | null =
+      null
+    let streamed = false
+    let disposed = false
+    const disposeConnection = async () => {
+      if (disposed || !connection) return
+      disposed = true
+      await connection[Symbol.asyncDispose]()
+    }
 
     try {
+      // Inside the try so format negotiation failures map to 415/406 below
+      // instead of escaping to the runtime as a generic 500
+      connection = await this.params.onConnect({
+        accept: negotiableAccept,
+        contentType: isBlob || !contentType ? '*/*' : contentType,
+        data: request,
+        protocolVersion: ProtocolVersion.v1,
+        type: ConnectionType.Unidirectional,
+      })
+
       const resolved = await this.params.resolve(connection, procedure)
 
       const allowHttpMethod =
@@ -250,7 +271,16 @@ export class HttpTransportServer implements TransportWorker<
           else responseHeaders.set(key, value)
         })
 
-        return new Response(body, {
+        // A handler-built Response may carry a streamed body; runtimes answer
+        // Content-Length: 0 without ever touching it, so an empty body must
+        // not wait on a finalizer that would never fire
+        const streamedBody =
+          body !== null && headers.get('content-length') !== '0'
+        const finalizedBody = streamedBody
+          ? this.finalizeOnBodyEnd(body!, signal, disposeConnection)
+          : body
+        streamed = streamedBody
+        return new Response(finalizedBody, {
           status,
           statusText,
           headers: responseHeaders,
@@ -283,7 +313,15 @@ export class HttpTransportServer implements TransportWorker<
           throw new Error('Invalid stream source')
         }
 
-        return new Response(stream, {
+        // Runtimes answer Content-Length: 0 without ever touching the body,
+        // so an empty blob must not wait on a body finalizer that would
+        // never fire
+        const finalizedBody =
+          metadata.size !== 0
+            ? this.finalizeOnBodyEnd(stream, signal, disposeConnection)
+            : stream
+        streamed = metadata.size !== 0
+        return new Response(finalizedBody, {
           status: HttpStatus.OK,
           statusText: HttpStatusText[HttpStatus.OK],
           headers: responseHeaders,
@@ -296,27 +334,44 @@ export class HttpTransportServer implements TransportWorker<
           connection.encoder.contentType,
         )
         responseHeaders.set('X-Accel-Buffering', 'no')
+        const encoder = connection.encoder
+        const iterator = result[Symbol.asyncIterator]()
+        const sseEncoder = new TextEncoder()
         const stream = new ReadableStream({
-          async start(controller) {
-            const encoder = new TextEncoder()
+          // pull-driven: the consumer's demand paces the generator instead of
+          // an eager pump buffering an unbounded backlog
+          async pull(controller) {
             try {
-              for await (const chunk of result) {
-                const encoded = connection.encoder.encode(chunk)
-                const base64 = Buffer.from(
-                  encoded.buffer,
-                  encoded.byteOffset,
-                  encoded.byteLength,
-                ).toString('base64')
-                controller.enqueue(encoder.encode(`data: ${base64}\n\n`))
+              const { done, value } = await iterator.next()
+              if (done) {
+                controller.close()
+                return
               }
-              controller.close()
+              const encoded = encoder.encode(value)
+              const base64 = Buffer.from(
+                encoded.buffer,
+                encoded.byteOffset,
+                encoded.byteLength,
+              ).toString('base64')
+              controller.enqueue(sseEncoder.encode(`data: ${base64}\n\n`))
             } catch (error) {
               if (isAbortError(error)) controller.close()
               else controller.error(error)
             }
           },
+          // client disconnect must unwind the handler generator, or an
+          // idle-waiting iterator (and its call scope) leaks forever
+          async cancel() {
+            await iterator.return?.()
+          },
         })
-        return new Response(stream, {
+        const finalizedBody = this.finalizeOnBodyEnd(
+          stream,
+          signal,
+          disposeConnection,
+        )
+        streamed = true
+        return new Response(finalizedBody, {
           status: HttpStatus.OK,
           statusText: HttpStatusText[HttpStatus.OK],
           headers: responseHeaders,
@@ -363,7 +418,7 @@ export class HttpTransportServer implements TransportWorker<
         })
       }
 
-      if (error instanceof ProtocolError) {
+      if (connection && error instanceof ProtocolError) {
         const status =
           error.code in HttpCodeMap
             ? HttpCodeMap[error.code]
@@ -384,21 +439,85 @@ export class HttpTransportServer implements TransportWorker<
       // this.logError(error, 'Unknown error while processing HTTP request')
       console.error(error)
 
-      const payload = connection.encoder.encode(
-        new ProtocolError(
-          ErrorCode.InternalServerError,
-          'Internal Server Error',
-        ),
-      )
-      responseHeaders.set('Content-Type', connection.encoder.contentType)
+      if (connection) {
+        const payload = connection.encoder.encode(
+          new ProtocolError(
+            ErrorCode.InternalServerError,
+            'Internal Server Error',
+          ),
+        )
+        responseHeaders.set('Content-Type', connection.encoder.contentType)
 
-      // @ts-expect-error
-      return new Response(payload, {
+        // @ts-expect-error
+        return new Response(payload, {
+          status: HttpStatus.InternalServerError,
+          statusText: HttpStatusText[HttpStatus.InternalServerError],
+          headers: responseHeaders,
+        })
+      }
+
+      // onConnect failed before a format was negotiated — there is no
+      // encoder to build a protocol error with
+      return new Response(HttpStatusText[HttpStatus.InternalServerError], {
         status: HttpStatus.InternalServerError,
         statusText: HttpStatusText[HttpStatus.InternalServerError],
         headers: responseHeaders,
       })
+    } finally {
+      // buffered responses and every error path keep the old
+      // dispose-at-return semantics; streamed bodies own their teardown
+      if (!streamed) await disposeConnection()
     }
+  }
+
+  /**
+   * Streamed bodies outlive httpHandler, so connection teardown must wait for
+   * the body's terminal state: close, error and cancel all funnel into the
+   * same idempotent finalizer. The request abort signal is wired in as a
+   * backstop for runtimes that drop a response without cancelling its body.
+   */
+  private finalizeOnBodyEnd(
+    body: ReadableStream,
+    signal: AbortSignal,
+    finalize: () => Promise<void>,
+  ): ReadableStream {
+    const reader = body.getReader()
+    const onAbort = () => {
+      // finalize first: aborting the connection signal wakes handlers
+      // idle-waiting inside the source, letting cancellation unwind them
+      void finalize()
+      reader.cancel(signal.reason).catch(noopFn)
+    }
+    const settle = () => {
+      signal.removeEventListener('abort', onAbort)
+      return finalize()
+    }
+    if (signal.aborted) onAbort()
+    else signal.addEventListener('abort', onAbort, { once: true })
+
+    return new ReadableStream({
+      async pull(controller) {
+        let result: Awaited<ReturnType<typeof reader.read>>
+        try {
+          result = await reader.read()
+        } catch (error) {
+          await settle()
+          controller.error(error)
+          return
+        }
+        if (result.done) {
+          await settle()
+          controller.close()
+        } else {
+          controller.enqueue(result.value)
+        }
+      },
+      async cancel(reason) {
+        const finalized = settle()
+        await reader.cancel(reason).catch(noopFn)
+        await finalized
+      },
+    })
   }
 
   private createBodySizeGuard() {

--- a/packages/http-transport/src/server.ts
+++ b/packages/http-transport/src/server.ts
@@ -171,11 +171,13 @@ export class HttpTransportServer implements TransportWorker<
     let connection: Awaited<ReturnType<typeof this.params.onConnect>> | null =
       null
     let streamed = false
-    let disposed = false
-    const disposeConnection = async () => {
-      if (disposed || !connection) return
-      disposed = true
-      await connection[Symbol.asyncDispose]()
+    let disposal: Promise<void> | null = null
+    const disposeConnection = () => {
+      // single-flight: a finalizer racing another (abort backstop vs body
+      // cancel/close) must await the same in-flight teardown instead of
+      // resolving while it is still running
+      if (!connection) return Promise.resolve()
+      return (disposal ??= Promise.resolve(connection[Symbol.asyncDispose]()))
     }
 
     try {
@@ -355,6 +357,13 @@ export class HttpTransportServer implements TransportWorker<
               ).toString('base64')
               controller.enqueue(sseEncoder.encode(`data: ${base64}\n\n`))
             } catch (error) {
+              // nothing cancels a closed/errored stream, so unwind the
+              // generator here (e.g. on encode failure) or a handler
+              // suspended at yield leaks with its call scope forever;
+              // a no-op when the failure came from next() itself
+              try {
+                await iterator.return?.()
+              } catch {}
               if (isAbortError(error)) controller.close()
               else controller.error(error)
             }
@@ -485,7 +494,7 @@ export class HttpTransportServer implements TransportWorker<
     const onAbort = () => {
       // finalize first: aborting the connection signal wakes handlers
       // idle-waiting inside the source, letting cancellation unwind them
-      void finalize()
+      finalize().catch(noopFn)
       reader.cancel(signal.reason).catch(noopFn)
     }
     const settle = () => {

--- a/packages/http-transport/tests/node-runtime.spec.ts
+++ b/packages/http-transport/tests/node-runtime.spec.ts
@@ -1,5 +1,6 @@
 import { setTimeout as delay } from 'node:timers/promises'
 
+import { ProtocolBlob } from '@nmtjs/protocol'
 import { BaseServerFormat, ProtocolFormats } from '@nmtjs/protocol/server'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -63,6 +64,7 @@ async function startServer(onRpc?: (...args: any[]) => Promise<unknown>) {
   return {
     url,
     requests,
+    connection,
     stop: () => worker.stop(params as any),
   }
 }
@@ -101,6 +103,68 @@ describe('node runtime adapter', () => {
         const response = await fetch(`${url}/test`)
         expect(response.status).toBe(200)
         expect(requests[0]?.url.protocol).toBe('http:')
+      } finally {
+        await stop()
+      }
+    })
+  })
+
+  describe('SSE client disconnect', () => {
+    it('finalizes the handler generator and disposes the connection', async () => {
+      let finalized = false
+      const { url, connection, stop } = await startServer(async () =>
+        (async function* () {
+          try {
+            let n = 0
+            while (true) {
+              yield { n: n++ }
+              await delay(5)
+            }
+          } finally {
+            finalized = true
+          }
+        })(),
+      )
+      const dispose = vi.fn(async () => {})
+      ;(connection as any)[Symbol.asyncDispose] = dispose
+
+      try {
+        const controller = new AbortController()
+        const response = await fetch(`${url}/test`, {
+          signal: controller.signal,
+        })
+        expect(response.headers.get('content-type')).toBe('text/event-stream')
+
+        const reader = response.body!.getReader()
+        await reader.read()
+        controller.abort()
+
+        await vi.waitFor(() => {
+          expect(finalized).toBe(true)
+          expect(dispose).toHaveBeenCalled()
+        })
+      } finally {
+        await stop()
+      }
+    })
+  })
+
+  describe('blob download connection lifetime', () => {
+    it('disposes the connection after a fixed-length body is fully served', async () => {
+      const { url, connection, stop } = await startServer(async () =>
+        ProtocolBlob.from('hello world'),
+      )
+      const dispose = vi.fn(async () => {})
+      ;(connection as any)[Symbol.asyncDispose] = dispose
+
+      try {
+        const response = await fetch(`${url}/test`, { method: 'POST' })
+        expect(response.headers.get('content-length')).toBe('11')
+        expect(await response.text()).toBe('hello world')
+
+        // the fixed-length pump ends at tryEnd-done: the body finalizer must
+        // still reach its terminal state and tear the connection down
+        await vi.waitFor(() => expect(dispose).toHaveBeenCalled())
       } finally {
         await stop()
       }

--- a/packages/http-transport/tests/node-runtime.spec.ts
+++ b/packages/http-transport/tests/node-runtime.spec.ts
@@ -5,7 +5,11 @@ import { BaseServerFormat, ProtocolFormats } from '@nmtjs/protocol/server'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { HttpTransportServerRequest } from '../src/types.ts'
-import { handleChunkedStream, HttpTransport } from '../src/runtimes/node.ts'
+import {
+  handleChunkedStream,
+  handleFixedLengthStream,
+  HttpTransport,
+} from '../src/runtimes/node.ts'
 
 class TestJsonFormat extends BaseServerFormat {
   accept = ['application/json']
@@ -205,6 +209,53 @@ describe('node runtime adapter', () => {
       } finally {
         await stop()
       }
+    })
+  })
+
+  describe('handleFixedLengthStream abort during backpressure', () => {
+    const tick = () => new Promise((resolve) => setImmediate(resolve))
+
+    it('settles the pump and cancels the reader when the client aborts', async () => {
+      let cancelled = false
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(8))
+        },
+        cancel() {
+          cancelled = true
+        },
+      })
+      let registrations = 0
+      const res: any = {
+        aborted: false,
+        wakeWritable: undefined,
+        cork(cb: () => void) {
+          cb()
+          return res
+        },
+        getWriteOffset: () => 0,
+        // backpressured and not done: the pump parks waiting for a drain
+        // that never comes once the client disconnects
+        tryEnd: () => [false, false],
+        onWritable() {
+          registrations++
+          return res
+        },
+      }
+
+      const pump = handleFixedLengthStream(res, body, 16)
+      await tick()
+      expect(registrations).toBe(1)
+
+      // mirrors what the route's onAborted handler does
+      res.aborted = true
+      res.wakeWritable?.()
+      res.cancelBody?.()
+
+      await expect(pump).rejects.toThrow('Response aborted')
+      // the finally must reach reader.cancel so wrapped bodies (and their
+      // connection finalizers) still hit a terminal state
+      expect(cancelled).toBe(true)
     })
   })
 

--- a/packages/http-transport/tests/server-lifecycle.spec.ts
+++ b/packages/http-transport/tests/server-lifecycle.spec.ts
@@ -102,6 +102,44 @@ describe('connection lifetime vs response body lifetime', () => {
       expect(dispose).toHaveBeenCalledTimes(1)
     })
 
+    it('makes concurrent finalizers await the same in-flight disposal', async () => {
+      let resolveDisposal!: () => void
+      const { params, connection } = createTestParams(
+        vi.fn(async () => ProtocolBlob.from('hello world')) as any,
+      )
+      const dispose = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveDisposal = resolve
+          }),
+      )
+      ;(connection as any)[Symbol.asyncDispose] = dispose
+      const server = await createTestServer({}, params)
+
+      const abortController = new AbortController()
+      const response = await server.httpHandler(
+        createTestRequest({}),
+        null,
+        abortController.signal,
+      )
+
+      // abort backstop starts the (slow) disposal…
+      abortController.abort()
+      expect(dispose).toHaveBeenCalledTimes(1)
+
+      // …and a racing cancel must ride it instead of resolving early
+      let cancelled = false
+      const cancelPromise = response.body!.cancel().then(() => {
+        cancelled = true
+      })
+      await tick()
+      expect(cancelled).toBe(false)
+
+      resolveDisposal()
+      await cancelPromise
+      expect(dispose).toHaveBeenCalledTimes(1)
+    })
+
     it('disposes the connection at return for zero-byte blobs', async () => {
       // runtimes answer Content-Length: 0 without touching the body, so the
       // connection must not wait on a body finalizer that would never fire
@@ -195,6 +233,75 @@ describe('connection lifetime vs response body lifetime', () => {
 
       expect(finalized).toBe(true)
       expect(dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('unwinds the generator when encoding a chunk fails', async () => {
+      let finalized = false
+      const { server, dispose } = await createLifecycleServer(async () =>
+        (async function* () {
+          try {
+            // the JSON test encoder rejects BigInt: encode throws while the
+            // generator is suspended at this yield
+            yield { n: 1n }
+            yield { n: 2 }
+          } finally {
+            finalized = true
+          }
+        })(),
+      )
+
+      const response = await server.httpHandler(
+        createTestRequest({}),
+        null,
+        new AbortController().signal,
+      )
+
+      // nothing cancels an errored stream — the pull path itself must
+      // return the generator or it leaks suspended forever
+      await expect(response.text()).rejects.toThrow()
+      expect(finalized).toBe(true)
+      expect(dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('unwinds a generator blocked inside next() when the request aborts', async () => {
+      let finalized = false
+      const { server, dispose } = await createLifecycleServer(
+        async (_connection: any, _rpc: any, signal: AbortSignal) =>
+          (async function* () {
+            try {
+              yield { ready: true }
+              // idle-wait for an event that never comes; only the rpc abort
+              // signal can wake it — the finalizer must fire it before
+              // cancelling the body so the queued return() can complete
+              await new Promise((_, reject) => {
+                signal.addEventListener('abort', () => reject(signal.reason), {
+                  once: true,
+                })
+              })
+            } finally {
+              finalized = true
+            }
+          })(),
+      )
+
+      const abortController = new AbortController()
+      const response = await server.httpHandler(
+        createTestRequest({}),
+        null,
+        abortController.signal,
+      )
+
+      const reader = response.body!.getReader()
+      await reader.read()
+      // park the source inside iterator.next() before disconnecting
+      const pending = reader.read().catch(() => {})
+      abortController.abort()
+
+      await pending
+      await vi.waitFor(() => {
+        expect(finalized).toBe(true)
+        expect(dispose).toHaveBeenCalledTimes(1)
+      })
     })
 
     it('finalizes on request abort even when the body is never consumed', async () => {

--- a/packages/http-transport/tests/server-lifecycle.spec.ts
+++ b/packages/http-transport/tests/server-lifecycle.spec.ts
@@ -1,0 +1,315 @@
+import { ProtocolBlob } from '@nmtjs/protocol'
+import {
+  UnsupportedAcceptTypeError,
+  UnsupportedContentTypeError,
+} from '@nmtjs/protocol/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createTestParams,
+  createTestRequest,
+  createTestServer,
+} from './_helpers/test-utils.ts'
+
+const tick = () => new Promise((resolve) => setImmediate(resolve))
+
+async function createLifecycleServer(onRpc: any) {
+  const { params, connection } = createTestParams(vi.fn(onRpc) as any)
+  const dispose = vi.fn(async () => {})
+  ;(connection as any)[Symbol.asyncDispose] = dispose
+  const server = await createTestServer({}, params)
+  return { server, params, dispose }
+}
+
+describe('connection lifetime vs response body lifetime', () => {
+  describe('buffered responses', () => {
+    it('disposes the connection before the handler returns', async () => {
+      const { server, dispose } = await createLifecycleServer(async () => ({
+        ok: true,
+      }))
+
+      const response = await server.httpHandler(
+        createTestRequest({}),
+        null,
+        new AbortController().signal,
+      )
+
+      expect(response.status).toBe(200)
+      expect(dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('disposes the connection on error responses', async () => {
+      const { server, dispose } = await createLifecycleServer(async () => {
+        throw new Error('boom')
+      })
+
+      const response = await server.httpHandler(
+        createTestRequest({}),
+        null,
+        new AbortController().signal,
+      )
+
+      expect(response.status).toBe(500)
+      expect(dispose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('blob download', () => {
+    it('keeps the connection alive until the body is fully consumed', async () => {
+      const { server, dispose } = await createLifecycleServer(async () =>
+        ProtocolBlob.from('hello world'),
+      )
+
+      const response = await server.httpHandler(
+        createTestRequest({}),
+        null,
+        new AbortController().signal,
+      )
+
+      // the body streams after the handler returned: the connection scope
+      // (abort signal + connection-scoped DI) must still be alive
+      expect(dispose).not.toHaveBeenCalled()
+
+      expect(await response.text()).toBe('hello world')
+      expect(dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('disposes the connection when the client cancels the body mid-stream', async () => {
+      let sourceCancelled = false
+      const source = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.enqueue(new Uint8Array(16))
+        },
+        cancel() {
+          sourceCancelled = true
+        },
+      })
+      const { server, dispose } = await createLifecycleServer(async () =>
+        ProtocolBlob.from(source),
+      )
+
+      const response = await server.httpHandler(
+        createTestRequest({}),
+        null,
+        new AbortController().signal,
+      )
+
+      const reader = response.body!.getReader()
+      await reader.read()
+      await reader.cancel('client disconnected')
+
+      expect(sourceCancelled).toBe(true)
+      expect(dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('disposes the connection at return for zero-byte blobs', async () => {
+      // runtimes answer Content-Length: 0 without touching the body, so the
+      // connection must not wait on a body finalizer that would never fire
+      const { server, dispose } = await createLifecycleServer(async () =>
+        ProtocolBlob.from(new Blob([])),
+      )
+
+      const response = await server.httpHandler(
+        createTestRequest({}),
+        null,
+        new AbortController().signal,
+      )
+
+      expect(response.headers.get('Content-Length')).toBe('0')
+      expect(dispose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('SSE streaming', () => {
+    const events = (...chunks: unknown[]) =>
+      async function* () {
+        yield* chunks
+      }
+
+    it('keeps the connection alive until the stream completes', async () => {
+      const { server, dispose } = await createLifecycleServer(async () =>
+        events({ n: 1 }, { n: 2 })(),
+      )
+
+      const response = await server.httpHandler(
+        createTestRequest({}),
+        null,
+        new AbortController().signal,
+      )
+
+      expect(response.headers.get('Content-Type')).toBe('text/event-stream')
+      expect(dispose).not.toHaveBeenCalled()
+
+      const body = await response.text()
+      expect(body.match(/^data: /gm)).toHaveLength(2)
+      expect(dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('is pull-driven instead of eagerly pumping the generator', async () => {
+      let produced = 0
+      const { server } = await createLifecycleServer(async () =>
+        (async function* () {
+          while (true) {
+            produced++
+            yield { produced }
+          }
+        })(),
+      )
+
+      const response = await server.httpHandler(
+        createTestRequest({}),
+        null,
+        new AbortController().signal,
+      )
+      await tick()
+
+      // without demand only queue pre-fill pulls may run; the old eager
+      // start() pump would advance the generator unboundedly
+      expect(produced).toBeLessThanOrEqual(2)
+
+      await response.body!.getReader().cancel()
+    })
+
+    it('returns the generator and disposes the connection on client disconnect', async () => {
+      let finalized = false
+      const { server, dispose } = await createLifecycleServer(async () =>
+        (async function* () {
+          try {
+            let n = 0
+            while (true) yield { n: n++ }
+          } finally {
+            finalized = true
+          }
+        })(),
+      )
+
+      const response = await server.httpHandler(
+        createTestRequest({}),
+        null,
+        new AbortController().signal,
+      )
+
+      const reader = response.body!.getReader()
+      await reader.read()
+      await reader.cancel('client disconnected')
+
+      expect(finalized).toBe(true)
+      expect(dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('finalizes on request abort even when the body is never consumed', async () => {
+      // mirrors the node runtime dropping an already-aborted response
+      // without reading or cancelling its body
+      let finalized = false
+      const { server, dispose } = await createLifecycleServer(async () =>
+        (async function* () {
+          try {
+            let n = 0
+            while (true) yield { n: n++ }
+          } finally {
+            finalized = true
+          }
+        })(),
+      )
+
+      const abortController = new AbortController()
+      await server.httpHandler(
+        createTestRequest({}),
+        null,
+        abortController.signal,
+      )
+
+      abortController.abort()
+      await tick()
+
+      expect(finalized).toBe(true)
+      expect(dispose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('format negotiation failures', () => {
+    it('maps an unsupported Accept type to 406', async () => {
+      const { params } = createTestParams()
+      params.onConnect = vi.fn(async () => {
+        throw new UnsupportedAcceptTypeError('Unsupported Accept type')
+      }) as any
+      const server = await createTestServer({}, params)
+
+      const response = await server.httpHandler(
+        createTestRequest({ accept: 'application/xml' }),
+        null,
+        new AbortController().signal,
+      )
+
+      expect(response.status).toBe(406)
+    })
+
+    it('maps an unsupported Content-Type to 415', async () => {
+      const { params } = createTestParams()
+      params.onConnect = vi.fn(async () => {
+        throw new UnsupportedContentTypeError('Unsupported Content type')
+      }) as any
+      const server = await createTestServer({}, params)
+
+      const response = await server.httpHandler(
+        createTestRequest({ 'content-type': 'application/xml' }),
+        null,
+        new AbortController().signal,
+      )
+
+      expect(response.status).toBe(415)
+    })
+
+    it('responds 500 without an encoder when onConnect fails otherwise', async () => {
+      const { params } = createTestParams()
+      params.onConnect = vi.fn(async () => {
+        throw new Error('identity failed')
+      }) as any
+      const server = await createTestServer({}, params)
+
+      const response = await server.httpHandler(
+        createTestRequest({}),
+        null,
+        new AbortController().signal,
+      )
+
+      expect(response.status).toBe(500)
+    })
+  })
+
+  describe('blob upload abort', () => {
+    it('errors the handler payload stream when the request body fails', async () => {
+      const bodyError = new Error('request aborted')
+      let observed: unknown
+      const { server } = await createLifecycleServer(
+        async (_connection: any, rpc: any) => {
+          try {
+            await rpc.payload.toArray()
+          } catch (error) {
+            observed = error
+          }
+          return { ok: true }
+        },
+      )
+
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(8))
+          controller.error(bodyError)
+        },
+      })
+
+      const response = await server.httpHandler(
+        createTestRequest({
+          'content-type': 'application/octet-stream',
+          'x-neemata-blob': 'true',
+        }),
+        body,
+        new AbortController().signal,
+      )
+
+      expect(response.status).toBe(200)
+      expect(observed).toBe(bodyError)
+    })
+  })
+})


### PR DESCRIPTION
Closes #209

## What was broken

`await using connection` at handler scope tore down the connection (abort signal + connection-scoped DI) the moment `httpHandler` returned, while SSE and blob bodies stream after return:

- streamed responses raced connection disposal — handlers observing `rpcAbortSignal` or using connection-scoped DI were killed mid-stream; blob downloads were worst since gateway `onRpc` also disposed the call scope immediately for non-function results
- the SSE `ReadableStream` pumped eagerly in `start()` (ignoring `desiredSize`), had no `cancel()` and never observed the request signal, so every SSE client disconnect leaked an idle-waiting handler generator
- format negotiation ran inside `onConnect` before the `try` that maps `UnsupportedFormatError`, making the 415/406 mapping dead code (clients got a generic 500)

## The fix

- streamed bodies (blob, SSE, handler-built `Response`) hand connection teardown to a single idempotent finalizer driven by the body's terminal state — close, error and cancel all funnel into it, with the request abort signal wired in as a backstop for runtimes that drop a response without cancelling its body; fully-buffered paths (and empty bodies, which runtimes answer without touching) keep the old dispose-at-return semantics, building on the single-flight `closeConnection`
- SSE is now a `pull()`-driven source paced by consumer demand, with a `cancel()` that returns the handler generator
- gateway `onRpc` defers call-scope disposal for `ProtocolBlob` results to connection teardown, so DI-scoped blob sources survive until the body is done
- `onConnect` moved inside the `try`: unsupported Accept/Content-Type now return 406/415; other `onConnect` failures return a plain 500 (no negotiated encoder exists yet)
- the node runtime's fixed-length pump cancels its reader at exit so wrapped bodies reach a terminal state even when the source outlasts the declared Content-Length

## Tests

- unit coverage for connection lifetime across buffered/blob/SSE/error paths: alive during streaming, disposed on completion, client cancel and unconsumed-body abort; SSE pull-pacing and generator finalization; 406/415 mapping; aborted blob upload erroring the handler's payload stream
- gateway coverage for blob call-scope deferral (alive after `onRpc`, disposed on teardown) and immediate disposal for buffered results
- end-to-end node runtime tests: SSE client disconnect finalizes the generator and disposes the connection; fixed-length blob download tears down after the body is served

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response lifecycles so call-scoped resources stay alive until blob bodies and SSE streams complete, and are cleaned up correctly on disconnect/cancellation.
  * Fixed fixed-length stream cleanup to properly cancel readers and avoid hangs during aborted writes.
  * Improved format negotiation errors: unsupported accept/content types now map to HTTP 406/415, with safer fallback behavior when connection setup fails.
* **Tests**
  * Added/expanded lifecycle and call-scope disposal coverage for buffered, blob, SSE, and abort scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->