### PR TITLE
workflows: serialize integration spec files to avoid TRUNCATE deadlocks

### DIFF
--- a/packages/workflows/vitest.config.ts
+++ b/packages/workflows/vitest.config.ts
@@ -14,6 +14,10 @@ export default defineProject({
     // integration scenarios race real workers on real clocks; absorb rare
     // load-induced timing misses without masking consistent regressions
     retry: includeIntegration ? 1 : 0,
+    // integration specs share one Postgres database and truncate the same
+    // workflow tables per harness; parallel spec files deadlock TRUNCATE
+    // against in-flight worker transactions (issue #257)
+    fileParallelism: includeIntegration ? false : undefined,
     typecheck: { enabled: true, tsconfig: './tsconfig.json' },
   },
 })


### PR DESCRIPTION
Closes #257

The workflows integration spec files share one Postgres database and each harness runs `TRUNCATE ... RESTART IDENTITY CASCADE` on the same seven workflow tables at setup/cleanup. Vitest runs spec files in parallel by default, so one file's truncate races another file's in-flight worker transactions — deadlocking in the worst case (40P01, seen on PR #256 CI) and causing the chronic `(retry x1)` marks on green runs.

This disables `fileParallelism` for the integration config only, so spec files run serially. Tests within a file were already sequential, and `afterEach` awaits every harness cleanup (including `pool.end()`) before the next test, so this closes the race structurally. Unit tests keep default parallelism.

Why not the other options from the issue:

- **Per-spec-file schemas** — the Postgres adapter emits unqualified table names and `installPostgresWorkflowSchemaForTesting` guards `CREATE TYPE` with database-wide `pg_type` lookups, so schema isolation would skip creating enum types in the second schema and break; disproportionate rework for a 3-file suite.
- **Draining workers before truncate** — only narrows the window; any poller mid-transaction still deadlocks.

CI applies the option as expected: `test:integration:services` runs each package's vitest config standalone (not through the root `projects` workspace), where `fileParallelism` is honored. The pubsub integration suite uses randomized per-test names and never truncates, so it's unaffected. The cost is wall-clock: the three files' runtimes now sum instead of overlap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration test reliability by preventing conflicting parallel execution that could cause database operation deadlocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->