### PR TITLE
pubsub: ignore expected stream cancellation errors

### DIFF
--- a/packages/pubsub/src/manager.ts
+++ b/packages/pubsub/src/manager.ts
@@ -119,6 +119,8 @@ export class PubSubManager {
     })
 
     stream.on('error', (error) => {
+      if (isAbortError(error)) return
+
       this.logger.error({ channel, error }, 'Pubsub channel stream failed')
     })
 

--- a/packages/pubsub/tests/manager.spec.ts
+++ b/packages/pubsub/tests/manager.spec.ts
@@ -4,7 +4,7 @@ import { setImmediate as tick } from 'node:timers/promises'
 import { EventContract, SubscriptionContract } from '@nmtjs/contract'
 import { createLogger } from '@nmtjs/core'
 import { t } from '@nmtjs/type'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { PubSubAdapter, PubSubMessage } from '../src/adapter.ts'
 import { PubSubManager } from '../src/manager.ts'
@@ -111,6 +111,7 @@ describe('PubSubManager subscription stream', () => {
       throw failure
     })
     const stream = await subscribeStream(manager)
+    const logError = vi.spyOn(manager['logger'], 'error')
 
     const received: unknown[] = []
     await expect(async () => {
@@ -122,6 +123,24 @@ describe('PubSubManager subscription stream', () => {
 
     expect(received).toEqual([{ event: 'message', payload: { text: 'first' } }])
     expect(stream.destroyed).toBe(true)
+    expect(logError).toHaveBeenCalledWith(
+      { channel: 'chat:general', error: failure },
+      'Pubsub channel stream failed',
+    )
+  })
+
+  it('does not log expected cancellation when iteration stops early', async () => {
+    const manager = createManager(async function* () {
+      yield message('first')
+    })
+    const stream = await subscribeStream(manager)
+    const logError = vi.spyOn(manager['logger'], 'error')
+
+    for await (const _item of stream) break
+    await tick()
+
+    expect(stream.destroyed).toBe(true)
+    expect(logError).not.toHaveBeenCalled()
   })
 
   it('ends the stream gracefully when the adapter iterator aborts', async () => {


### PR DESCRIPTION
## Summary

- ignore expected `AbortError` events when pubsub subscription iteration stops early
- continue logging non-abort stream failures
- cover both behaviors with regression assertions

## Why

Breaking or returning from a `for await...of` subscription loop destroys the Node `Readable` and emits an expected cancellation error. The manager treated that normal cleanup path as a pubsub failure even though the adapter and message pump already handle aborts gracefully.

Closes #306

## Validation

- `pnpm --dir packages/pubsub exec vitest run --config vitest.config.ts tests/manager.spec.ts --reporter=agent` — 8 tests passed
- `pnpm run fmt`
- `pnpm run check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Abort-related stream errors are no longer logged as failures.
  * Other stream errors continue to be logged normally.
  * Early cancellation now cleanly closes the stream without producing an error log.

* **Tests**
  * Added coverage for error logging and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->