### PR TITLE
workflows: registry-free enqueue — retry resolves definitions instead of implementations

### DIFF
--- a/packages/workflows/src/runtime/client.ts
+++ b/packages/workflows/src/runtime/client.ts
@@ -5,6 +5,7 @@ import type {
 import type {
   AnyTaskDefinition,
   AnyWorkflowDefinition,
+  RunnableDefinition,
   RunUniqueConstraint,
   TaskInput,
   TaskRun,
@@ -110,8 +111,21 @@ export type WorkflowRuntimeAdapter<Connection = never> = {
 
 export type CreateWorkflowRuntimeClientInput<Connection = never> =
   WorkflowRuntimeAdapter<Connection> & {
+    /**
+     * Implementations are consulted only to cross-check `start()` targets and
+     * to resolve `retry()` by name — enqueueing itself never executes them.
+     * Omit them on enqueue-only surfaces so importing the client never drags
+     * the implementation graph into the caller's import closure (an
+     * implementation that enqueues would otherwise form a cycle).
+     */
     readonly workflows?: readonly RegisteredWorkflowImplementation[]
     readonly tasks?: readonly RegisteredTaskImplementation[]
+    /**
+     * Name→definition source for `retry()` and future by-name operations.
+     * Definitions live in leaf modules both sides can import, so management
+     * surfaces resolve stored names without touching implementation code.
+     */
+    readonly definitions?: readonly RunnableDefinition[]
   }
 
 export type WorkflowRuntimeClient<Connection = never> = {
@@ -162,6 +176,14 @@ export type WorkflowRuntimeClient<Connection = never> = {
   }
 }
 
+/**
+ * Constructible from the adapter alone: every operation except `retry()` is
+ * registry-free. `start()` reads everything it needs (input schema, `tags`,
+ * `idempotency`, `unique`) off the definition it receives, and execution is
+ * handled by workers that own the implementations. Only `retry()` resolves a
+ * stored run back to something startable by name, and accepts `definitions`
+ * for that so enqueue/management surfaces never import implementation code.
+ */
 export function createWorkflowRuntimeClient<Connection = never>(
   input: CreateWorkflowRuntimeClientInput<Connection>,
 ): WorkflowRuntimeClient<Connection> {
@@ -169,6 +191,7 @@ export function createWorkflowRuntimeClient<Connection = never>(
     workflows: input.workflows,
     tasks: input.tasks,
   })
+  const definitions = createDefinitionIndex(registry, input.definitions)
 
   const start = (async (
     runnable: AnyWorkflowDefinition | AnyTaskDefinition,
@@ -218,7 +241,7 @@ export function createWorkflowRuntimeClient<Connection = never>(
     start,
     deleteRun: (runId) => input.store.deleteRun(runId),
     retry: (runId, options) =>
-      retryRun(input.store, registry, start, runId, options),
+      retryRun(input.store, definitions, start, runId, options),
     cancel: async (runId) => {
       const run = await input.store.requestRunCancellation({ runId })
       if (!run) return undefined
@@ -379,9 +402,63 @@ async function pruneRuns(
   }
 }
 
+/**
+ * Name→definition maps backing `retry()`. Seeded from registered
+ * implementations (their definitions ride along anyway) and extended by the
+ * explicit `definitions` input, so retry works identically whether the client
+ * was built for execution or as a registry-free enqueue/management surface.
+ */
+type WorkflowDefinitionIndex = {
+  readonly workflows: ReadonlyMap<string, AnyWorkflowDefinition>
+  readonly tasks: ReadonlyMap<string, AnyTaskDefinition>
+}
+
+function createDefinitionIndex(
+  registry: WorkflowRuntimeRegistry,
+  definitions: readonly RunnableDefinition[] | undefined,
+): WorkflowDefinitionIndex {
+  const workflows = new Map<string, AnyWorkflowDefinition>()
+  const tasks = new Map<string, AnyTaskDefinition>()
+
+  for (const implementation of registry.workflows.values()) {
+    workflows.set(implementation.workflow.name, implementation.workflow)
+  }
+  for (const implementation of registry.tasks.values()) {
+    tasks.set(implementation.task.name, implementation.task)
+  }
+  for (const definition of definitions ?? []) {
+    // Two objects under one name would make by-name resolution ambiguous and
+    // `start()`'s definition↔implementation identity check a coin toss.
+    switch (definition.kind) {
+      case 'workflow': {
+        const existing = workflows.get(definition.name)
+        if (existing && existing !== definition) {
+          throw new Error(
+            `Conflicting workflow definition [${definition.name}]: another definition or registered implementation uses the same name`,
+          )
+        }
+        workflows.set(definition.name, definition)
+        break
+      }
+      case 'task': {
+        const existing = tasks.get(definition.name)
+        if (existing && existing !== definition) {
+          throw new Error(
+            `Conflicting task definition [${definition.name}]: another definition or registered implementation uses the same name`,
+          )
+        }
+        tasks.set(definition.name, definition)
+        break
+      }
+    }
+  }
+
+  return { workflows, tasks }
+}
+
 async function retryRun<Connection>(
   store: WorkflowStore,
-  registry: WorkflowRuntimeRegistry,
+  definitions: WorkflowDefinitionIndex,
   start: WorkflowRuntimeClient<Connection>['start'],
   runId: string,
   options?: WorkflowRuntimeStartOptions<Connection>,
@@ -397,13 +474,13 @@ async function retryRun<Connection>(
 
   switch (run.kind) {
     case 'workflow': {
-      const implementation = registry.getWorkflow(run.workflowName)
-      if (!implementation) {
+      const workflow = definitions.workflows.get(run.workflowName)
+      if (!workflow) {
         throw new Error(
-          `No registered workflow implementation [${run.workflowName}]`,
+          `Cannot retry run [${runId}]: no workflow definition [${run.workflowName}] is known to this client — pass it via 'definitions' (or its implementation via 'workflows') to createWorkflowRuntimeClient`,
         )
       }
-      return (await start(implementation.workflow, run.input as never, {
+      return (await start(workflow, run.input as never, {
         tags: run.tags,
         // scope 'all' constraints conflict with the terminal run itself on
         // retry — surfaced honestly; override via options.unique if intended
@@ -413,11 +490,13 @@ async function retryRun<Connection>(
     }
     case 'task': {
       const taskName = run.taskName ?? run.name
-      const implementation = registry.getTask(taskName)
-      if (!implementation) {
-        throw new Error(`No registered task implementation [${taskName}]`)
+      const task = definitions.tasks.get(taskName)
+      if (!task) {
+        throw new Error(
+          `Cannot retry run [${runId}]: no task definition [${taskName}] is known to this client — pass it via 'definitions' (or its implementation via 'tasks') to createWorkflowRuntimeClient`,
+        )
       }
-      return (await start(implementation.task, run.input as never, {
+      return (await start(task, run.input as never, {
         tags: run.tags,
         ...(run.unique === undefined ? {} : { unique: run.unique }),
         ...options,

--- a/packages/workflows/tests/runtime-client.spec.ts
+++ b/packages/workflows/tests/runtime-client.spec.ts
@@ -575,7 +575,7 @@ describe('workflow runtime client', () => {
     )
   })
 
-  it('refuses to retry runs without a registered implementation', async () => {
+  it('refuses to retry runs whose definition is unknown to the client', async () => {
     const workflow = defineWorkflow({
       name: 'client-retry-unregistered-workflow',
       input: t.object({ scenario: t.string() }),
@@ -590,8 +590,91 @@ describe('workflow runtime client', () => {
     })
 
     await expect(client.retry(run.id)).rejects.toThrow(
-      `No registered workflow implementation [${workflow.name}]`,
+      `Cannot retry run [${run.id}]: no workflow definition [${workflow.name}] is known to this client`,
     )
+  })
+
+  it('retries workflow runs resolved from definitions without implementations', async () => {
+    const workflow = defineWorkflow({
+      name: 'client-retry-definition-workflow',
+      input: t.object({ scenario: t.string() }),
+      output: t.object({ caseId: t.string() }),
+    }).build()
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient({
+      ...runtime,
+      definitions: [workflow],
+    })
+    const run = await client.start(
+      workflow,
+      { scenario: 'alpha' },
+      { tags: { tenantId: 'tenant-1' } },
+    )
+    await runtime.store.completeRun({
+      runId: run.id,
+      output: { caseId: 'alpha' },
+    })
+
+    const retried = await client.retry(run.id)
+
+    expect(retried).toMatchObject({
+      kind: 'workflow',
+      workflowName: workflow.name,
+      status: 'queued',
+      input: { scenario: 'alpha' },
+      tags: { tenantId: 'tenant-1' },
+    })
+    expect(retried.id).not.toBe(run.id)
+  })
+
+  it('retries task runs resolved from definitions without implementations', async () => {
+    const task = defineTask({
+      name: 'client-retry-definition-task',
+      input: t.object({ text: t.string() }),
+      output: t.object({ id: t.string() }),
+    })
+    const runtime = createInMemoryWorkflowRuntime()
+    const client = createWorkflowRuntimeClient({
+      ...runtime,
+      definitions: [task],
+    })
+    const run = await client.start(task, { text: 'alpha' })
+    await runtime.store.completeRun({ runId: run.id, output: { id: 'alpha' } })
+
+    const retried = await client.retry(run.id)
+
+    expect(retried).toMatchObject({
+      kind: 'task',
+      taskName: task.name,
+      status: 'queued',
+      input: { text: 'alpha' },
+    })
+    expect(retried.id).not.toBe(run.id)
+  })
+
+  it('rejects conflicting definitions under one name at construction', async () => {
+    const workflow = defineWorkflow({
+      name: 'client-conflicting-definition',
+      input: t.object({ scenario: t.string() }),
+      output: t.object({ caseId: t.string() }),
+    }).build()
+    const shadow = defineWorkflow({
+      name: 'client-conflicting-definition',
+      input: t.object({ scenario: t.string() }),
+      output: t.object({ caseId: t.string() }),
+    }).build()
+    const implementation = implementWorkflow(workflow).finish(
+      (_ctx, _outputs, input) => ({ caseId: input.scenario }),
+    )
+    const runtime = createInMemoryWorkflowRuntime()
+
+    expect(() =>
+      createWorkflowRuntimeClient({
+        ...runtime,
+        workflows: [implementation],
+        definitions: [shadow],
+      }),
+    ).toThrow('Conflicting workflow definition [client-conflicting-definition]')
   })
 
   it('manages schedules through the adapter scheduler', async () => {

--- a/skills/use-neemata/references/workflows.md
+++ b/skills/use-neemata/references/workflows.md
@@ -139,10 +139,21 @@ const connection = createPostgresWorkflowConnection(
 await verifyPostgresWorkflowSchema(connection) // fail fast on schema drift
 const runtime = createPostgresWorkflowRuntime({ connection })
 
+// Execution-side client: implementations registered for the workers.
 const client = createWorkflowRuntimeClient({
   ...runtime,
   workflows: [publishWorkflowImpl],
   tasks: [embedTaskImpl],
+})
+
+// Enqueue/query-side client: registry-free — implementations are never
+// needed to start runs (start resolves schemas/tags/idempotency/unique from
+// the definition argument), so callers that only enqueue don't import the
+// implementation graph and can't form import cycles with it. `definitions`
+// is only consulted by retry(), which resolves stored runs by name.
+const enqueueClient = createWorkflowRuntimeClient({
+  ...runtime,
+  definitions: [publishWorkflow, embedTask],
 })
 
 const run = await client.start(
@@ -174,7 +185,10 @@ full payloads, these don't):
 Management: `client.deleteRun(runId)` deletes a terminal run and its whole
 descendant tree; `client.retry(runId)` starts a fresh run from a stored one —
 copies input and tags but NOT the idempotency key (the old key still points
-at the original run), `options` overrides win.
+at the original run), `options` overrides win. Retry is the only by-name
+operation: it maps the stored `workflowName`/`taskName` back to a definition,
+so the client needs that name in `definitions` (or a registered
+implementation) and fails with a specific error otherwise.
 
 Live updates: `client.watch(runId, { family?, afterEventId?, signal?,
 pollIntervalMs? })` returns an `AsyncIterable<StoredRunEvent>` — history from


### PR DESCRIPTION
Closes #290

`createWorkflowRuntimeClient` no longer needs the implementation registry for anything except name→code resolution, and that resolution now works from definitions alone:

- **`definitions?: readonly RunnableDefinition[]`** on `CreateWorkflowRuntimeClientInput` — a name→definition source for `retry()` (and future by-name operations). Definitions live in leaf modules both sides can import, so enqueue/management surfaces resolve stored run names without importing the implementation graph — no `client → registry → implementation → client` cycle can form.
- **`retry()` resolves through a definition index** seeded from registered implementations' definitions and extended by explicit `definitions`. Execution-side clients (implementations registered) behave exactly as before; enqueue-side clients pass definitions only. An unknown name fails loudly: `Cannot retry run [id]: no workflow definition [name] is known to this client — pass it via 'definitions' (or its implementation via 'workflows')`.
- **Conflicting definitions fail at construction** — two different definition objects under one name throw immediately rather than making by-name resolution ambiguous (a management surface might not call `retry` for days; boot is the right place to surface the wiring bug).
- **Registry-free guarantee documented** in JSDoc on `createWorkflowRuntimeClient` and the input's `workflows`/`tasks` fields: `start` reads schemas/`tags`/`idempotency`/`unique` off the definition argument, and `get`/`list`/`watch`/`cancel`/`deleteRun`/`pruneRuns` never touch implementations. The `use-neemata` skill reference now shows both client constructions.

Tests: workflow and task retry from `definitions` alone, construction-time conflict rejection, updated unknown-definition error; registry-free `start` was already covered.