### PR TITLE
workflows: count lease-expiry redeliveries so poison commands dead-letter

### DIFF
--- a/packages/workflows/src/adapters/postgres/executor.ts
+++ b/packages/workflows/src/adapters/postgres/executor.ts
@@ -7,6 +7,7 @@ import type {
 import type { AttemptExecutor } from '../../runtime/executors.ts'
 import type { StoredRun } from '../../runtime/state.ts'
 import type { PostgresWorkflowCommandContext } from './queue.ts'
+import { DEFAULT_LEASE_MS } from '../../runtime/executors.ts'
 import { createPostgresWorkflowCommandHelpers } from './queue.ts'
 import { WORKFLOW_COMMANDS_CHANNEL, id, json, many, one } from './sql.ts'
 
@@ -146,7 +147,7 @@ export const createAttemptExecutor = (
       if (eligible.length === 0) return null
       return claimAttempt(eligible, params, worker.workerId, worker.leaseMs)
     },
-    async heartbeat(attempt, leaseMs = 30_000) {
+    async heartbeat(attempt, leaseMs = DEFAULT_LEASE_MS) {
       await ready
       const updated = await one<{
         id: string

--- a/packages/workflows/src/adapters/postgres/queue.ts
+++ b/packages/workflows/src/adapters/postgres/queue.ts
@@ -4,7 +4,10 @@ import type {
   RunCoordinationExecutor,
 } from '../../runtime/executors.ts'
 import type { WorkflowPostgresConnection } from './connection.ts'
-import { toStoredError } from '../../runtime/errors.ts'
+import {
+  COMMAND_LEASE_EXPIRED_ERROR,
+  toStoredError,
+} from '../../runtime/errors.ts'
 import {
   MAX_ERROR_BACKOFF_MS,
   RELEASE_BACKOFF_MS,
@@ -20,6 +23,16 @@ export type PostgresWorkflowCommandContext = {
   readonly ready: Promise<void>
   readonly maxDeliveries: number
 }
+
+// One source for the dead-letter threshold so the release path and the
+// claim-time takeover cannot drift apart.
+const atDeadLetterThreshold = (maxDeliveriesParam: string) =>
+  `delivery_count + 1 >= ${maxDeliveriesParam}`
+
+// Bounds the dead-letter drain inside a single claim call: a backlog of
+// at-threshold expired commands (e.g. after a fleet-wide crash) must not
+// stall one claimer for its full length — the poll loop retries shortly.
+const MAX_DEAD_LETTERED_PER_CLAIM = 16
 
 export const createPostgresWorkflowCommandHelpers = (
   ctx: PostgresWorkflowCommandContext,
@@ -95,7 +108,7 @@ export const createPostgresWorkflowCommandHelpers = (
           delivery_count = delivery_count + 1,
           last_error = $3::jsonb,
           dead_at = CASE
-            WHEN delivery_count + 1 >= $4 THEN now()
+            WHEN ${atDeadLetterThreshold('$4')} THEN now()
             ELSE dead_at
           END,
           run_at = now() + (
@@ -121,7 +134,6 @@ export const createPostgresWorkflowCommandHelpers = (
     workerId: string,
     leaseMs: number,
   ) => {
-    const leaseToken = id()
     const conditions = typeof where === 'string' ? [where] : where
     const candidateQuery = (condition: string) => `
       SELECT id, priority, run_at, created_at
@@ -158,19 +170,52 @@ export const createPostgresWorkflowCommandHelpers = (
             LIMIT 1
           )
         `
-    return await one(
-      db,
-      `
+    // Taking over an expired lease means the previous delivery died without
+    // any release — the one failure mode release-time counting can never see
+    // (a crashed worker persists nothing). Counting it here is what makes
+    // poison commands reach `dead_at` instead of crash-looping forever; at
+    // the threshold the row is dead-lettered instead of delivered. SET
+    // expressions read pre-update values, so `lease_token IS NOT NULL`
+    // identifies a takeover (the candidate filter already proved expiry).
+    // The lease fields are written even on the dead branch: a dead row with
+    // lease_token NULL would enter the continue-dedup partial unique index
+    // and collide with a coexisting fresh continue row for the same run.
+    // last_error only fills a gap — a real error from a prior release is
+    // better dead-letter diagnostics than the synthetic lease message.
+    const takeover = 'lease_token IS NOT NULL'
+    const takeoverDead = `${takeover} AND ${atDeadLetterThreshold(`$${params.length + 4}`)}`
+    const claimSql = `
       WITH ${candidateSql}
       UPDATE workflow_commands
-      SET lease_owner = $${params.length + 1},
+      SET delivery_count = delivery_count
+            + CASE WHEN ${takeover} THEN 1 ELSE 0 END,
+          last_error = CASE
+            WHEN ${takeover} AND last_error IS NULL THEN $${params.length + 5}::jsonb
+            ELSE last_error
+          END,
+          dead_at = CASE WHEN ${takeoverDead} THEN now() ELSE dead_at END,
+          lease_owner = $${params.length + 1},
           lease_token = $${params.length + 2},
           lease_expires_at = now() + ($${params.length + 3}::int * interval '1 millisecond')
       WHERE id = (SELECT id FROM candidate)
       RETURNING *
-    `,
-      [...params, workerId, leaseToken, leaseMs],
-    )
+    `
+    const leaseExpiredErrorJson = json(COMMAND_LEASE_EXPIRED_ERROR)
+    for (let drained = 0; drained <= MAX_DEAD_LETTERED_PER_CLAIM; drained++) {
+      const claimed = await one(db, claimSql, [
+        ...params,
+        workerId,
+        id(),
+        leaseMs,
+        maxDeliveries,
+        leaseExpiredErrorJson,
+      ])
+      if (!claimed) return null
+      if (claimed.dead_at == null) return claimed
+      // The candidate was dead-lettered, not delivered — keep claiming so a
+      // single poison command can't starve the worker of the work behind it.
+    }
+    return null
   }
 
   const ackCommand = async (commandId: string, leaseToken: string) => {

--- a/packages/workflows/src/runtime/errors.ts
+++ b/packages/workflows/src/runtime/errors.ts
@@ -32,6 +32,19 @@ export class WorkflowRunConflictError extends Error {
   }
 }
 
+/**
+ * Recorded as `last_error` when a claim takes over an expired lease and no
+ * real error is stored yet. The dying worker persisted nothing, so this
+ * synthetic error is the only trace of WHY the delivery is being counted.
+ * A pre-serialized constant without a stack: capturing one would point at
+ * the claiming worker, not the crash, and would misdirect an incident.
+ */
+export const COMMAND_LEASE_EXPIRED_ERROR: StoredError = {
+  name: 'Error',
+  message:
+    'Workflow command lease expired without release — the worker likely crashed mid-delivery',
+}
+
 const MAX_STORED_ERROR_CAUSE_DEPTH = 5
 
 export function toStoredError(

--- a/packages/workflows/src/runtime/executors.ts
+++ b/packages/workflows/src/runtime/executors.ts
@@ -9,6 +9,13 @@ import type {
 } from './commands.ts'
 import type { RuntimeRunStatus } from './status.ts'
 
+/**
+ * Single home for the fallback lease duration so the worker loop and both
+ * adapters' heartbeat defaults cannot drift apart — the value now decides
+ * when an expired lease counts as a lost delivery.
+ */
+export const DEFAULT_LEASE_MS = 30_000
+
 export type CommandReleaseOptions = {
   readonly error?: unknown
   /**
@@ -17,7 +24,9 @@ export type CommandReleaseOptions = {
    * a longer backoff, so definition drift surfaces in dead commands instead
    * of an unbounded claim/release loop. A plain release (no error, no reason)
    * stays uncounted — it means "expected to succeed on redelivery" (worker
-   * shutdown, lease loss).
+   * shutdown, lease loss). Crashed deliveries never release at all: claiming
+   * a command whose lease expired counts the lost delivery instead, so poison
+   * commands that keep killing workers still reach dead-lettering.
    */
   readonly reason?: 'unroutable'
 }
@@ -29,6 +38,14 @@ export type AttemptHeartbeatResult = {
 export type RunCoordinationExecutor = {
   enqueue(command: ContinueRunCommand): Promise<void>
   enqueueDelayed(command: ContinueRunCommand, runAt: Date): Promise<void>
+  /**
+   * Continue commands have no heartbeat, so a continuation that outlives
+   * `leaseMs` loses its lease and the takeover counts a delivery even though
+   * the worker is healthy. Accumulation is bounded (~1 per slow pass — the
+   * original executor still advances run state, so redelivered copies no-op
+   * and ack), but `leaseMs` must comfortably exceed the worst-case
+   * continuation time relative to `maxDeliveries`.
+   */
   claim(worker: RunCoordinationWorkerClaim): Promise<ClaimedCommand | null>
   ack(command: ClaimedCommand): Promise<void>
   release(

--- a/packages/workflows/src/runtime/in-memory.ts
+++ b/packages/workflows/src/runtime/in-memory.ts
@@ -44,7 +44,12 @@ import type {
   WorkflowWakeEvents,
 } from './wake-events.ts'
 import { dispatchTaskRunAttempt } from './coordinator/attempt.ts'
-import { WorkflowRunConflictError, toStoredError } from './errors.ts'
+import {
+  COMMAND_LEASE_EXPIRED_ERROR,
+  WorkflowRunConflictError,
+  toStoredError,
+} from './errors.ts'
+import { DEFAULT_LEASE_MS } from './executors.ts'
 import {
   nextStoredScheduleRunAt,
   normalizeScheduleDefinitions,
@@ -80,6 +85,7 @@ type InspectQueueItem<T> = {
 
 type ClaimedQueueItem<T> = QueueItem<T> & {
   readonly leaseToken: string
+  readonly leaseExpiresAt: Date
 }
 
 const RELEASE_BACKOFF_MS = 50
@@ -1507,8 +1513,13 @@ export function createInMemoryWorkflowRuntime(
     return left <= right ? left : right
   }
   const enqueueContinue = (command: ContinueRunCommand, runAt?: Date) => {
+    // Dead items must not absorb fresh enqueues — a dead-lettered continue
+    // command would otherwise silently swallow every later wake-up for its
+    // run. Mirrors postgres, where claim-time dead rows keep their lease
+    // token and therefore stay outside the continue-dedup partial index.
     const existingIndex = continueRunCommands.findIndex(
-      (item) => item.payload.runId === command.runId,
+      (item) =>
+        item.deadAt === undefined && item.payload.runId === command.runId,
     )
     if (existingIndex === -1) {
       continueRunCommands.push(queueItem(id('continue'), command, runAt))
@@ -1526,6 +1537,19 @@ export function createInMemoryWorkflowRuntime(
     }
     if (runAt === undefined || runAt <= new Date()) {
       fireWake(commandWakeListeners.get('continue'))
+    }
+  }
+  // Shared dead-letter bookkeeping for both failure paths — error releases
+  // and expired-lease takeovers — so the threshold rule cannot drift.
+  const countFailedDelivery = <T>(
+    item: QueueItem<T>,
+    error: StoredError,
+  ): Pick<QueueItem<T>, 'deliveryCount' | 'lastError' | 'deadAt'> => {
+    const deliveryCount = item.deliveryCount + 1
+    return {
+      deliveryCount,
+      lastError: error,
+      ...(deliveryCount >= maxDeliveries ? { deadAt: now() } : {}),
     }
   }
   const releaseQueueItem = <T>(
@@ -1549,16 +1573,43 @@ export function createInMemoryWorkflowRuntime(
     const error =
       options.error ??
       new Error('No implementation can execute this workflow command')
-    const deliveryCount = item.deliveryCount + 1
+    const counted = countFailedDelivery(item, toStoredError(error))
     return {
       ...item,
-      deliveryCount,
-      lastError: toStoredError(error),
-      ...(deliveryCount >= maxDeliveries ? { deadAt: now() } : {}),
+      ...counted,
       runAt: new Date(
         Date.now() +
-          Math.min(2 ** deliveryCount * backoffBaseMs, MAX_ERROR_BACKOFF_MS),
+          Math.min(
+            2 ** counted.deliveryCount * backoffBaseMs,
+            MAX_ERROR_BACKOFF_MS,
+          ),
       ),
+    }
+  }
+  // Mirrors the postgres claim-time takeover: an expired lease means the
+  // delivery died without any release (the only failure release-time counting
+  // can never see), so requeueing must count it — otherwise a poison command
+  // whose processing kills the claimer crash-loops with deliveryCount stuck
+  // at 0 and deadAt unreachable. At the threshold the item dead-letters
+  // instead of becoming claimable again.
+  const reclaimExpiredLeases = <T>(
+    claimed: Map<string, ClaimedQueueItem<T>>,
+    queue: QueueItem<T>[],
+  ) => {
+    const date = now()
+    for (const [key, item] of claimed) {
+      if (item.leaseExpiresAt > date) continue
+      claimed.delete(key)
+      const { leaseToken: _token, leaseExpiresAt: _expires, ...released } = item
+      // A real error from a prior release beats the synthetic lease message
+      // as dead-letter diagnostics, so the takeover only fills a gap.
+      queue.push({
+        ...released,
+        ...countFailedDelivery(
+          item,
+          item.lastError ?? COMMAND_LEASE_EXPIRED_ERROR,
+        ),
+      })
     }
   }
   const mapDeadCommand = (
@@ -1620,6 +1671,7 @@ export function createInMemoryWorkflowRuntime(
       enqueueContinue(command, runAt)
     },
     async claim(worker) {
+      reclaimExpiredLeases(claimedContinueRunCommands, continueRunCommands)
       const date = now()
       const item = claimQueued(
         continueRunCommands,
@@ -1637,6 +1689,7 @@ export function createInMemoryWorkflowRuntime(
       claimedContinueRunCommands.set(claim.id, {
         ...item,
         leaseToken: claim.leaseToken,
+        leaseExpiresAt: new Date(date.getTime() + worker.leaseMs),
       })
       return claim
     },
@@ -1659,6 +1712,7 @@ export function createInMemoryWorkflowRuntime(
 
   const claimedAttempt = (
     item: QueueItem<AttemptCommand> | undefined,
+    leaseMs: number,
   ):
     | {
         readonly claim: ClaimedAttempt
@@ -1677,6 +1731,7 @@ export function createInMemoryWorkflowRuntime(
       item: {
         ...item,
         leaseToken,
+        leaseExpiresAt: new Date(now().getTime() + leaseMs),
       },
     }
   }
@@ -1701,6 +1756,7 @@ export function createInMemoryWorkflowRuntime(
       }
     },
     async claim(worker) {
+      reclaimExpiredLeases(claimedAttemptCommands, attemptCommands)
       const date = now()
       const claimed = claimedAttempt(
         claimQueued(
@@ -1719,15 +1775,21 @@ export function createInMemoryWorkflowRuntime(
           },
           compareAttemptCommands,
         ),
+        worker.leaseMs,
       )
       if (!claimed) return null
       claimedAttemptCommands.set(claimed.claim.id, claimed.item)
       return claimed.claim
     },
-    async heartbeat(attempt) {
-      if (!matchesClaim(claimedAttemptCommands.get(attempt.id), attempt)) {
+    async heartbeat(attempt, leaseMs = DEFAULT_LEASE_MS) {
+      const claimed = claimedAttemptCommands.get(attempt.id)
+      if (!claimed || !matchesClaim(claimed, attempt)) {
         throw new Error('Workflow attempt heartbeat lease lost')
       }
+      claimedAttemptCommands.set(attempt.id, {
+        ...claimed,
+        leaseExpiresAt: new Date(now().getTime() + leaseMs),
+      })
       return { runStatus: runs.get(attempt.command.runId)?.status ?? 'queued' }
     },
     async ack(attempt) {

--- a/packages/workflows/src/runtime/in-memory.ts
+++ b/packages/workflows/src/runtime/in-memory.ts
@@ -1591,14 +1591,19 @@ export function createInMemoryWorkflowRuntime(
   // can never see), so requeueing must count it — otherwise a poison command
   // whose processing kills the claimer crash-loops with deliveryCount stuck
   // at 0 and deadAt unreachable. At the threshold the item dead-letters
-  // instead of becoming claimable again.
+  // instead of becoming claimable again. Only leases the polling worker is
+  // eligible to redeliver are reclaimed — in postgres the takeover happens
+  // inside the eligible claim itself, and an unrelated worker must not
+  // revoke (or dead-letter) work it cannot execute while the original
+  // claimer may still finish and ack.
   const reclaimExpiredLeases = <T>(
     claimed: Map<string, ClaimedQueueItem<T>>,
     queue: QueueItem<T>[],
+    eligible: (payload: T) => boolean,
   ) => {
     const date = now()
     for (const [key, item] of claimed) {
-      if (item.leaseExpiresAt > date) continue
+      if (item.leaseExpiresAt > date || !eligible(item.payload)) continue
       claimed.delete(key)
       const { leaseToken: _token, leaseExpiresAt: _expires, ...released } = item
       // A real error from a prior release beats the synthetic lease message
@@ -1671,12 +1676,18 @@ export function createInMemoryWorkflowRuntime(
       enqueueContinue(command, runAt)
     },
     async claim(worker) {
-      reclaimExpiredLeases(claimedContinueRunCommands, continueRunCommands)
+      const eligible = (command: ContinueRunCommand) =>
+        worker.workflowNames.includes(command.workflowName)
+      reclaimExpiredLeases(
+        claimedContinueRunCommands,
+        continueRunCommands,
+        eligible,
+      )
       const date = now()
       const item = claimQueued(
         continueRunCommands,
         (queued) =>
-          worker.workflowNames.includes(queued.payload.workflowName) &&
+          eligible(queued.payload) &&
           (queued.runAt === undefined || queued.runAt <= date),
       )
       if (!item) return null
@@ -1756,23 +1767,24 @@ export function createInMemoryWorkflowRuntime(
       }
     },
     async claim(worker) {
-      reclaimExpiredLeases(claimedAttemptCommands, attemptCommands)
+      const eligible = (command: AttemptCommand) => {
+        if (command.kind === 'taskAttempt') {
+          return worker.taskNames.includes(command.taskName)
+        }
+        return (
+          worker.workflowNames.includes(command.workflowName) &&
+          (worker.activityNames === undefined ||
+            worker.activityNames.includes(command.activityName))
+        )
+      }
+      reclaimExpiredLeases(claimedAttemptCommands, attemptCommands, eligible)
       const date = now()
       const claimed = claimedAttempt(
         claimQueued(
           attemptCommands,
-          (queued) => {
-            const command = queued.payload
-            if (queued.runAt !== undefined && queued.runAt > date) return false
-            if (command.kind === 'taskAttempt') {
-              return worker.taskNames.includes(command.taskName)
-            }
-            return (
-              worker.workflowNames.includes(command.workflowName) &&
-              (worker.activityNames === undefined ||
-                worker.activityNames.includes(command.activityName))
-            )
-          },
+          (queued) =>
+            (queued.runAt === undefined || queued.runAt <= date) &&
+            eligible(queued.payload),
           compareAttemptCommands,
         ),
         worker.leaseMs,

--- a/packages/workflows/src/runtime/worker/loop.ts
+++ b/packages/workflows/src/runtime/worker/loop.ts
@@ -9,7 +9,7 @@ import type {
 } from '../store.ts'
 import { parseDurationMs } from '../duration.ts'
 
-export const DEFAULT_LEASE_MS = 30_000
+export { DEFAULT_LEASE_MS } from '../executors.ts'
 
 export type WorkerLoopResult = {
   readonly processed: number

--- a/packages/workflows/tests/runtime-adapter-contract.spec.ts
+++ b/packages/workflows/tests/runtime-adapter-contract.spec.ts
@@ -27,8 +27,12 @@ type RuntimeFactory = (
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
-const waitForReleaseBackoff = () =>
-  new Promise((resolve) => setTimeout(resolve, 60))
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const waitForReleaseBackoff = () => wait(60)
+
+// Comfortably past the 30 ms claim leases used by the crash-loop tests.
+const waitForLeaseExpiry = () => wait(80)
 
 const createPgliteConnection = () =>
   createPostgresWorkflowConnection(new PGlite())
@@ -720,6 +724,243 @@ function workflowRuntimeAdapterContract(
         leaseMs: 30_000,
       })
       expect(requeued?.command).toStrictEqual(command)
+    })
+
+    it('counts lease-expired continue redeliveries toward dead-lettering', async () => {
+      const runtime = await createRuntime({ maxDeliveries: 2 })
+      const run = await runtime.store.createRun({
+        workflowName: 'crash-loop-continue-workflow',
+        input: {},
+      })
+      await runtime.runCoordinationExecutor.enqueue({
+        kind: 'continueRun',
+        runId: run.id,
+        workflowName: 'crash-loop-continue-workflow',
+      })
+      const claimWorker = (workerId: string) =>
+        runtime.runCoordinationExecutor.claim({
+          workerId,
+          workflowNames: ['crash-loop-continue-workflow'],
+          leaseMs: 30,
+        })
+
+      // Delivery 1 "crashes": no ack, no release — only the lease expires.
+      const first = await claimWorker('crashing-worker-1')
+      expect(first?.command.runId).toBe(run.id)
+      await waitForLeaseExpiry()
+
+      // The takeover claim counts the lost delivery but still redelivers
+      // (1 of maxDeliveries 2 spent).
+      const second = await claimWorker('crashing-worker-2')
+      expect(second?.command.runId).toBe(run.id)
+      expect(second?.id).toBe(first?.id)
+      await expect(runtime.store.listDeadCommands()).resolves.toStrictEqual([])
+      await waitForLeaseExpiry()
+
+      // Second crashed delivery reaches the threshold: the command
+      // dead-letters at claim time instead of being delivered again.
+      await expect(claimWorker('crashing-worker-3')).resolves.toBeNull()
+      const dead = await runtime.store.listDeadCommands()
+      expect(dead).toMatchObject([
+        {
+          kind: 'continue',
+          runId: run.id,
+          workflowName: 'crash-loop-continue-workflow',
+          deliveryCount: 2,
+          lastError: {
+            name: 'Error',
+            message: expect.stringContaining('lease expired without release'),
+          },
+        },
+      ])
+      expect(dead[0]?.deadAt).toBeInstanceOf(Date)
+
+      await runtime.store.requeueDeadCommand(dead[0]!.id)
+      const requeued = await claimWorker('recovered-worker')
+      expect(requeued?.command.runId).toBe(run.id)
+    })
+
+    it('dead-letters an expired continue lease alongside a coexisting fresh continue', async () => {
+      const runtime = await createRuntime({ maxDeliveries: 1 })
+      const run = await runtime.store.createRun({
+        workflowName: 'coexisting-dead-continue-workflow',
+        input: {},
+      })
+      const claimWorker = (workerId: string) =>
+        runtime.runCoordinationExecutor.claim({
+          workerId,
+          workflowNames: ['coexisting-dead-continue-workflow'],
+          leaseMs: 30,
+        })
+
+      await runtime.runCoordinationExecutor.enqueue({
+        kind: 'continueRun',
+        runId: run.id,
+        workflowName: 'coexisting-dead-continue-workflow',
+        generation: 1,
+      })
+      const first = await claimWorker('crashing-worker')
+      expect(first).not.toBeNull()
+      // While the first command is leased, a fresh continue for the same run
+      // legally coexists (the continue dedupe only covers unleased commands).
+      await runtime.runCoordinationExecutor.enqueue({
+        kind: 'continueRun',
+        runId: run.id,
+        workflowName: 'coexisting-dead-continue-workflow',
+        generation: 2,
+      })
+      await waitForLeaseExpiry()
+
+      // The takeover dead-letters the expired command at the threshold and
+      // must still deliver the fresh one — not trip over the continue-dedup
+      // uniqueness or swallow the run's pending work.
+      const second = await claimWorker('worker-2')
+      expect(second?.id).not.toBe(first?.id)
+      expect(second?.command).toMatchObject({ runId: run.id, generation: 2 })
+      const dead = await runtime.store.listDeadCommands()
+      expect(dead).toMatchObject([
+        { kind: 'continue', runId: run.id, deliveryCount: 1 },
+      ])
+    })
+
+    it('keeps the last real error when a crashed delivery dead-letters a command', async () => {
+      const runtime = await createRuntime({ maxDeliveries: 2 })
+      const run = await runtime.store.createRun({
+        workflowName: 'real-error-dead-workflow',
+        input: {},
+      })
+      await runtime.runCoordinationExecutor.enqueue({
+        kind: 'continueRun',
+        runId: run.id,
+        workflowName: 'real-error-dead-workflow',
+      })
+      const claimWorker = (workerId: string) =>
+        runtime.runCoordinationExecutor.claim({
+          workerId,
+          workflowNames: ['real-error-dead-workflow'],
+          leaseMs: 30,
+        })
+
+      const first = await claimWorker('worker-1')
+      await runtime.runCoordinationExecutor.release(first!, {
+        error: new Error('real poison failure'),
+      })
+      // First counted delivery backs off exponentially (2^1 * 50 ms).
+      await wait(200)
+      const second = await claimWorker('crashing-worker')
+      expect(second).not.toBeNull()
+      await waitForLeaseExpiry()
+
+      // The crashed delivery reaches the threshold, but the synthetic lease
+      // error must not clobber the real error a prior release recorded.
+      await expect(claimWorker('worker-3')).resolves.toBeNull()
+      const dead = await runtime.store.listDeadCommands()
+      expect(dead).toMatchObject([
+        {
+          kind: 'continue',
+          runId: run.id,
+          deliveryCount: 2,
+          lastError: { name: 'Error', message: 'real poison failure' },
+        },
+      ])
+    })
+
+    it('counts lease-expired attempt redeliveries toward dead-lettering', async () => {
+      const runtime = await createRuntime({ maxDeliveries: 1 })
+      const run = await runtime.store.createRun({
+        workflowName: 'crash-loop-attempt-workflow',
+        input: {},
+      })
+      const command = {
+        kind: 'activityAttempt' as const,
+        workflowName: 'crash-loop-attempt-workflow',
+        activityName: 'content',
+        runId: run.id,
+        nodeName: 'content',
+        childKey: '$self',
+        attemptId: '00000000-0000-4000-8000-000000000213',
+        leaseToken: 'attempt-lease',
+        input: {},
+      }
+      await runtime.attemptExecutor.dispatchActivity(command)
+      const claimWorker = (workerId: string) =>
+        runtime.attemptExecutor.claim({
+          taskNames: [],
+          workerId,
+          workflowNames: ['crash-loop-attempt-workflow'],
+          activityNames: ['content'],
+          leaseMs: 30,
+        })
+
+      const claimed = await claimWorker('crashing-activity-worker')
+      expect(claimed?.command).toStrictEqual(command)
+      await waitForLeaseExpiry()
+
+      await expect(claimWorker('activity-worker-2')).resolves.toBeNull()
+      const dead = await runtime.store.listDeadCommands()
+      expect(dead).toMatchObject([
+        {
+          kind: 'activity',
+          runId: run.id,
+          workflowName: 'crash-loop-attempt-workflow',
+          activityName: 'content',
+          attemptId: command.attemptId,
+          deliveryCount: 1,
+          lastError: {
+            name: 'Error',
+            message: expect.stringContaining('lease expired without release'),
+          },
+        },
+      ])
+      // The crashed claimer's lease was consumed by the takeover.
+      await expect(runtime.attemptExecutor.ack(claimed!)).rejects.toThrow(
+        'Stale workflow command ack',
+      )
+
+      await runtime.store.requeueDeadCommand(dead[0]!.id)
+      const requeued = await claimWorker('activity-worker-3')
+      expect(requeued?.command).toStrictEqual(command)
+    })
+
+    it('keeps heartbeated attempt leases from expiring into redelivery', async () => {
+      const runtime = await createRuntime({ maxDeliveries: 1 })
+      const run = await runtime.store.createRun({
+        workflowName: 'heartbeat-lease-workflow',
+        input: {},
+      })
+      await runtime.attemptExecutor.dispatchActivity({
+        kind: 'activityAttempt',
+        workflowName: 'heartbeat-lease-workflow',
+        activityName: 'content',
+        runId: run.id,
+        nodeName: 'content',
+        childKey: '$self',
+        attemptId: '00000000-0000-4000-8000-000000000214',
+        leaseToken: 'attempt-lease',
+        input: {},
+      })
+      const claimWorker = (workerId: string) =>
+        runtime.attemptExecutor.claim({
+          taskNames: [],
+          workerId,
+          workflowNames: ['heartbeat-lease-workflow'],
+          activityNames: ['content'],
+          leaseMs: 500,
+        })
+
+      const claimed = await claimWorker('slow-activity-worker')
+      expect(claimed).not.toBeNull()
+      await wait(200)
+      await runtime.attemptExecutor.heartbeat(claimed!, 30_000)
+      await wait(400)
+
+      // Past the original 500 ms lease, but the heartbeat extended it — the
+      // attempt must be neither redelivered nor counted as a lost delivery.
+      await expect(claimWorker('stealing-worker')).resolves.toBeNull()
+      await expect(runtime.store.listDeadCommands()).resolves.toStrictEqual([])
+      await expect(
+        runtime.attemptExecutor.ack(claimed!),
+      ).resolves.toBeUndefined()
     })
 
     it('prunes old terminal root run trees and associated commands', async () => {

--- a/packages/workflows/tests/runtime-adapter-contract.spec.ts
+++ b/packages/workflows/tests/runtime-adapter-contract.spec.ts
@@ -793,22 +793,20 @@ function workflowRuntimeAdapterContract(
           leaseMs: 30,
         })
 
-      await runtime.runCoordinationExecutor.enqueue({
-        kind: 'continueRun',
+      const staleCommand = {
+        kind: 'continueRun' as const,
         runId: run.id,
         workflowName: 'coexisting-dead-continue-workflow',
         generation: 1,
-      })
+      }
+      const freshCommand = { ...staleCommand, generation: 2 }
+
+      await runtime.runCoordinationExecutor.enqueue(staleCommand)
       const first = await claimWorker('crashing-worker')
       expect(first).not.toBeNull()
       // While the first command is leased, a fresh continue for the same run
       // legally coexists (the continue dedupe only covers unleased commands).
-      await runtime.runCoordinationExecutor.enqueue({
-        kind: 'continueRun',
-        runId: run.id,
-        workflowName: 'coexisting-dead-continue-workflow',
-        generation: 2,
-      })
+      await runtime.runCoordinationExecutor.enqueue(freshCommand)
       await waitForLeaseExpiry()
 
       // The takeover dead-letters the expired command at the threshold and
@@ -821,6 +819,44 @@ function workflowRuntimeAdapterContract(
       expect(dead).toMatchObject([
         { kind: 'continue', runId: run.id, deliveryCount: 1 },
       ])
+    })
+
+    it('leaves expired leases alone for workers that cannot execute them', async () => {
+      const runtime = await createRuntime({ maxDeliveries: 1 })
+      const run = await runtime.store.createRun({
+        workflowName: 'eligible-reclaim-workflow',
+        input: {},
+      })
+      await runtime.runCoordinationExecutor.enqueue({
+        kind: 'continueRun',
+        runId: run.id,
+        workflowName: 'eligible-reclaim-workflow',
+      })
+      const claimed = await runtime.runCoordinationExecutor.claim({
+        workerId: 'stalled-worker',
+        workflowNames: ['eligible-reclaim-workflow'],
+        leaseMs: 30,
+      })
+      expect(claimed).not.toBeNull()
+      await waitForLeaseExpiry()
+
+      // A worker for an unrelated workflow polls past the expired lease: it
+      // must neither count the lost delivery nor dead-letter work it cannot
+      // execute.
+      await expect(
+        runtime.runCoordinationExecutor.claim({
+          workerId: 'unrelated-worker',
+          workflowNames: ['some-other-workflow'],
+          leaseMs: 30,
+        }),
+      ).resolves.toBeNull()
+      await expect(runtime.store.listDeadCommands()).resolves.toStrictEqual([])
+
+      // Nobody eligible took the command over, so the stalled-but-alive
+      // claimer can still finish and ack.
+      await expect(
+        runtime.runCoordinationExecutor.ack(claimed!),
+      ).resolves.toBeUndefined()
     })
 
     it('keeps the last real error when a crashed delivery dead-letters a command', async () => {


### PR DESCRIPTION
Fixes #296

## Why

The queue's dead-letter mechanism (`delivery_count`, `maxDeliveries`, `dead_at`) was unreachable for the failure class it should protect against most: a poison command whose processing kills the worker. `delivery_count` only advanced on an explicit error release — a crashed worker persists nothing, and `claimCommand` re-claimed expired-lease rows touching only the lease fields. Every counter was reset by the very crash it should be counting, so the command crash-looped forever, surviving full restarts.

The in-memory adapter was worse than the issue described: it ignored `leaseMs` entirely — claimed items sat in a map with no expiry, so an abandoned claim stranded the command forever.

## What

Claim-time takeover counting. A claim that finds a still-set `lease_token` (necessarily expired — the candidate filter proves it) is taking over from a delivery that died without a release. That claim now:

1. increments `delivery_count`,
2. records a synthetic "lease expired without release" error — only when no real error is already stored,
3. at the threshold, **dead-letters the row instead of delivering it**, then moves on to the next candidate.

Once dead, the existing reaper fails the run cleanly — no downstream or schema changes.

Takeover-counting was chosen over SQS-style count-on-every-claim because plain (shutdown/abandon) releases are documented as uncounted; counting every claim would let healthy commands dead-letter during rolling restarts. The arithmetic composes with the release path — `delivery_count` remains "completed deliveries" whether an attempt ended in an error release or a crash. Crash redelivery is inherently throttled at ~`leaseMs` per cycle (a crash must hold its lease to expiry before the next counted claim), so no extra backoff is needed.

## How

**`adapters/postgres/queue.ts`** — the single-statement claim UPDATE gained CASE arms keyed on pre-update `lease_token`. Two subtleties:

- The dead branch **keeps the claimer's lease fields set**: nulling `lease_token` would push the dead row into the `continue_dedup` partial unique index (`WHERE kind='continue' AND lease_token IS NULL`) and collide with a legally coexisting fresh continue row for the same run — a 23505 out of `claim()` wedging the worker poll. Dead rows are already unclaimable via `dead_at IS NULL`, and `requeueDeadCommand` clears leases on revival.
- The drain loop is capped at 16 dead-letters per `claim()` call so an at-threshold backlog (e.g. after a fleet-wide crash) cannot stall one claimer; the poller resumes shortly.

**`runtime/in-memory.ts`** — claimed items carry `leaseExpiresAt`; every claim first sweeps expired leases back into the queue through a `countFailedDelivery` helper shared with the release path (threshold rule cannot drift). `heartbeat` now actually extends the lease, and `enqueueContinue` skips dead items in its dedupe scan so a dead command cannot silently swallow later wake-ups.

**`runtime/errors.ts`** — the synthetic error is a pre-serialized, deliberately stackless `StoredError` constant: a captured stack would point at the claiming worker rather than the crash, and building it per poll would put allocation + stack formatting + JSON serialization in the hot path.

**`runtime/executors.ts`** — documents both semantics: expired-lease claims count the lost delivery, and continue commands have no heartbeat, so `leaseMs` must comfortably exceed worst-case continuation time relative to `maxDeliveries`. `DEFAULT_LEASE_MS` centralized here for the worker loop and both adapters' heartbeat defaults.

**Tests** (contract suite, runs against in-memory and PGlite-Postgres): crash-loop dead-lettering for continue and attempt commands, stale ack after takeover, heartbeat keeping a lease alive past its original expiry, plus regressions for the index-collision scenario and real-error preservation.

## Out of scope (follow-ups)

- Pre-existing release-path variant of the swallowed-enqueue hole (dead rows with `lease_token = NULL` absorbing `ON CONFLICT` upserts).
- A command-lease heartbeat for long continuations (changes the `RunCoordinationExecutor` contract).
- Issue #296's optional items: crash-report attribution of the in-flight command and `AsyncLocalStorage` rejection attribution (live in `packages/neem`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lease-expiration recovery: expired commands are safely taken over, counted as lost deliveries, and reclaimed for correct redelivery.
  - Dead-letter handling is now consistent across release and claim paths, including during lease takeover.
  - Preserved real `lastError` details when lease-expiration takeover occurs.
  - Heartbeats now reliably extend leases using a shared default lease duration.

- **Reliability**
  - Reduced risk of poisoned commands stalling progress by limiting per-claim dead-letter draining.

- **Tests**
  - Added lease-expiry and takeover coverage for both coordinator continuations and activity attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->