### PR TITLE
type: rebuild custom types on zod codecs, validate defaults via prefault

### DIFF
--- a/packages/type/src/types/base.ts
+++ b/packages/type/src/types/base.ts
@@ -11,12 +11,13 @@ import type {
   ZodMiniNumber,
   ZodMiniObject,
   ZodMiniOptional,
+  ZodMiniPrefault,
   ZodMiniRecord,
   ZodMiniString,
   ZodMiniType,
   ZodMiniUnion,
 } from 'zod/mini'
-import { _default, core, nullable, optional } from 'zod/mini'
+import { core, nullable, optional, prefault } from 'zod/mini'
 
 import type { TypeMetadata } from './_metadata.ts'
 import { standard } from '../standart-schema.ts'
@@ -29,6 +30,7 @@ export type PrimitiveZodType =
   | ZodMiniDefault
   | ZodMiniNullable
   | ZodMiniOptional
+  | ZodMiniPrefault
   | ZodMiniString
   | ZodMiniObject
   | ZodMiniAny
@@ -48,13 +50,11 @@ export type ZodType = SimpleZodType | ZodMiniType<any, any, any>
 export type TypeProps = Record<string, any>
 
 export type TypeParams = {
-  encode?: (value: any) => any
   metadata?: TypeMetadata
   checks: Array<core.CheckFn<any> | core.$ZodCheck<any>>
 }
 
 export type DefaultTypeParams = {
-  encode?: TypeParams['encode']
   metadata?: TypeMetadata
 }
 
@@ -116,7 +116,9 @@ export abstract class BaseType<
     return this.nullable().optional()
   }
 
-  default(value: this['encodeZodType']['_zod']['input']): DefaultType<this> {
+  default(
+    value: core.util.NoUndefined<this['encodeZodType']['_zod']['input']>,
+  ): DefaultType<this> {
     return DefaultType.factory(this, value)
   }
 
@@ -130,9 +132,7 @@ export abstract class BaseType<
 
   examples(...examples: this['encodeZodType']['_zod']['input'][]): this {
     return this.meta({
-      examples: this.params.encode
-        ? examples.map(this.params.encode)
-        : examples,
+      examples: examples.map((example) => this.encode(example)),
     })
   }
 
@@ -147,14 +147,14 @@ export abstract class BaseType<
     data: this['encodeZodType']['_zod']['input'],
     context: core.ParseContext<core.$ZodIssue> = {},
   ): this['encodeZodType']['_zod']['output'] {
-    return this.encodeZodType.parse(data, { reportInput: true, ...context })
+    return this.encodeZodType.parse(data, context)
   }
 
   decode(
     data: this['decodeZodType']['_zod']['input'],
     context: core.ParseContext<core.$ZodIssue> = {},
   ): this['decodeZodType']['_zod']['output'] {
-    return this.decodeZodType.parse(data, { reportInput: true, ...context })
+    return this.decodeZodType.parse(data, context)
   }
 }
 
@@ -193,17 +193,22 @@ export class NullableType<
 export class DefaultType<
   Type extends BaseTypeAny = BaseTypeAny,
 > extends BaseType<
