### PR TITLE
ci: add CodeRabbit config focused on correctness reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+language: en-US
+tone_instructions: >-
+  Focus exclusively on correctness: bugs, logic errors, race conditions, data
+  loss, and security issues. Do not comment on formatting, naming, code style,
+  or aesthetics.
+
+reviews:
+  profile: chill
+  poem: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  suggested_labels: false
+  suggested_reviewers: false
+  path_instructions:
+    - path: '**'
+      instructions: |
+        Only flag issues that affect runtime behavior or correctness:
+        - logic errors, wrong conditions, off-by-one mistakes
+        - concurrency bugs, race conditions, unhandled promise rejections
+        - resource leaks, missing cleanup, gaps in error handling
+        - protocol/API contract violations, unsound type assertions
+        - security vulnerabilities
+
+        Do NOT comment on: formatting, whitespace, naming preferences, import
+        ordering, comment or documentation wording, or stylistic refactors that
+        do not change behavior. Linting and formatting are already enforced by
+        oxlint in CI.
+  finishing_touches:
+    docstrings:
+      enabled: false
+  pre_merge_checks:
+    docstrings:
+      mode: 'off'
+  tools:
+    # style/prose linters — not correctness, covered locally or irrelevant
+    markdownlint:
+      enabled: false
+    languagetool:
+      enabled: false
+    yamllint:
+      enabled: false
+    # already enforced via oxlint in CI, avoid duplicate noise
+    oxc:
+      enabled: false
+    biome:
+      enabled: false


### PR DESCRIPTION
Adds `.coderabbit.yaml` to steer CodeRabbit reviews toward correctness and away from style noise:

- Global tone and `path_instructions` restrict comments to bugs, logic errors, concurrency issues, resource leaks, contract violations, and security — explicitly excluding formatting, naming, and stylistic refactors.
- Disables style/prose linters (`markdownlint`, `languagetool`, `yamllint`) and `oxc`/`biome`, since linting is already enforced by oxlint in CI. Security and bug-finding tools stay enabled.
- Turns off review fluff: poems, sequence diagrams, effort estimates, label/reviewer suggestions, and docstring generation/checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CodeRabbit configuration to generate automated review feedback focused on correctness, security, logic errors, and race conditions.
  * Reduced review noise by disabling formatting/style guidance and other non-behavioral commentary (including documentation and aesthetic checks).
  * Turned off several ancillary automated linting tools and supplemental review features to streamline the review output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->