### PR TITLE
server: rename package to @nmtjs/server-host

### DIFF
--- a/packages/http-transport/package.json
+++ b/packages/http-transport/package.json
@@ -54,7 +54,7 @@
     "@nmtjs/common": "workspace:*",
     "@nmtjs/gateway": "workspace:*",
     "@nmtjs/protocol": "workspace:*",
-    "@nmtjs/server": "workspace:*",
+    "@nmtjs/server-host": "workspace:*",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0"
   },
   "peerDependencies": {
@@ -63,7 +63,7 @@
     "@nmtjs/core": "workspace:*",
     "@nmtjs/gateway": "workspace:*",
     "@nmtjs/protocol": "workspace:*",
-    "@nmtjs/server": "workspace:*",
+    "@nmtjs/server-host": "workspace:*",
     "@types/bun": "^1.3.0",
     "@types/deno": "^2.3.0",
     "@types/node": "^24.13.2",

--- a/packages/http-transport/src/adapter.ts
+++ b/packages/http-transport/src/adapter.ts
@@ -2,7 +2,7 @@ import type {
   ServerHost,
   ServerHostOptions,
   ServerRuntimeName,
-} from '@nmtjs/server'
+} from '@nmtjs/server-host'
 
 import type { HttpAdapterParams, HttpAdapterServer } from './types.ts'
 

--- a/packages/http-transport/src/constants.ts
+++ b/packages/http-transport/src/constants.ts
@@ -2,8 +2,8 @@ import type { MetadataKind } from '@nmtjs/application'
 import { createMeta } from '@nmtjs/application'
 import { ErrorCode } from '@nmtjs/protocol'
 
-// Single source in @nmtjs/server: the host enforces the same default bound
-export { DEFAULT_MAX_REQUEST_BODY_SIZE } from '@nmtjs/server'
+// Single source in @nmtjs/server-host: the host enforces the same default bound
+export { DEFAULT_MAX_REQUEST_BODY_SIZE } from '@nmtjs/server-host'
 
 export enum HttpStatus {
   Continue = 100,

--- a/packages/http-transport/src/runtimes/bun.ts
+++ b/packages/http-transport/src/runtimes/bun.ts
@@ -1,7 +1,7 @@
 import type { ApplicationTransport } from '@nmtjs/application'
 import type { ConnectionType } from '@nmtjs/protocol'
 import { ProxyableTransportType } from '@nmtjs/gateway'
-import { createServerHost } from '@nmtjs/server/bun'
+import { createServerHost } from '@nmtjs/server-host/bun'
 
 import type { HttpAdapterParams, HttpTransportOptions } from '../types.ts'
 import { createHostAdapter } from '../adapter.ts'

--- a/packages/http-transport/src/runtimes/deno.ts
+++ b/packages/http-transport/src/runtimes/deno.ts
@@ -1,7 +1,7 @@
 import type { ApplicationTransport } from '@nmtjs/application'
 import type { ConnectionType } from '@nmtjs/protocol'
 import { ProxyableTransportType } from '@nmtjs/gateway'
-import { createServerHost } from '@nmtjs/server/deno'
+import { createServerHost } from '@nmtjs/server-host/deno'
 
 import type { HttpAdapterParams, HttpTransportOptions } from '../types.ts'
 import { createHostAdapter } from '../adapter.ts'

--- a/packages/http-transport/src/runtimes/node.ts
+++ b/packages/http-transport/src/runtimes/node.ts
@@ -1,7 +1,7 @@
 import type { ApplicationTransport } from '@nmtjs/application'
 import type { ConnectionType } from '@nmtjs/protocol'
 import { ProxyableTransportType } from '@nmtjs/gateway'
-import { createServerHost } from '@nmtjs/server/node'
+import { createServerHost } from '@nmtjs/server-host/node'
 
 import type { HttpAdapterParams, HttpTransportOptions } from '../types.ts'
 import { createHostAdapter } from '../adapter.ts'

--- a/packages/http-transport/src/types.ts
+++ b/packages/http-transport/src/types.ts
@@ -9,7 +9,7 @@ import type {
   ServerRuntimeName,
   ServerRuntimeOptions,
   ServerTlsOptions,
-} from '@nmtjs/server'
+} from '@nmtjs/server-host'
 
 export type { DenoServer }
 

--- a/packages/http-transport/src/utils.ts
+++ b/packages/http-transport/src/utils.ts
@@ -1,7 +1,7 @@
 import { ErrorCode } from '@nmtjs/protocol'
 import { ProtocolError } from '@nmtjs/protocol/server'
 