-  ZodMiniDefault<Type['encodeZodType']>,
-  ZodMiniDefault<Type['decodeZodType']>,
+  ZodMiniPrefault<Type['encodeZodType']>,
+  ZodMiniPrefault<Type['decodeZodType']>,
   { inner: Type }
 > {
-  static factory<T extends BaseTypeAny<any>>(type: T, defaultValue: any) {
+  static factory<T extends BaseTypeAny<any>>(
+    type: T,
+    defaultValue: core.util.NoUndefined<T['encodeZodType']['_zod']['input']>,
+  ) {
+    const encodedDefault = type.encode(defaultValue)
+
     return new DefaultType<T>({
-      encodeZodType: _default(
-        type.encodeZodType,
-        type.params.encode?.(defaultValue) ?? defaultValue,
+      encodeZodType: prefault(type.encodeZodType, defaultValue),
+      decodeZodType: prefault(
+        type.decodeZodType,
+        encodedDefault as T['decodeZodType']['_zod']['input'],
       ),
-      decodeZodType: _default(type.decodeZodType, defaultValue),
       props: { inner: type },
     })
   }

--- a/packages/type/src/types/custom.ts
+++ b/packages/type/src/types/custom.ts
@@ -1,26 +1,72 @@
 import type { MaybePromise } from '@nmtjs/common'
-import type { core, ZodMiniType } from 'zod/mini'
-import {
-  any,
-  overwrite,
-  pipe,
-  refine,
-  superRefine,
-  custom as zodCustom,
-} from 'zod/mini'
+import type { core, ZodMiniCodec, ZodMiniType } from 'zod/mini'
+import { NEVER, any, codec, invertCodec, superRefine } from 'zod/mini'
 
 import type { SimpleZodType, ZodType } from './base.ts'
 import { BaseType } from './base.ts'
 
 export type CustomTransformFn<I, O> = (value: I) => O
+
+type CustomValidation<Type extends ZodType> = (
+  value: Type['_zod']['output'],
+  payload: core.$RefinementCtx<Type['_zod']['output']>,
+) => MaybePromise<void>
+
 export abstract class TransformType<
   Type,
   EncodeType extends SimpleZodType = ZodMiniType<Type, Type>,
   DecodeType extends ZodType = ZodMiniType<Type, Type>,
 > extends BaseType<
-  ZodMiniType<EncodeType['_zod']['output'], DecodeType['_zod']['input']>,
-  ZodMiniType<DecodeType['_zod']['output'], EncodeType['_zod']['input']>
+  ZodMiniCodec<DecodeType, EncodeType>,
+  ZodMiniCodec<EncodeType, DecodeType>
 > {}
+
+const addIssue = (
+  payload: core.ParsePayload,
+  value: unknown,
+  issue: string | core.$ZodSuperRefineIssue,
+) => {
+  payload.issues.push(
+    (typeof issue === 'string'
+      ? { code: 'custom', message: issue, input: value }
+      : {
+          ...issue,
+          code: issue.code ?? 'custom',
+          input: issue.input ?? value,
+        }) as core.$ZodRawIssue,
+  )
+}
+
+const refinementContext = <T>(
+  payload: core.ParsePayload<T>,
+): core.$RefinementCtx<T> => {
+  return Object.assign(payload, {
+    addIssue: (issue: string | core.$ZodSuperRefineIssue) =>
+      addIssue(payload, payload.value, issue),
+  })
+}
+
+const addTransformIssue = (
+  payload: core.ParsePayload,
+  value: unknown,
+  error: string | core.$ZodErrorMap<core.$ZodIssueBase> | undefined,
+  cause: unknown,
+) => {
+  const issue = {
+    code: 'custom',
+    input: value,
+  } as const satisfies core.$ZodRawIssue
+  const mappedError = typeof error === 'function' ? error(issue) : undefined
+  const message =
+    typeof error === 'string'
+      ? error
+      : typeof mappedError === 'string'
+        ? mappedError
+        : (mappedError?.message ??
+          (cause instanceof Error ? cause.message : 'Invalid input'))
+
+  payload.issues.push({ ...issue, message })
+}
 
 export class CustomType<
   Type,
@@ -37,35 +83,28 @@ export class CustomType<
     validation,
     error,
     type = any() as unknown as EncodeType,
+    decodedType = any() as unknown as DecodeType,
     prototype,
   }: {
     decode: CustomTransformFn<
-      EncodeType['_zod']['input'],
-      DecodeType['_zod']['output']
+      EncodeType['_zod']['output'],
+      DecodeType['_zod']['input']
     >
     encode: CustomTransformFn<
-      DecodeType['_zod']['input'],
-      EncodeType['_zod']['output']
+      DecodeType['_zod']['output'],
+      EncodeType['_zod']['input']
     >
     validation?:
-      | ((
-          value: EncodeType['_zod']['input'] | DecodeType['_zod']['output'],
-          payload: core.$RefinementCtx<
-            EncodeType['_zod']['output'] | DecodeType['_zod']['output']
-          >,
-        ) => MaybePromise<void>)
+      | CustomValidation<DecodeType>
       | {
-          encode?: (
-            value: EncodeType['_zod']['input'],
-            payload: core.$RefinementCtx<EncodeType['_zod']['output']>,
-          ) => MaybePromise<void>
-          decode?: (
-            value: DecodeType['_zod']['output'],
-            payload: core.$RefinementCtx<DecodeType['_zod']['output']>,
-          ) => MaybePromise<void>
+          encode?: CustomValidation<DecodeType>
+          decode?: CustomValidation<DecodeType>
         }
     error?: string | core.$ZodErrorMap<core.$ZodIssueBase>
+    /** Schema for the encoded/wire representation. */
     type?: EncodeType
+    /** Schema for the decoded/runtime representation. */
+    decodedType?: DecodeType
     prototype?: object
   }): CustomType<Type, EncodeType, DecodeType> {
     const _validation = validation
@@ -73,36 +112,41 @@ export class CustomType<
         ? { encode: validation, decode: validation }
         : validation
       : undefined
-    const errorParams =
-      typeof error === 'string'
-        ? error
-        : error
-          ? { error: error as any }
-          : undefined
+
+    const decodeZodType = codec(type, decodedType, {
+      decode: (value, payload) => {
+        try {
+          return decode(value)
+        } catch (cause) {
+          addTransformIssue(payload, value, error, cause)
+          return NEVER
+        }
+      },
+      encode: (value, payload) => {
+        const transform = () => {
+          if (payload.issues.length > 0) return NEVER
+
+          try {
+            return encode(value)
+          } catch (cause) {
+            addTransformIssue(payload, value, error, cause)
+            return NEVER
+          }
+        }
+        const result = _validation?.encode?.(value, refinementContext(payload))
+
+        return result instanceof Promise ? result.then(transform) : transform()
+      },
+    })
+    const encodeZodType = invertCodec(decodeZodType)
+
+    if (_validation?.decode) {
+      decodeZodType.check(superRefine(_validation.decode))
+    }
 
     const instance = new CustomType<Type, EncodeType, DecodeType>({
-      encodeZodType: pipe(
-        zodCustom(undefined, errorParams).check(
-          ...[
-            refine((val) => typeof val !== 'undefined', { abort: true }),
-            _validation?.encode ? superRefine(_validation.encode) : undefined,
-            overwrite(encode),
-          ].filter((v) => !!v),
-        ),
-        type,
-      ),
-      decodeZodType: pipe(
-        type,
-        // @ts-expect-error
-        zodCustom(undefined, errorParams).check(
-          ...[
-            refine((val) => typeof val !== 'undefined', { abort: true }),
-            overwrite(decode),
-            _validation?.decode ? superRefine(_validation.decode) : undefined,
-          ].filter((v) => !!v),
-        ),
-      ),
-      params: { encode },
+      encodeZodType,
+      decodeZodType,
     })
 
     if (prototype) Object.setPrototypeOf(instance, prototype)

--- a/packages/type/src/types/date.ts
+++ b/packages/type/src/types/date.ts
@@ -1,20 +1,24 @@
-import type { ZodMiniUnion } from 'zod/mini'
-import { iso, union } from 'zod/mini'
+import type { ZodMiniDate, ZodMiniUnion } from 'zod/mini'
+import { date as zodDate, iso, union } from 'zod/mini'
 
 import { CustomType, TransformType } from './custom.ts'
 
 export class DateType extends TransformType<
   Date,
-  ZodMiniUnion<[iso.ZodMiniISODate, iso.ZodMiniISODateTime]>
+  ZodMiniUnion<[iso.ZodMiniISODate, iso.ZodMiniISODateTime]>,
+  ZodMiniDate<Date>
 > {
   static factory(): DateType {
     return CustomType.factory<
       Date,
-      ZodMiniUnion<[iso.ZodMiniISODate, iso.ZodMiniISODateTime]>
+      ZodMiniUnion<[iso.ZodMiniISODate, iso.ZodMiniISODateTime]>,
+      ZodMiniDate<Date>
     >({
       decode: (value) => new Date(value),
       encode: (value) => value.toISOString(),
       type: union([iso.date(), iso.datetime()]),
+      decodedType: zodDate('Invalid Date'),
+      error: 'Invalid date format',
       prototype: DateType.prototype,
     })
   }

--- a/packages/type/src/types/number.ts
+++ b/packages/type/src/types/number.ts
@@ -1,5 +1,11 @@
-import type { core, ZodMiniNumber, ZodMiniString } from 'zod/mini'
+import type {
+  core,
+  ZodMiniBigInt,
+  ZodMiniNumber,
+  ZodMiniString,
+} from 'zod/mini'
 import {
+  bigint as zodBigInt,
   gt,
   gte,
   int,
@@ -57,12 +63,21 @@ export class IntegerType extends NumberType {
   }
 }
 
-export class BigIntType extends TransformType<bigint, ZodMiniString<string>> {
+export class BigIntType extends TransformType<
+  bigint,
+  ZodMiniString<string>,
+  ZodMiniBigInt<bigint>
+> {
   static factory() {
-    return CustomType.factory<bigint, ZodMiniString<string>>({
+    return CustomType.factory<
+      bigint,
+      ZodMiniString<string>,
+      ZodMiniBigInt<bigint>
+    >({
       decode: (value) => BigInt(value),
       encode: (value) => value.toString(),
       type: zodString().check(regex(/^-?\d+$/)),
+      decodedType: zodBigInt('Invalid bigint'),
       error: 'Invalid bigint format',
     })
   }

--- a/packages/type/src/types/temporal.ts
+++ b/packages/type/src/types/temporal.ts
@@ -1,5 +1,5 @@
-import type { ZodMiniString } from 'zod/mini'
-import { iso, regex, string } from 'zod/mini'
+import type { ZodMiniString, ZodMiniType } from 'zod/mini'
+import { custom as zodCustom, iso, regex, string } from 'zod/mini'
 
 import { CustomType, TransformType } from './custom.ts'
 
@@ -31,6 +31,22 @@ const createTemporalTransformer = <T extends typeof Temporal, U extends Types>(
 }
 
 type EncodeType = ZodMiniString<string>
+type DomainTypes = Types | 'Instant'
+
+const temporalType = <T extends typeof Temporal, U extends DomainTypes>(
+  implementation: T,
+  type: U,
+  error: string,
+): ZodMiniType<InstanceType<T[U]>, InstanceType<T[U]>> => {
+  const Constructor = implementation[type] as unknown as abstract new (
+    ...args: any[]
+  ) => InstanceType<T[U]>
+
+  return zodCustom<InstanceType<T[U]>>(
+    (value) => value instanceof Constructor,
+    error,
+  )
+}
 
 export class PlainDateType<
   T extends typeof Temporal = typeof Temporal,
@@ -43,6 +59,11 @@ export class PlainDateType<
       decode: transformer.decode,
       encode: transformer.encode,
       type: iso.date(),
+      decodedType: temporalType(
+        implementation,
+        'PlainDate',
+        'Invalid PlainDate',
+      ),
       error: 'Invalid date format',
     })
   }
@@ -62,6 +83,11 @@ export class PlainDateTimeType<
       decode: transformer.decode,
       encode: transformer.encode,
       type: iso.datetime({ local: true }),
+      decodedType: temporalType(
+        implementation,
+        'PlainDateTime',
+        'Invalid PlainDateTime',
+      ),
       error: 'Invalid datetime format',
     })
   }
@@ -83,6 +109,11 @@ export class ZonedDateTimeType<
       decode: transformer.decode,
       encode: transformer.encode,
       type: string(),
+      decodedType: temporalType(
+        implementation,
+        'ZonedDateTime',
+        'Invalid ZonedDateTime',
+      ),
       error: 'Invalid zoned datetime format',
     })
   }
