### PR TITLE
ci: migrate from Blacksmith to GitHub-hosted runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,8 +42,8 @@ jobs:
         node:
           - 24
         os:
-          - blacksmith-4vcpu-ubuntu-2404
-          - blacksmith-6vcpu-macos-26
+          - ubuntu-24.04
+          - macos-26
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -69,11 +69,11 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - run: pnpm install
       - name: Install Playwright browser (Linux)
-        if: matrix.os == 'blacksmith-4vcpu-ubuntu-2404'
+        if: runner.os == 'Linux'
         run: |
           pnpm exec playwright install --with-deps chromium firefox webkit
       - name: Install Playwright browser (macOS)
-        if: matrix.os == 'blacksmith-6vcpu-macos-26'
+        if: runner.os == 'macOS'
         run: |
           pnpm exec playwright install chromium firefox webkit
       - run: |
@@ -83,7 +83,7 @@ jobs:
 
   tests-integration-services:
     needs: [ lint ]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     services:
       redis:
         image: redis:8-alpine


### PR DESCRIPTION
Replaces Blacksmith runner labels in `test.yml` with GitHub-hosted equivalents:

- `blacksmith-4vcpu-ubuntu-2404` → `ubuntu-24.04` (lint, tests matrix, integration services)
- `blacksmith-6vcpu-macos-26` → `macos-26` (tests matrix)

The OS-specific Playwright install steps now branch on `runner.os` instead of hardcoded runner labels, so they no longer need updating if runner labels change again.

No caching changes were needed — the workflows already use `actions/cache@v4` rather than Blacksmith's cache action. `claude.yml` and `publish.yml` were already on GitHub-hosted runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated linting and integration test environments to use Ubuntu 24.04.
  * Expanded test coverage across Ubuntu 24.04 and macOS 26.
  * Improved Playwright browser setup for Linux and macOS test runs by simplifying OS-based installation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->