### PR TITLE
neem: log proxy bound listen address

### DIFF
--- a/packages/neem/src/internal/host/proxy.ts
+++ b/packages/neem/src/internal/host/proxy.ts
@@ -85,12 +85,10 @@ export class ProxyController {
       }
       await this.proxy.start()
       this.running = true
-      this.logger.debug('Neem proxy started')
+      const listen = this.resolveListenUrl()
+      this.logger.info(`Neem proxy listening on [${listen}]`)
       this.logger.trace(
-        {
-          listen: `${this.config.hostname}:${this.config.port}`,
-          upstreams: this.desired.size,
-        },
+        { listen, upstreams: this.desired.size },
         'Neem proxy upstreams',
       )
     } catch (error) {
@@ -161,6 +159,25 @@ export class ProxyController {
       failedUpstreams,
       lastError: failedUpstreams.at(-1)?.error,
     }
+  }
+
+  /**
+   * The configured port may be 0, so only the bound address tells operators
+   * where the proxy actually accepts traffic. Never let reporting break start.
+   */
+  private resolveListenUrl(): string {
+    let address: { hostname: string; port: number } | null = null
+    try {
+      address = this.proxy?.address() ?? null
+    } catch (error) {
+      this.logger.debug(
+        new Error('Failed to read Neem proxy listen address', { cause: error }),
+      )
+    }
+    return formatProxyListenUrl(
+      address ?? { hostname: this.config.hostname, port: this.config.port },
+      Boolean(this.config.tls),
+    )
   }
 
   private async reconcile(): Promise<void> {
@@ -296,6 +313,17 @@ export function toProxyUpstream(
     hostname: url.hostname,
     port,
   }
+}
+
+export function formatProxyListenUrl(
+  address: { hostname: string; port: number },
+  secure: boolean,
+): string {
+  // Bare IPv6 addresses need brackets to stay a valid URL authority
+  const hostname = address.hostname.includes(':')
+    ? `[${address.hostname}]`
+    : address.hostname
+  return `${secure ? 'https' : 'http'}://${hostname}:${address.port}`
 }
 
 export function createNativeProxyOptions(

--- a/packages/neem/tests/unit/proxy.spec.ts
+++ b/packages/neem/tests/unit/proxy.spec.ts
@@ -1,12 +1,28 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
+import type { RuntimeSnapshot } from '../../src/internal/manifest/snapshot.ts'
 import type { NeemProxyConfig } from '../../src/shared/types.ts'
 import {
   createDesiredUpstreams,
   createNativeProxyOptions,
+  formatProxyListenUrl,
   normalizeRuntimeUpstream,
+  ProxyController,
   toProxyUpstream,
 } from '../../src/internal/host/proxy.ts'
+
+vi.mock('@nmtjs/proxy', () => ({
+  Proxy: class {
+    async start() {}
+    async stop() {}
+    // stands in for the port the OS picks when `port: 0` is configured
+    address() {
+      return { hostname: '127.0.0.1', port: 54321 }
+    }
+    async addUpstream() {}
+    async removeUpstream() {}
+  },
+}))
 
 describe('Neem proxy helpers', () => {
   it('normalizes wildcard runtime upstreams to loopback', () => {
@@ -106,6 +122,53 @@ describe('Neem proxy helpers', () => {
         { api: {}, jobs: {} },
       ).applications,
     ).toEqual([])
+  })
+
+  it('formats the bound proxy listen address', () => {
+    expect(
+      formatProxyListenUrl({ hostname: '127.0.0.1', port: 8080 }, false),
+    ).toBe('http://127.0.0.1:8080')
+    expect(formatProxyListenUrl({ hostname: '0.0.0.0', port: 443 }, true)).toBe(
+      'https://0.0.0.0:443',
+    )
+    expect(formatProxyListenUrl({ hostname: '::1', port: 8080 }, false)).toBe(
+      'http://[::1]:8080',
+    )
+  })
+
+  it('logs the bound listen address instead of the configured port', async () => {
+    const messages: string[] = []
+    const noop = () => {}
+    const logger = {
+      info: (message: string) => {
+        messages.push(message)
+      },
+      debug: noop,
+      trace: noop,
+      warn: noop,
+      // annotated to keep the self-reference out of type inference
+      child: (): unknown => logger,
+    }
+
+    const controller = new ProxyController({
+      logger,
+      config: {
+        proxy: { hostname: '0.0.0.0', port: 0 },
+        runtimes: { api: { proxy: { routing: { type: 'default' } } } },
+      },
+    } as unknown as RuntimeSnapshot)
+
+    await controller.start([
+      {
+        runtimeName: 'api',
+        upstreams: [{ type: 'http', url: 'http://0.0.0.0:3000' }],
+      },
+    ])
+    await controller.stop()
+
+    expect(messages).toContain(
+      'Neem proxy listening on [http://127.0.0.1:54321]',
+    )
   })
 
   it('rejects multiple default proxy routes', () => {


### PR DESCRIPTION
## Problem

`ProxyController.start()` logged only `Neem proxy started` at `debug`, plus a `trace` line carrying the *configured* `${hostname}:${port}`. With `port: 0` — a supported and used configuration — that printed `127.0.0.1:0`, so there was no way to learn where the proxy actually accepts traffic.

The native proxy already exposes the bound address via `Proxy.address()`, which returns `null` unless the proxy is running. Neem never called it.

## Change

- `start()` now logs `Neem proxy listening on [http://127.0.0.1:54321]` at `info`, using the bound address. This matches the existing precedent in `Gateway.start()`, which logs `Transport [ws] started on [url]` with the real bound port.
- The `trace` line reuses the same resolved value, so the two cannot drift.
- `resolveListenUrl()` falls back to the configured host/port when `address()` returns `null`, and swallows a throw into a `debug` line — reporting must never fail an otherwise successful start.
- `formatProxyListenUrl()` is exported and pure: it derives the scheme from `tls` config and brackets bare IPv6 hosts, which the native side returns unbracketed.

## Tests

- New unit test asserting the log carries the bound port rather than the configured `0`, using the existing `@nmtjs/proxy` import seam.
- New unit test covering scheme selection and IPv6 bracketing.
- `packages/neem` unit suite (87 tests) and e2e suite (65 tests) pass; `oxlint` and `oxfmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy startup logs now show the actual address and port the proxy is listening on.
  * Improved listen URL formatting for IPv4, IPv6, HTTP, and HTTPS configurations.

* **Tests**
  * Added coverage for listen URL formatting and dynamically assigned proxy ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->