@@ -100,6 +131,7 @@ export class InstantType<
       decode,
       encode,
       type: iso.datetime(),
+      decodedType: temporalType(implementation, 'Instant', 'Invalid Instant'),
       error: 'Invalid instant format',
     }) as InstantType<T>
   }
@@ -116,6 +148,11 @@ export class PlainTimeType<
       decode: transformer.decode,
       encode: transformer.encode,
       type: iso.time(),
+      decodedType: temporalType(
+        implementation,
+        'PlainTime',
+        'Invalid PlainTime',
+      ),
       error: 'Invalid time format',
     })
   }
@@ -132,6 +169,7 @@ export class DurationType<
       decode: transformer.decode,
       encode: transformer.encode,
       type: iso.duration(),
+      decodedType: temporalType(implementation, 'Duration', 'Invalid Duration'),
       error: 'Invalid duration format',
     })
   }
@@ -151,6 +189,11 @@ export class PlainYearMonthType<
       decode: transformer.decode,
       encode: transformer.encode,
       type: string().check(regex(/^\d{4}-\d{2}$/)),
+      decodedType: temporalType(
+        implementation,
+        'PlainYearMonth',
+        'Invalid PlainYearMonth',
+      ),
       error: 'Invalid year-month format',
     })
   }
@@ -170,6 +213,11 @@ export class PlainMonthDayType<
       decode: transformer.decode,
       encode: transformer.encode,
       type: string().check(regex(/^\d{2}-\d{2}$/)),
