### PR TITLE
streaming: batch RPC stream credits

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -21,6 +21,7 @@ import type { BaseClientTransformer } from './transformers.ts'
 import type { ClientTransportFactory } from './transport.ts'
 import type {
   AnyResolvedContractRouter,
+  ClientBackpressureOptions,
   ClientCallers,
   ResolveAPIRouterRoutes,
 } from './types.ts'
@@ -39,6 +40,11 @@ export interface ClientOptions<
   application?: string
   autoConnect?: boolean
   timeout?: number
+  /**
+   * Backpressure defaults for streaming responses; individual calls override
+   * them.
+   */
+  backpressure?: ClientBackpressureOptions
   plugins?: ClientPlugin[]
   safe?: SafeCall
 }
@@ -134,6 +140,7 @@ export class Client<
     this.streamLayer = createStreamLayer(this.core)
     this.rpcLayer = createRpcLayer(this.core, this.streamLayer, transformer, {
       timeout: this.options.timeout,
+      rpcStreamWindow: this.options.backpressure?.rpc?.window,
       safe: this.options.safe,
     })
     this.pingLayer = createPingLayer(this.core)

--- a/packages/client/src/layers/rpc.ts
+++ b/packages/client/src/layers/rpc.ts
@@ -21,6 +21,7 @@ import { toReasonString } from './streams.ts'
 export type ProtocolClientCall = Future<any> & {
   procedure: string
   signal?: AbortSignal
+  rpcStreamWindow: number
   cleanup?: () => void
 }
 
@@ -32,6 +33,19 @@ export interface RpcLayerApi {
   ): Promise<any>
   readonly pendingCallCount: number
   readonly activeStreamCount: number
