### PR TITLE
config: @nmtjs/config validator-agnostic env config injectables

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@nmtjs/config",
+  "description": "Typed, validator-agnostic configuration injectables for Neemata applications.",
+  "type": "module",
+  "scripts": {
+    "clean-build": "rm -rf ./dist",
+    "test": "vitest run --config vitest.config.ts"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./dist/index.js",
+      "module-sync": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "module-sync": "./dist/index.js"
+      }
+    }
+  },
+  "dependencies": {
+    "@nmtjs/core": "workspace:*",
+    "@standard-schema/spec": "^1.1.0"
+  },
+  "devDependencies": {
+    "@nmtjs/common": "workspace:*",
+    "@nmtjs/type": "workspace:*",
+    "@types/node": "^24.13.2"
+  },
+  "files": [
+    "dist",
+    "src",
+    "LICENSE.md",
+    "README.md"
+  ]
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -63,14 +63,18 @@ export async function resolveEnvConfig<Variables extends EnvConfigVariables>(
     const { name, schema } = isConfigSchema(variable)
       ? { name: key, schema: variable }
       : variable
-    // Standard Schema allows async validation, so resolution is async even
-    // though most validators (including @nmtjs/type) are synchronous.
-    let result = schema['~standard'].validate(source[name])
-    if (result instanceof Promise) result = await result
+    // Awaited unconditionally: Standard Schema allows async validation, and
+    // `instanceof Promise` would misclassify cross-realm promises/thenables.
+    const result = await schema['~standard'].validate(source[name])
     // Collect issues across all variables instead of failing on the first
     // one, so a misconfigured environment is reported in a single pass.
-    if (result.issues) issues[name] = result.issues
-    else config[key] = result.value
+    // Merged rather than assigned: multiple config keys may read the same
+    // environment variable, and each schema's issues must survive.
+    if (result.issues) {
+      issues[name] = [...(issues[name] ?? []), ...result.issues]
+    } else {
+      config[key] = result.value
+    }
   }
 
   if (Object.keys(issues).length > 0) throw new EnvConfigError(issues)

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,103 @@
+import type { FactoryInjectable } from '@nmtjs/core'
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+import { createFactoryInjectable } from '@nmtjs/core'
+
+export type ConfigSchema = StandardSchemaV1
+
+/**
+ * A schema alone binds the record key as the environment variable name;
+ * the object form decouples them (e.g. `dbUrl` reading `DATABASE_URL`).
+ */
+export type EnvConfigVariable =
+  | ConfigSchema
+  | { name: string; schema: ConfigSchema }
+
+export type EnvConfigVariables = Record<string, EnvConfigVariable>
+
+export type EnvConfigSource = Record<string, string | undefined>
+
+export type InferEnvConfig<Variables extends EnvConfigVariables> = {
+  [K in keyof Variables]: Variables[K] extends ConfigSchema
+    ? StandardSchemaV1.InferOutput<Variables[K]>
+    : Variables[K] extends { schema: infer Schema extends ConfigSchema }
+      ? StandardSchemaV1.InferOutput<Schema>
+      : never
+}
+
+export interface EnvConfigOptions {
+  /**
+   * Environment variables are read from `process.env` unless a custom
+   * source is given (tests, pre-resolved env snapshots).
+   */
+  source?: EnvConfigSource
+}
+
+export class EnvConfigError extends Error {
+  override name = 'EnvConfigError'
+  /** Validation issues keyed by environment variable name. */
+  readonly issues: Readonly<Record<string, readonly StandardSchemaV1.Issue[]>>
+
+  constructor(issues: Record<string, readonly StandardSchemaV1.Issue[]>) {
+    super(formatIssues(issues))
+    this.issues = Object.freeze(issues)
+  }
+}
+
+export function createEnvConfig<Variables extends EnvConfigVariables>(
+  variables: Variables,
+  options: EnvConfigOptions = {},
+): FactoryInjectable<InferEnvConfig<Variables>> {
+  return createFactoryInjectable<InferEnvConfig<Variables>>({
+    create: () => resolveEnvConfig(variables, options.source),
+  })
+}
+
+export async function resolveEnvConfig<Variables extends EnvConfigVariables>(
+  variables: Variables,
+  source: EnvConfigSource = process.env,
+): Promise<InferEnvConfig<Variables>> {
+  const config: Record<string, unknown> = {}
+  const issues: Record<string, readonly StandardSchemaV1.Issue[]> = {}
+
+  for (const [key, variable] of Object.entries(variables)) {
+    const { name, schema } = isConfigSchema(variable)
+      ? { name: key, schema: variable }
+      : variable
+    // Standard Schema allows async validation, so resolution is async even
+    // though most validators (including @nmtjs/type) are synchronous.
+    let result = schema['~standard'].validate(source[name])
+    if (result instanceof Promise) result = await result
+    // Collect issues across all variables instead of failing on the first
+    // one, so a misconfigured environment is reported in a single pass.
+    if (result.issues) issues[name] = result.issues
+    else config[key] = result.value
+  }
+
+  if (Object.keys(issues).length > 0) throw new EnvConfigError(issues)
+  return config as InferEnvConfig<Variables>
+}
+
+const isConfigSchema = (
+  variable: EnvConfigVariable,
+): variable is ConfigSchema => '~standard' in variable
+
+function formatIssues(
+  issues: Record<string, readonly StandardSchemaV1.Issue[]>,
+): string {
+  const lines: string[] = []
+  for (const [name, variableIssues] of Object.entries(issues)) {
+    for (const issue of variableIssues) {
+      const path = issue.path
+        ?.map((segment) =>
+          typeof segment === 'object' ? String(segment.key) : String(segment),
+        )
+        .join('.')
+      lines.push(
+        path
+          ? `${name} (${path}): ${issue.message}`
+          : `${name}: ${issue.message}`,
+      )
+    }
+  }
+  return `Failed to resolve environment configuration:\n  ${lines.join('\n  ')}`
+}