+      decodedType: temporalType(
+        implementation,
+        'PlainMonthDay',
+        'Invalid PlainMonthDay',
+      ),
       error: 'Invalid month-day format',
     })
   }

--- a/packages/type/tests/index.spec.ts
+++ b/packages/type/tests/index.spec.ts
@@ -91,7 +91,11 @@ describe('Simple type with defaults', () => {
     }
 
     const result = schema.decode(value)
-    expect(result.prop9).toBeDefined()
+    expect(result.prop9).toEqual([
+      {
+        prop1: [{ prop1: 'default', prop2: 42 }],
+      },
+    ])
   })
 
   it('should encode', () => {
@@ -107,7 +111,56 @@ describe('Simple type with defaults', () => {
     }
 
     const result = schema.encode(value)
-    expect(result.prop9).toBeDefined()
+    expect(result.prop9).toEqual([
+      {
+        prop1: [{ prop1: 'default', prop2: 42 }],
+      },
+    ])
+  })
+
+  it('applies transformed defaults through both directions', () => {
+    const defaultDate = new Date('2024-02-03T04:05:06.000Z')
+    const transformed = t
+      .object({
+        createdAt: t.date().default(defaultDate),
+        count: t.bigInt().default(42n),
+      })
+      .default({})
+
+    expect(transformed.decode(undefined)).toEqual({
+      createdAt: defaultDate,
+      count: 42n,
+    })
+    expect(transformed.encode(undefined)).toEqual({
+      createdAt: '2024-02-03T04:05:06.000Z',
+      count: '42',
+    })
+  })
+
+  it('validates defaults instead of returning them unchecked', () => {
+    expect(() => t.number().default(Number.NaN)).toThrow(t.NeemataTypeError)
+  })
+})
+
+describe('Error input reporting', () => {
+  it('omits rejected input by default', () => {
+    try {
+      t.string().decode(42 as any)
+      throw new Error('Expected validation to fail')
+    } catch (error) {
+      if (!(error instanceof t.NeemataTypeError)) throw error
+      expect(error.issues[0]).not.toHaveProperty('input')
+    }
+  })
+
+  it('allows callers to explicitly include rejected input', () => {
+    try {
+      t.string().decode(42 as any, { reportInput: true })
+      throw new Error('Expected validation to fail')
+    } catch (error) {
+      if (!(error instanceof t.NeemataTypeError)) throw error
+      expect(error.issues[0]).toHaveProperty('input', 42)
+    }
   })
 })
 