+}
+
+const DEFAULT_RPC_STREAM_WINDOW = 16
+
+const resolveRpcStreamWindow = (
+  value: number | undefined = DEFAULT_RPC_STREAM_WINDOW,
+) => {
+  if (!Number.isInteger(value) || value < 1 || value > MAX_UINT32) {
+    throw new RangeError(
+      'backpressure.rpc.window must be a positive uint32 integer',
+    )
+  }
+  return value
 }
 
 const toAbortError = (signal: AbortSignal) => {
@@ -187,10 +201,15 @@ export const createRpcLayer = (
   core: ClientCore,
   streams: StreamLayerApi,
   transformer: BaseClientTransformer,
-  options: { timeout?: number; safe?: boolean } = {},
+  options: {
+    timeout?: number
+    rpcStreamWindow?: number
+    safe?: boolean
+  } = {},
 ): RpcLayerApi => {
   const calls = new Map<number, ProtocolClientCall>()
   const rpcStreams = new ServerStreams<ProtocolServerRPCStream>()
+  const defaultRpcStreamWindow = resolveRpcStreamWindow(options.rpcStreamWindow)
 
   let callId = 0
 
@@ -302,13 +321,27 @@ export const createRpcLayer = (
       stream: true,
     })
 
-    const { procedure, signal } = call
+    const { procedure, signal, rpcStreamWindow } = call
+    const rpcStreamRefill = Math.ceil(rpcStreamWindow / 2)
+    let initialCreditGrant = true
+    let pullsUntilRefill = rpcStreamRefill
     const stream = new ProtocolServerRPCStream({
-      // one chunk credit per consumer read (hwm 0): the server sends nothing
-      // until the consumer actually iterates
       pull: () => {
         if (!core.messageContext) return
 
+        let size: number
+        if (initialCreditGrant) {
+          initialCreditGrant = false
+          size = rpcStreamWindow
+        } else {
+          pullsUntilRefill--
+          if (pullsUntilRefill > 0) return
+          pullsUntilRefill = rpcStreamRefill
+          size = rpcStreamRefill
+        }
+
+        // Batch refills preserve a bounded producer lead without putting a
+        // wire round trip on every consumer read.
         core.emitStreamEvent({
           direction: 'outgoing',
           streamType: 'rpc',
@@ -319,7 +352,7 @@ export const createRpcLayer = (
         const buffer = core.protocol.encodeMessage(
           core.messageContext,
           ClientMessageType.RpcStreamPull,
-          { callId: message.callId, size: 1 },
+          { callId: message.callId, size },
         )
 
         core.send(buffer).catch(noopFn)
@@ -647,6 +680,9 @@ export const createRpcLayer = (
     payload: any,
     callOptions: ClientCallOptions = {},
   ) => {
+    const rpcStreamWindow = resolveRpcStreamWindow(
+      callOptions.backpressure?.rpc?.window ?? defaultRpcStreamWindow,
+    )
     const timeout = callOptions.timeout ?? options.timeout
     const controller = new AbortController()
 
@@ -661,6 +697,7 @@ export const createRpcLayer = (
     const call = createFuture() as ProtocolClientCall
     call.procedure = procedure
     call.signal = signal
+    call.rpcStreamWindow = rpcStreamWindow
 
     calls.set(currentCallId, call)
     core.emitClientEvent({

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -17,7 +17,30 @@ export type RpcCallOptions = {
   keepalive?: boolean
 }
 
-export type StreamCallOptions = RpcCallOptions & { autoReconnect?: boolean }
+export type ClientBackpressureOptions = {
+  rpc?: {
+    /**
+     * Maximum number of chunks a bidirectional RPC response stream may
+     * produce ahead of the consumer. Credits count chunks, not bytes, so a
+     * side-effectful producer may advance by up to this amount before client
+     * cancellation arrives.
+     *
+     * Unidirectional transports use their native stream backpressure instead.
+     * Larger windows proportionally extend the gateway's idle allowance once
+     * the granted batch has been exhausted.
+     * @default 16
+     */
+    window?: number
+  }
+}
+
+export type StreamCallOptions = RpcCallOptions & {
+  autoReconnect?: boolean
+  /**
+   * Overrides the client backpressure defaults for this stream.
+   */
+  backpressure?: ClientBackpressureOptions
+}
 
 export type ClientCallOptions = StreamCallOptions & {
   /**

--- a/packages/client/tests/public-clients.spec.ts
+++ b/packages/client/tests/public-clients.spec.ts
@@ -158,7 +158,10 @@ describe('public clients', () => {
       })
       .mockReturnValueOnce({ type: ServerMessageType.RpcStreamEnd, callId: 0 })
 
-    const streamPromise = client.stream.admin.audit.feed({ limit: 2 })
+    const streamPromise = client.stream.admin.audit.feed(
+      { limit: 2 },
+      { backpressure: { rpc: { window: 4 } } },
+    )
 
     expect(encodedMessages.at(-1)).toMatchObject({
       procedure: 'admin/audit/feed',
@@ -172,6 +175,7 @@ describe('public clients', () => {
 
     const firstChunk = iterator.next()
     await Promise.resolve()
+    expect(encodedMessages.at(-1)).toEqual({ callId: 0, size: 4 })
     transport.emitMessage(new Uint8Array([2]))
     await expect(firstChunk).resolves.toEqual({
       done: false,

--- a/packages/client/tests/rpc-streams.spec.ts
+++ b/packages/client/tests/rpc-streams.spec.ts
@@ -65,7 +65,27 @@ class MockCore extends EventEmitter<{
 }
 
 describe('RPC streams', () => {
-  it('sends exactly one RpcStreamPull per consumed chunk and nothing else', async () => {
+  it('rejects invalid RPC backpressure windows', async () => {
+    const core = new MockCore()
+    const rpcLayer = createRpcLayer(
+      core as any,
+      { addServerBlobStream: vi.fn() } as any,
+      new BaseClientTransformer(),
+    )
+
+    await expect(
+      rpcLayer.call(
+        'users/profile',
+        { userId: '1' },
+        { _stream_response: true, backpressure: { rpc: { window: 0 } } },
+      ),
+    ).rejects.toThrow(
+      'backpressure.rpc.window must be a positive uint32 integer',
+    )
+    expect(core.send).not.toHaveBeenCalled()
+  })
+
+  it('batches RPC credits and refills after eight reads', async () => {
     const core = new MockCore()
     const rpcLayer = createRpcLayer(
       core as any,
@@ -98,51 +118,53 @@ describe('RPC streams', () => {
     const firstChunkPromise = iterator.next()
 
     await Promise.resolve()
-    // the read triggers one single-chunk credit grant
+    // One read opens enough credit for a short burst from the server.
     expect(core.send).toHaveBeenCalledTimes(1)
     expect(core.protocol.encodeMessage).toHaveBeenCalledWith(
       expect.anything(),
       ClientMessageType.RpcStreamPull,
-      { callId: 0, size: 1 },
+      { callId: 0, size: 16 },
     )
+    core.emitStreamEvent.mockClear()
 
-    core.emit(
-      'message',
-      {
-        type: ServerMessageType.RpcStreamChunk,
-        callId: 0,
-        chunk: encodeJson({ ok: true, echoed: { userId: '1' } }),
-      },
-      new Uint8Array([2]),
-    )
-
+    for (let sequence = 1; sequence <= 9; sequence++) {
+      core.emit(
+        'message',
+        {
+          type: ServerMessageType.RpcStreamChunk,
+          callId: 0,
+          chunk: encodeJson({ sequence }),
+        },
+        new Uint8Array([2]),
+      )
+    }
     await expect(firstChunkPromise).resolves.toEqual({
       done: false,
-      value: { ok: true, echoed: { userId: '1' } },
+      value: { sequence: 1 },
     })
-    // receiving the chunk itself grants nothing
+    // Receiving the rest of the granted burst does not send another pull.
+    expect(core.send).toHaveBeenCalledTimes(1)
+    expect(core.emitStreamEvent).toHaveBeenCalledTimes(9)
+
+    for (let sequence = 2; sequence <= 8; sequence++) {
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: { sequence },
+      })
+    }
     expect(core.send).toHaveBeenCalledTimes(1)
 
-    const secondChunkPromise = iterator.next()
-    await Promise.resolve()
+    const ninthChunkPromise = iterator.next()
+    await expect(ninthChunkPromise).resolves.toEqual({
+      done: false,
+      value: { sequence: 9 },
+    })
     expect(core.send).toHaveBeenCalledTimes(2)
     expect(core.protocol.encodeMessage).toHaveBeenLastCalledWith(
       expect.anything(),
       ClientMessageType.RpcStreamPull,
-      { callId: 0, size: 1 },
+      { callId: 0, size: 8 },
     )
-
-    core.emit(
-      'message',
-      { type: ServerMessageType.RpcStreamEnd, callId: 0 },
-      new Uint8Array([3]),
-    )
-
-    await expect(secondChunkPromise).resolves.toEqual({
-      done: true,
-      value: undefined,
-    })
-    expect(core.send).toHaveBeenCalledTimes(2)
   })
 
   it('reuses the initial stream when autoReconnect is enabled', async () => {
@@ -179,7 +201,7 @@ describe('RPC streams', () => {
     expect(core.protocol.encodeMessage).toHaveBeenLastCalledWith(
       expect.anything(),
       ClientMessageType.RpcStreamPull,
-      { callId: 0, size: 1 },
+      { callId: 0, size: 16 },
     )
 
     core.emit(

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -64,6 +64,8 @@ import {
 
 type RpcStreamCreditState = {
   credits: number
+  // credits granted since the previous idle wait
+  idleCredits: number
   // resolves the in-flight credit wait; also poked on abort/teardown
   notify: (() => void) | null
   // fails the whole stream (e.g. credit violation) from the message handler
@@ -93,9 +95,12 @@ export interface GatewayOptions<
   identity?: ConnectionIdentity
   /**
    * Bounds peer inactivity per stream. For RPC streams it caps only how long
-   * the server waits for consumer credit (a client that isn't pulling);
-   * producer stalls with a live, waiting consumer are allowed indefinitely
-   * (sparse streams, e.g. pubsub subscriptions). For blob streams it bounds
+   * the server waits for consumer credit (a client that isn't pulling). The
+   * allowance applies per exhausted chunk credit, so a batched grant does not
+   * reduce the time available to consume each chunk. Producer stalls with a
+   * live, waiting consumer are allowed indefinitely (sparse streams, e.g.
+   * pubsub subscriptions). Consequently, a larger RPC window also allows an
+   * inactive consumer to retain the stream longer. For blob streams it bounds
    * inactivity in either direction (chunk sent/received, credit
    * granted/received). Expiry aborts the stream.
    */
@@ -111,6 +116,9 @@ export interface GatewayOptions<
 const DEFAULT_GATEWAY_HEARTBEAT_INTERVAL = 15000
 const DEFAULT_GATEWAY_HEARTBEAT_TIMEOUT = 5000
 const DEFAULT_STREAM_IDLE_TIMEOUT = 30_000
+// Node clamps larger timer delays to 1ms, which would invert a large credit
+// window into an immediate timeout.
+const MAX_TIMER_DELAY = 2 ** 31 - 1
 /**
  * Upper bound per connection teardown step so a never-settling transport
  * close or container disposal can't hang closeConnection() and stop().
@@ -705,6 +713,10 @@ export class Gateway<
                 break
               }
               credit.credits += message.size
+              credit.idleCredits = Math.min(
+                credit.idleCredits + message.size,
+                MAX_STREAM_CREDITS,
+              )
               credit.notify?.()
             }
             break
@@ -839,6 +851,7 @@ export class Gateway<
         flow.promise.catch(noopFn)
         const credit: RpcStreamCreditState = {
           credits: 0,
+          idleCredits: 0,
           notify: null,
           fail: (error) => flow.reject(error),
         }
@@ -880,12 +893,18 @@ export class Gateway<
             while (credit.credits <= 0) {
               // idle detection bounds only consumer inactivity: the producer
               // is ready but the client isn't pulling
+              const idleTimeout = Math.min(
+                this.options.streamIdleTimeout *
+                  Math.max(credit.idleCredits, 1),
+                MAX_TIMER_DELAY,
+              )
+              credit.idleCredits = 0
               const grant = createFuture<void>()
               credit.notify = grant.resolve
               const idleTimer = setTimeout(
                 () =>
                   flow.reject(new StreamFlowError(STREAM_IDLE_TIMEOUT_REASON)),
-                this.options.streamIdleTimeout,
+                idleTimeout,
               )
               try {
                 await Promise.race([grant.promise, flow.promise])

--- a/packages/protocol/src/server/stream.ts
+++ b/packages/protocol/src/server/stream.ts
@@ -7,10 +7,9 @@ import { MAX_UINT32 } from '@nmtjs/common'
 import type { ProtocolBlob, ProtocolBlobMetadata } from '../common/blob.ts'
 
 /**
- * Upper bound for outstanding stream credit. Far above any sane consumer's
- * demand (our client pulls 64KB of bytes / 1 chunk per read) but low enough
- * that additive grants can never reach unsafe-integer territory where
- * decrements would silently stop working.
+ * Upper bound for outstanding stream credit. Credits represent bytes for blob
+ * streams and chunks for RPC streams. The bound keeps additive grants below
+ * unsafe-integer territory where decrements would silently stop working.
  */
 export const MAX_STREAM_CREDITS = MAX_UINT32
 

--- a/packages/ws-transport/tests/stream-e2e.spec.ts
+++ b/packages/ws-transport/tests/stream-e2e.spec.ts
@@ -162,6 +162,7 @@ afterEach(async () => {
 async function createHarness(options: {
   handlers: Handlers
   streamIdleTimeout?: number
+  rpcBackpressureWindow?: number
   runtimeWs?: WsTransportRuntimeNode['ws']
   plugins?: ClientPlugin[]
 }) {
@@ -214,6 +215,9 @@ async function createHarness(options: {
       contract,
       protocol: ProtocolVersion.v1,
       format: new ClientJsonFormat(),
+      backpressure: {
+        rpc: { window: options.rpcBackpressureWindow },
+      },
       plugins: options.plugins,
     },
     WsTransportFactory,
@@ -287,12 +291,26 @@ describe('stream flow control over a real WS transport', () => {
     expect(sourceBytes).toBe(BLOB_SIZE)
   })
 
-  it('never lets an RPC stream producer run ahead of the consumer', async () => {
+  it('delivers an RPC chunk batch from one pull grant', async () => {
     const TOTAL = 30
+    const CREDIT_SIZE = 12
+    const REFILL_SIZE = 6
     let yielded = 0
     let finished = false
+    let pulls = 0
+    let pushes = 0
+
+    const pacingObserver: ClientPlugin = () => ({
+      onClientEvent: (event) => {
+        if (event.kind !== 'stream_event' || event.streamType !== 'rpc') return
+        if (event.direction === 'outgoing' && event.action === 'pull') pulls++
+        if (event.direction === 'incoming' && event.action === 'push') pushes++
+      },
+    })
 
     const { client } = await createHarness({
+      plugins: [pacingObserver],
+      rpcBackpressureWindow: CREDIT_SIZE,
       handlers: {
         chunks: async () => () =>
           (async function* () {
@@ -311,28 +329,71 @@ describe('stream flow control over a real WS transport', () => {
     const stream = await client.stream.chunks({})
     const iterator = stream[Symbol.asyncIterator]()
 
-    // consume one chunk, then pause: the producer must have advanced exactly
-    // once — one credit, one yield, no prefetch (yielded is server-internal
-    // instrumentation, exact by construction)
+    // Consume one chunk, then pause. The first pull grants a whole batch, so
+    // the server can deliver the remaining chunks without another round trip.
     const first = await iterator.next()
     expect(first.value).toBe('chunk-0')
-    await waitQuiescent(() => yielded)
-    expect(yielded).toBe(1)
+    await waitQuiescent(() => `${yielded}:${pushes}:${pulls}`)
+    expect({ pulls, pushes, yielded }).toEqual({
+      pulls: 1,
+      pushes: CREDIT_SIZE,
+      yielded: CREDIT_SIZE,
+    })
+    expect(finished).toBe(false)
 
     const received: string[] = [first.value]
+    while (received.length < REFILL_SIZE) {
+      const { value } = await iterator.next()
+      received.push(value)
+    }
+    expect(pulls).toBe(1)
+
+    const nextAfterRefill = await iterator.next()
+    received.push(nextAfterRefill.value)
+    await waitQuiescent(() => `${yielded}:${pushes}:${pulls}`)
+    expect({ pulls, pushes, yielded }).toEqual({
+      pulls: 2,
+      pushes: CREDIT_SIZE + REFILL_SIZE,
+      yielded: CREDIT_SIZE + REFILL_SIZE,
+    })
+
     while (true) {
       const { done, value } = await iterator.next()
       if (done) break
       received.push(value)
-      // strict lockstep: the next credit is only granted by the next read,
-      // so the generator can never be ahead of what the client consumed
-      expect(yielded).toBe(received.length)
     }
 
     expect(received).toEqual(
       Array.from({ length: TOTAL }, (_, i) => `chunk-${i}`),
     )
     expect(finished).toBe(true)
+  })
+
+  it('keeps a slowly consumed batched RPC stream alive', async () => {
+    const IDLE_TIMEOUT = 50
+    const CONSUME_DELAY = 35
+    const TOTAL = 6
+
+    const { client } = await createHarness({
+      streamIdleTimeout: IDLE_TIMEOUT,
+      rpcBackpressureWindow: 4,
+      handlers: {
+        chunks: async () => () =>
+          (async function* () {
+            for (let i = 0; i < TOTAL; i++) yield `chunk-${i}`
+          })(),
+      },
+    })
+
+    const received: string[] = []
+    for await (const chunk of await client.stream.chunks({})) {
+      received.push(chunk)
+      await sleep(CONSUME_DELAY)
+    }
+
+    expect(received).toEqual(
+      Array.from({ length: TOTAL }, (_, i) => `chunk-${i}`),
+    )
   })
 
   it('keeps a sparse producer alive across silences beyond the idle timeout', async () => {


### PR DESCRIPTION
## Summary

- batch bidirectional RPC stream credits with a default 16-chunk window and half-window refills
- allow client-wide defaults and per-call overrides through `backpressure.rpc.window`
- preserve the gateway's per-chunk idle allowance when credit batches are exhausted
- document that RPC credits count chunks, may advance side-effectful producers, and are separate from byte-based blob flow control

## Why

RPC response streams previously sent one pull frame for every consumed chunk. Small-chunk streams therefore paid a wire round trip per chunk and produced alternating push/pull traffic. A bounded credit window lets the server deliver a short burst while retaining backpressure.

## Validation

- `CI=true vp env exec pnpm test -- --reporter=agent`
  - 123 test files passed, 1 skipped
  - 1,289 tests passed, 6 skipped
  - no type errors
- full `oxlint` completed without errors
- formatter and `git diff --check` passed
- targeted Chromium RPC stream tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable backpressure windows for RPC streams at both client-wide and per-stream levels.
  * RPC streams now request and refill credits in batches, improving efficiency during sustained consumption.

* **Bug Fixes**
  * Invalid backpressure window values are now rejected with a clear error.
  * Slowly consumed streams remain available longer by scaling idle timeouts with granted credits.

* **Tests**
  * Expanded coverage for batched streaming, reconnects, validation, and end-to-end slow-consumption scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->