--- a/packages/config/tests/env.spec.ts
+++ b/packages/config/tests/env.spec.ts
@@ -90,6 +90,26 @@ describe('resolveEnvConfig', () => {
     expect(error.message).toContain('RETRIES: expected integer')
   })
 
+  it('merges issues from multiple keys reading the same variable', async () => {
+    const failing = (message: string) =>
+      schema(() => ({ issues: [{ message }] }))
+    const error = await resolveEnvConfig(
+      {
+        a: { name: 'SHARED', schema: failing('first') },
+        b: { name: 'SHARED', schema: failing('second') },
+      },
+      {},
+    ).then(
+      () => null,
+      (e) => e,
+    )
+
+    expect(error.issues.SHARED.map((issue: any) => issue.message)).toEqual([
+      'first',
+      'second',
+    ])
+  })
+
   it('includes issue paths for structured variables', async () => {
     const error = await resolveEnvConfig(
       {

--- a/packages/config/tests/env.spec.ts
+++ b/packages/config/tests/env.spec.ts
@@ -1,0 +1,121 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+import { isFactoryInjectable } from '@nmtjs/core'
+import { t } from '@nmtjs/type'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+
+import {
+  createEnvConfig,
+  EnvConfigError,
+  resolveEnvConfig,
+} from '../src/index.ts'
+
+const schema = <Output>(
+  validate: (
+    value: unknown,
+  ) =>
+    | StandardSchemaV1.Result<Output>
+    | Promise<StandardSchemaV1.Result<Output>>,
+): StandardSchemaV1<unknown, Output> => ({
+  '~standard': { version: 1, vendor: 'test', validate },
+})
+
+const intFromString = schema<number>((value) => {
+  const parsed = Number(value)
+  return Number.isInteger(parsed)
+    ? { value: parsed }
+    : { issues: [{ message: `expected integer, received ${value}` }] }
+})
+
+describe('resolveEnvConfig', () => {
+  it('resolves variables using record keys as names', async () => {
+    const config = await resolveEnvConfig(
+      { HOST: t.string(), PORT: intFromString },
+      { HOST: 'localhost', PORT: '3000' },
+    )
+    expect(config).toEqual({ HOST: 'localhost', PORT: 3000 })
+    expectTypeOf(config).toEqualTypeOf<{ HOST: string; PORT: number }>()
+  })
+
+  it('resolves renamed variables via the object form', async () => {
+    const config = await resolveEnvConfig(
+      { dbUrl: { name: 'DATABASE_URL', schema: t.string() } },
+      { DATABASE_URL: 'postgres://localhost' },
+    )
+    expect(config).toEqual({ dbUrl: 'postgres://localhost' })
+    expectTypeOf(config).toEqualTypeOf<{ dbUrl: string }>()
+  })
+
+  it('supports async standard schemas', async () => {
+    const config = await resolveEnvConfig(
+      { KEY: schema(async (value) => ({ value: String(value).length })) },
+      { KEY: 'abc' },
+    )
+    expect(config).toEqual({ KEY: 3 })
+  })
+
+  it('accepts any standard schema alongside @nmtjs/type', async () => {
+    const config = await resolveEnvConfig(
+      { NAME: t.string(), COUNT: intFromString },
+      { NAME: 'neemata', COUNT: '42' },
+    )
+    expect(config).toEqual({ NAME: 'neemata', COUNT: 42 })
+  })
+
+  it('reads from process.env by default', async () => {
+    process.env.NMTJS_CONFIG_TEST = 'value'
+    try {
+      const config = await resolveEnvConfig({ NMTJS_CONFIG_TEST: t.string() })
+      expect(config).toEqual({ NMTJS_CONFIG_TEST: 'value' })
+    } finally {
+      delete process.env.NMTJS_CONFIG_TEST
+    }
+  })
+
+  it('aggregates issues across all variables into a single error', async () => {
+    const error = await resolveEnvConfig(
+      {
+        HOST: t.string(),
+        PORT: intFromString,
+        retries: { name: 'RETRIES', schema: intFromString },
+      },
+      { HOST: 'localhost', PORT: 'nope' },
+    ).then(
+      () => null,
+      (e) => e,
+    )
+
+    expect(error).toBeInstanceOf(EnvConfigError)
+    expect(Object.keys(error.issues)).toEqual(['PORT', 'RETRIES'])
+    expect(error.message).toContain('PORT: expected integer, received nope')
+    expect(error.message).toContain('RETRIES: expected integer')
+  })
+
+  it('includes issue paths for structured variables', async () => {
+    const error = await resolveEnvConfig(
+      {
+        NESTED: schema(() => ({
+          issues: [{ message: 'invalid', path: ['inner', { key: 'value' }] }],
+        })),
+      },
+      { NESTED: '{}' },
+    ).then(
+      () => null,
+      (e) => e,
+    )
+
+    expect(error.message).toContain('NESTED (inner.value): invalid')
+  })
+})
+
+describe('createEnvConfig', () => {
+  it('creates a factory injectable resolving the config', async () => {
+    const injectable = createEnvConfig(
+      { PORT: intFromString },
+      { source: { PORT: '8080' } },
+    )
+    expect(isFactoryInjectable(injectable)).toBe(true)
+    const config = await injectable.create({} as never)
+    expect(config).toEqual({ PORT: 8080 })
+    expectTypeOf(config).toEqualTypeOf<{ PORT: number }>()
+  })
+})

--- a/packages/config/tsconfig.build.json
+++ b/packages/config/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "noEmit": false,
+    "outDir": "./dist",
+    "declaration": true,
+    "sourceMap": true,
+    "isolatedDeclarations": false
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/config/vitest.config.ts
+++ b/packages/config/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineProject } from 'vitest/config'
+
+export default defineProject({
+  test: { environment: 'node', include: ['tests/**/*.spec.ts'] },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,25 @@ importers:
 
   packages/common: {}
 
+  packages/config:
+    dependencies:
+      '@nmtjs/core':
+        specifier: workspace:*
+        version: link:../core
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
+    devDependencies:
+      '@nmtjs/common':
+        specifier: workspace:*
+        version: link:../common
+      '@nmtjs/type':
+        specifier: workspace:*
+        version: link:../type
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
+
   packages/contract:
     dependencies:
       '@nmtjs/protocol':

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,6 +10,9 @@
       "path": "./packages/common/tsconfig.build.json"
     },
     {
+      "path": "./packages/config/tsconfig.build.json"
+    },
+    {
       "path": "./packages/contract/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "./packages/common/tsconfig.json"
     },
     {
+      "path": "./packages/config/tsconfig.json"
+    },
+    {
       "path": "./packages/contract/tsconfig.json"
     },
     {


### PR DESCRIPTION
Adds a new `@nmtjs/config` package: typed environment configuration exposed as DI injectables.

- `createEnvConfig(variables, options?)` returns a global-scope factory injectable that resolves and validates env variables on first injection.
- Variables accept any [Standard Schema](https://github.com/standard-schema/standard-schema) validator (`@nmtjs/type` types implement it natively; zod/valibot/arktype work out of the box, including their string-coercion facilities). Record key doubles as the env variable name, with an object form `{ name, schema }` for renaming.
- `resolveEnvConfig(variables, source?)` is exported for non-DI use; `source` defaults to `process.env`.
- Validation failures across all variables are aggregated into a single `EnvConfigError` with a readable multi-line message and structured `issues` keyed by variable name.

```ts
const AppConfig = createEnvConfig({
  HOST: t.string(),
  dbUrl: { name: 'DATABASE_URL', schema: t.string() },
})
```

Dependencies are limited to `@nmtjs/core` and the types-only `@standard-schema/spec` — no dotenv, no zod imports. Env sourcing/layering stays owned by the neem host; this package only types and validates the final environment.

Covered by unit tests (resolution, renaming, coercion, async schemas, `@nmtjs/type` interop, error aggregation, injectable integration, type-level inference).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configuration package for resolving environment variables into typed application settings.
  - Supports renamed variables, default environment sources, synchronous or asynchronous validation, and custom schemas.
  - Provides aggregated, detailed validation errors for invalid configuration values.
  - Added factory-based configuration injection support.

- **Tests**
  - Added coverage for successful resolution, validation failures, async schemas, renamed variables, and nested error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->