-// Response helpers and PayloadTooLargeError live in @nmtjs/server: the
+// Response helpers and PayloadTooLargeError live in @nmtjs/server-host: the
 // runtime hosts throw/build them, and instanceof matching in this package
 // requires the same class identity
 export {
@@ -9,7 +9,7 @@ export {
   NotFoundHttpResponse,
   OkResponse,
   PayloadTooLargeError,
-} from '@nmtjs/server'
+} from '@nmtjs/server-host'
 
 export const InternalError = (message = 'Internal Server Error') =>
   new ProtocolError(ErrorCode.InternalServerError, message)

--- a/packages/neem/package.json
+++ b/packages/neem/package.json
@@ -67,7 +67,7 @@
     "@nmtjs/metrics": "workspace:*",
     "@nmtjs/protocol": "workspace:*",
     "@nmtjs/proxy": "1.0.0-beta.7",
-    "@nmtjs/server": "workspace:*",
+    "@nmtjs/server-host": "workspace:*",
     "@nmtjs/ws-transport": "workspace:*",
     "@types/node": "^24.13.2",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0"

--- a/packages/neem/tests/e2e/fixtures/cases/shared-server/shared-server.worker.ts
+++ b/packages/neem/tests/e2e/fixtures/cases/shared-server/shared-server.worker.ts
@@ -11,7 +11,7 @@ import { HttpTransport } from '@nmtjs/http-transport/node'
 import { JsonFormat } from '@nmtjs/json-format/server'
 import { defineRuntimeWorker } from '@nmtjs/neem'
 import { ProtocolFormats } from '@nmtjs/protocol/server'
-import { createServerHost } from '@nmtjs/server/node'
+import { createServerHost } from '@nmtjs/server-host/node'
 import { WsTransport } from '@nmtjs/ws-transport/node'
 
 import { record } from '../../shared/support/_events.ts'

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nmtjs/server",
+  "name": "@nmtjs/server-host",
   "description": "Shared HTTP server host for Neemata transports across runtimes.",
   "type": "module",
   "exports": {

--- a/packages/ws-transport/package.json
+++ b/packages/ws-transport/package.json
@@ -60,7 +60,7 @@
     "@nmtjs/http-transport": "workspace:*",
     "@nmtjs/json-format": "workspace:*",
     "@nmtjs/protocol": "workspace:*",
-    "@nmtjs/server": "workspace:*",
+    "@nmtjs/server-host": "workspace:*",
     "@nmtjs/type": "workspace:*",
     "@nmtjs/ws-client": "workspace:*",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.67.0"
@@ -71,7 +71,7 @@
     "@nmtjs/core": "workspace:*",
     "@nmtjs/gateway": "workspace:*",
     "@nmtjs/protocol": "workspace:*",
-    "@nmtjs/server": "workspace:*",
+    "@nmtjs/server-host": "workspace:*",
     "@types/bun": "^1.3.0",
     "@types/deno": "^2.3.0",
     "@types/node": "^24.13.2",

--- a/packages/ws-transport/src/adapter.ts
+++ b/packages/ws-transport/src/adapter.ts
@@ -2,7 +2,7 @@ import type {
   ServerHost,
   ServerHostOptions,
   ServerRuntimeName,
-} from '@nmtjs/server'
+} from '@nmtjs/server-host'
 
 import type { WsAdapterParams, WsAdapterServer } from './types.ts'
 

--- a/packages/ws-transport/src/runtimes/bun.ts
+++ b/packages/ws-transport/src/runtimes/bun.ts
@@ -1,7 +1,7 @@
 import type { ApplicationTransport } from '@nmtjs/application'
 import type { ConnectionType } from '@nmtjs/protocol'
 import { ProxyableTransportType } from '@nmtjs/gateway'
-import { createServerHost } from '@nmtjs/server/bun'
+import { createServerHost } from '@nmtjs/server-host/bun'
 
 import type { WsAdapterParams, WsTransportOptions } from '../types.ts'
 import { createHostAdapter } from '../adapter.ts'

--- a/packages/ws-transport/src/runtimes/deno.ts
+++ b/packages/ws-transport/src/runtimes/deno.ts
@@ -1,7 +1,7 @@
 import type { ApplicationTransport } from '@nmtjs/application'
 import type { ConnectionType } from '@nmtjs/protocol'
 import { ProxyableTransportType } from '@nmtjs/gateway'
-import { createServerHost } from '@nmtjs/server/deno'
+import { createServerHost } from '@nmtjs/server-host/deno'
 
 import type { WsAdapterParams, WsTransportOptions } from '../types.ts'
 import { createHostAdapter } from '../adapter.ts'

--- a/packages/ws-transport/src/runtimes/node.ts
+++ b/packages/ws-transport/src/runtimes/node.ts
@@ -1,7 +1,7 @@
 import type { ApplicationTransport } from '@nmtjs/application'
 import type { ConnectionType } from '@nmtjs/protocol'
 import { ProxyableTransportType } from '@nmtjs/gateway'