--- a/packages/type/tests/standard-schema.spec.ts
+++ b/packages/type/tests/standard-schema.spec.ts
@@ -54,6 +54,14 @@ describe('Standard schema', () => {
 
     expect(result.value.id).toBe('123')
     expect(result.value.createdAt).toBe('2021-01-01T00:00:00.000Z')
+
+    const invalid = await standard.validate({
+      id: 123,
+      createdAt: '2021-01-01',
+      name: 'Ada',
+    } as any)
+
+    expect('issues' in invalid).toBe(true)
   })
 
   it('exposes JSON schema helpers', () => {

--- a/packages/type/tests/types/custom.spec.ts
+++ b/packages/type/tests/types/custom.spec.ts
@@ -1,6 +1,32 @@
 import { describe, expect, it } from 'vitest'
+import { number as zodNumber, string as zodString } from 'zod/mini'
 
 import { t } from '../../src/index.ts'
+
+describe('CustomType - codec engine', () => {
+  const numericString = t.custom({
+    type: zodString(),
+    decodedType: zodNumber(),
+    decode: (value) => {
+      if (value === 'explode') throw new Error('conversion failed')
+      return Number(value)
+    },
+    encode: (value) => String(value),
+  })
+
+  it('validates the decoded and encoded endpoints', () => {
+    expect(numericString.decode('42')).toBe(42)
+    expect(numericString.encode(42)).toBe('42')
+    expect(() => numericString.decode('not-a-number')).toThrow(
+      t.NeemataTypeError,
+    )
+    expect(() => numericString.encode('42' as any)).toThrow(t.NeemataTypeError)
+  })
+
+  it('turns conversion exceptions into structured issues', () => {
+    expect(() => numericString.decode('explode')).toThrow(t.NeemataTypeError)
+  })
+})
 
 describe('CustomType - Date', () => {
   const dateType = t.date()
@@ -34,6 +60,18 @@ describe('CustomType - Date', () => {
 
       expect(typeof result).toBe('string')
       expect(result).toBe('2021-01-01T12:30:45.123Z')
+    })
+
+    it('should reject a non-Date with a structured validation error', () => {
+      expect(() => dateType.encode('2021-01-01' as any)).toThrow(
+        t.NeemataTypeError,
+      )
+    })
+
+    it('should reject an invalid Date with a structured validation error', () => {
+      expect(() => dateType.encode(new Date('invalid'))).toThrow(
+        t.NeemataTypeError,
+      )
     })
   })
 })
