### PR TITLE
nmtjs: export envConfig from umbrella and document config in use-neemata skill

### DIFF
--- a/packages/nmtjs/package.json
+++ b/packages/nmtjs/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@nmtjs/application": "workspace:*",
+    "@nmtjs/config": "workspace:*",
     "@nmtjs/contract": "workspace:*",
     "@nmtjs/core": "workspace:*",
     "@nmtjs/gateway": "workspace:*",

--- a/packages/nmtjs/src/index.ts
+++ b/packages/nmtjs/src/index.ts
@@ -35,6 +35,7 @@ export {
   defineApplicationHost as host,
   implement as implementRouter,
 } from '@nmtjs/application'
+export { createEnvConfig as envConfig, EnvConfigError } from '@nmtjs/config'
 export { blobType, c } from '@nmtjs/contract'
 export {
   CoreInjectables,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
       '@nmtjs/application':
         specifier: workspace:*
         version: link:../application
+      '@nmtjs/config':
+        specifier: workspace:*
+        version: link:../config
       '@nmtjs/contract':
         specifier: workspace:*
         version: link:../contract

--- a/skills/use-neemata/SKILL.md
+++ b/skills/use-neemata/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-neemata
-description: 'Use when answering questions or writing code for Neemata RPC applications: contracts, procedures, routers, applications, DI, metadata, guards, middleware, filters, clients, workflows, pubsub, metrics, streaming, blobs, and Neemata runtime integration.'
+description: 'Use when answering questions or writing code for Neemata RPC applications: contracts, procedures, routers, applications, DI, env config, metadata, guards, middleware, filters, clients, workflows, pubsub, metrics, streaming, blobs, and Neemata runtime integration.'
 ---
 
 # Use Neemata
@@ -29,7 +29,7 @@ Exceptions:
 - [Implementations](references/implementations.md) - contract-backed handlers,
   routers, and `implementRouter(...)`.
 - [Injectables](references/injectables.md) - values, lazy tokens, factories,
-  scopes, built-ins.
+  scopes, built-ins, env config.
 - [Subscriptions](references/subscriptions.md) - typed event/channel contracts.
 - [PubSub](references/pubsub.md) - ephemeral fanout, publish/subscribe.
 - [Workflows](references/workflows.md) - durable orchestration: task/workflow

--- a/skills/use-neemata/references/api-reference.md
+++ b/skills/use-neemata/references/api-reference.md
@@ -14,6 +14,8 @@ import {
   contractProcedure,
   contractRouter,
   CoreInjectables,
+  envConfig,
+  EnvConfigError,
   ErrorCode,
   ExecutionEnvironmentLifecycleHook,
   factory,
@@ -56,8 +58,8 @@ import {
 - Use direct package subpaths for clients, transports, formats, adapters, and
   runtime helpers: `@nmtjs/client`, `@nmtjs/http-transport/node`,
   `@nmtjs/application/neem/runtime`, `@nmtjs/pubsub/redis`, etc.
-- Avoid direct `@nmtjs/core`, `@nmtjs/type`, `@nmtjs/contract`, or
-  `@nmtjs/pubsub` imports in end-user examples when
+- Avoid direct `@nmtjs/core`, `@nmtjs/type`, `@nmtjs/contract`,
+  `@nmtjs/config`, or `@nmtjs/pubsub` imports in end-user examples when
   `nmtjs` exposes the same symbol.
 
 ## Common Builders
@@ -95,6 +97,18 @@ import {
   the namespace.
 - `Scope` - `Global`, `Connection`, `Call`, `Transient`.
 - `meta()` and `MetadataKind` - typed metadata tokens and static constraints.
+
+## Config
+
+- `envConfig(variables, { source? }?)` - global injectable resolving and
+  validating environment variables on first injection. Each record key is the
+  env variable name and maps to a Standard Schema validator (`t.*` schemas
+  qualify); the `{ name, schema }` value form decouples config key from env
+  variable name.
+- `EnvConfigError` - thrown with validation failures aggregated across all
+  variables, keyed by env variable name in `error.issues`.
+- `resolveEnvConfig(variables, source?)` - non-DI resolver, direct import from
+  `@nmtjs/config`.
 
 ## PubSub
 

--- a/skills/use-neemata/references/injectables.md
+++ b/skills/use-neemata/references/injectables.md
@@ -253,6 +253,34 @@ export const resolveMessage = factory({
 `inject.inject.explicit(...)` returns `{ instance, [Symbol.asyncDispose] }` for
 explicit resource blocks when `using` is supported.
 
+## Environment Config
+
+`envConfig(...)` creates a global factory injectable that reads, validates, and
+types environment variables on first injection. Values are validated by any
+Standard Schema validator — `t.*` schemas qualify, as do third-party validators
+(zod, valibot, arktype), including their string-coercion helpers.
+
+```ts
+import { envConfig, procedure, t } from 'nmtjs'
+
+const config = envConfig({
+  HOST: t.string(),
+  dbUrl: { name: 'DATABASE_URL', schema: t.string() },
+})
+
+export const status = procedure({
+  dependencies: { config },
+  handler: ({ config }) => ({ host: config.HOST }),
+})
+```
+
+- Record keys double as env variable names; the `{ name, schema }` form decouples
+  the config key from the variable name.
+- All invalid variables are reported together in a single `EnvConfigError`
+  (issues keyed by variable name), not one at a time.
+- `resolveEnvConfig(variables, source?)` from `@nmtjs/config` resolves the same
+  shape outside DI; `source` defaults to `process.env`.
+
 ## Built-In Tokens
 
 Prefer merged `inject.*` tokens in application code:


### PR DESCRIPTION
Follow-up to #304, which added `@nmtjs/config` but left it out of the umbrella package and the `use-neemata` skill.

- `nmtjs` now depends on `@nmtjs/config` and re-exports `createEnvConfig as envConfig` and `EnvConfigError`, following the existing alias style. `resolveEnvConfig` intentionally remains a direct `@nmtjs/config` import (non-DI utility, not app-building surface).
- `use-neemata` skill updates:
  - `SKILL.md`: "env config" added to the trigger description and the Injectables reference line.
  - `references/api-reference.md`: `envConfig`/`EnvConfigError` in the canonical import block, `@nmtjs/config` in the avoid-direct-imports rule, new "Config" section.
  - `references/injectables.md`: new "Environment Config" section with usage example and semantics (key-as-name vs `{ name, schema }`, aggregated `EnvConfigError`, `process.env` default).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment configuration utilities to the public package API.
  * Added validation error reporting for invalid environment variables.
* **Documentation**
  * Expanded application setup and API guidance for environment configuration.
  * Documented dependency-injection and standalone environment configuration workflows.
  * Added examples covering schema validation, variable naming, and aggregated validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->