-import { createServerHost } from '@nmtjs/server/node'
+import { createServerHost } from '@nmtjs/server-host/node'
 
 import type { WsAdapterParams, WsTransportOptions } from '../types.ts'
 import { createHostAdapter } from '../adapter.ts'
@@ -14,7 +14,7 @@ export {
   DEFAULT_WS_MAX_BACKPRESSURE,
   DEFAULT_WS_MAX_PAYLOAD,
   resolveUwsWsOptions,
-} from '@nmtjs/server/node'
+} from '@nmtjs/server-host/node'
 
 function adapterFactory(params: WsAdapterParams<'node'>) {
   return createHostAdapter(createServerHost, params)

--- a/packages/ws-transport/src/types.ts
+++ b/packages/ws-transport/src/types.ts
@@ -7,7 +7,7 @@ import type {
   ServerRuntimeOptions,
   ServerTlsOptions,
   ServerWebSocketRuntimeOptions,
-} from '@nmtjs/server'
+} from '@nmtjs/server-host'
 import type { Hooks } from 'crossws'
 
 export type WsTransportServerRequest = ServerRequest

--- a/packages/ws-transport/src/utils.ts
+++ b/packages/ws-transport/src/utils.ts
@@ -1,12 +1,12 @@
 import { ErrorCode } from '@nmtjs/protocol'
 import { ProtocolError } from '@nmtjs/protocol/server'
 
-// Response helpers live in @nmtjs/server, shared by every runtime host
+// Response helpers live in @nmtjs/server-host, shared by every runtime host
 export {
   InternalServerErrorHttpResponse,
   NotFoundHttpResponse,
   OkResponse as StatusResponse,
-} from '@nmtjs/server'
+} from '@nmtjs/server-host'
 
 export const InternalError = (message = 'Internal Server Error') =>
   new ProtocolError(ErrorCode.InternalServerError, message)

--- a/packages/ws-transport/tests/shared-server.spec.ts
+++ b/packages/ws-transport/tests/shared-server.spec.ts
@@ -1,5 +1,5 @@
 import { HttpTransport } from '@nmtjs/http-transport/node'
-import { createServerHost } from '@nmtjs/server/node'
+import { createServerHost } from '@nmtjs/server-host/node'
 import { describe, expect, it, vi } from 'vitest'
 
 import { WsTransport } from '../src/runtimes/node.ts'

--- a/packages/ws-transport/tests/stream-e2e.spec.ts
+++ b/packages/ws-transport/tests/stream-e2e.spec.ts
@@ -9,7 +9,7 @@ import type {
   TransportWorker,
 } from '@nmtjs/gateway'
 import type { ConnectionType } from '@nmtjs/protocol'
-import type { ServerWebSocketRuntimeOptions } from '@nmtjs/server'
+import type { ServerWebSocketRuntimeOptions } from '@nmtjs/server-host'
 import { RuntimeClient } from '@nmtjs/client'
 import { blobType, c } from '@nmtjs/contract'
 import { Container, createLogger, Hooks } from '@nmtjs/core'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,7 +223,7 @@ importers:
       '@nmtjs/protocol':
         specifier: workspace:*
         version: link:../protocol
-      '@nmtjs/server':
+      '@nmtjs/server-host':
         specifier: workspace:*
         version: link:../server
       uWebSockets.js:
@@ -317,7 +317,7 @@ importers:
       '@nmtjs/proxy':
         specifier: 1.0.0-beta.7
         version: 1.0.0-beta.7
-      '@nmtjs/server':
+      '@nmtjs/server-host':
         specifier: workspace:*
         version: link:../server
       '@nmtjs/ws-transport':
@@ -584,7 +584,7 @@ importers:
       '@nmtjs/protocol':
         specifier: workspace:*
         version: link:../protocol
-      '@nmtjs/server':
+      '@nmtjs/server-host':
         specifier: workspace:*
         version: link:../server
       '@nmtjs/type':


### PR DESCRIPTION
## Summary

- Rename the published package from `@nmtjs/server` to `@nmtjs/server-host`.
- Update workspace consumers, imports, tests, and the lockfile.

## Why

The `@nmtjs/server` registry entry is stuck in npm's unpublished tombstone state, so consumers cannot resolve the newly uploaded version and the beta release cannot complete. The new name also describes the package's shared HTTP/WebSocket host role more precisely.

## Validation

- `vp env exec pnpm build`
- `CI=true vp env exec pnpm vitest --run packages/server/tests packages/http-transport/tests packages/ws-transport/tests --reporter=agent` (12 files, 69 tests)
- `vp env exec pnpm run fmt`
- `vp env exec pnpm run check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated server-host integration across HTTP and WebSocket transports to the renamed server-host package.
  * Preserved existing transport APIs, response helpers, runtime behavior, and compatibility exports.
  * Updated Node.js, Bun, and Deno integrations to use the new package naming consistently.
  * Updated related development dependencies and test references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->