@@ -82,6 +120,10 @@ describe('CustomType - BigInt', () => {
 
       expect(typeof result).toBe('string')
       expect(result).toBe('-987654321098765432109876543210')
+    })
+
+    it('should reject non-bigint values instead of coercing them', () => {
+      expect(() => bigIntType.encode(123 as any)).toThrow(t.NeemataTypeError)
     })
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 8.0.11
       version: 8.0.11
     zod:
-      specifier: ^4.0.0
-      version: 4.3.6
+      specifier: ^4.4.3
+      version: 4.4.3
 
 importers:
 
@@ -83,7 +83,7 @@ importers:
     devDependencies:
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   packages/client:
     devDependencies:
@@ -113,7 +113,7 @@ importers:
     devDependencies:
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   packages/core:
     dependencies:
@@ -272,7 +272,7 @@ importers:
         version: 1.1.2
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@nmtjs/metrics':
         specifier: workspace:*
@@ -375,7 +375,7 @@ importers:
         version: 1.0.1
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   packages/vite:
     dependencies:
@@ -428,7 +428,7 @@ importers:
         version: 1.0.0-rc.4
       drizzle-orm:
         specifier: 1.0.0-rc.4
-        version: 1.0.0-rc.4(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(bun-types@1.3.2(@types/react@19.1.9))(pg@8.22.0)(zod@4.3.6)
+        version: 1.0.0-rc.4(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(bun-types@1.3.2(@types/react@19.1.9))(pg@8.22.0)(zod@4.4.3)
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -2400,8 +2400,8 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -3184,14 +3184,14 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.4(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(bun-types@1.3.2(@types/react@19.1.9))(pg@8.22.0)(zod@4.3.6):
+  drizzle-orm@1.0.0-rc.4(@electric-sql/pglite@0.5.3)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(bun-types@1.3.2(@types/react@19.1.9))(pg@8.22.0)(zod@4.4.3):
     optionalDependencies:
       '@electric-sql/pglite': 0.5.3
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.20.0
       bun-types: 1.3.2(@types/react@19.1.9)
       pg: 8.22.0
-      zod: 4.3.6
+      zod: 4.4.3
 
   end-of-stream@1.4.4:
     dependencies:
@@ -3788,4 +3788,4 @@ snapshots:
 
   xtend@4.0.2: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ allowBuilds:
 
 catalog:
   vite: 8.0.11
-  zod: ^4.0.0
+  zod: ^4.4.3
 
 minimumReleaseAgeExclude:
   - '@nmtjs/prom-client'


### PR DESCRIPTION
Rebuilds the custom-type machinery in `@nmtjs/type` on zod 4.4's native codec primitives and fixes default-value handling.

## Changes

- **`CustomType` on `codec()`/`invertCodec()`**: replaces the previous `pipe` + `overwrite` (+ `@ts-expect-error`) construction with a real bidirectional codec pair. Exceptions thrown inside decode/encode transforms now surface as structured `NeemataTypeError` issues instead of escaping raw.
- **New `decodedType` parameter**: custom types can now declare a schema for the decoded/runtime representation, not just the wire one. `t.date().encode('2021-01-01')`, `encode(new Date('invalid'))` and `t.bigInt().encode(123)` are rejected with validation errors instead of being coerced. Wired into Date, BigInt and all Temporal types.
- **`default()` uses `prefault` instead of `_default`**: defaults are validated and run through the transform pipeline in both directions, so `t.number().default(NaN)` throws at construction time and transformed defaults encode to their correct wire form (`t.bigInt().default(42n)` → `'42'`). The `params.encode` side-channel this previously required is removed.
- **Input reporting is opt-in**: `encode`/`decode` no longer force `reportInput: true`, keeping rejected input values out of error issues unless the caller passes it explicitly.
- **zod catalog bump**: `^4.0.0` → `^4.4.3` (required for `codec`, `invertCodec`, `prefault`).

## Testing

- `packages/type` suite extended to cover codec validation on both endpoints, structured transform errors, bidirectional defaults, and opt-in input reporting.
- Full workspace: `pnpm build` clean, `tsc -b --noEmit` clean, 1312 unit tests passing.